### PR TITLE
[Issue #35] Fixed lord flag not being set if class randomization is not enabled.

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
@@ -113,5 +113,5 @@ public interface GBAFECharacterData extends FEModifiableData, FELockableData {
 	
 	public void prepareForClassRandomization();
 	
-	public void setIsLord();
+	public void setIsLord(boolean isLord);
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
@@ -433,16 +433,16 @@ public class FE6Character implements GBAFECharacterData {
 		wasModified = true;
 	}
 	
-	public void setIsLord() {
+	public void setIsLord(boolean isLord) {
 		assert !isReadOnly : "Attempted to modify a locked character.";
 		// Mark as Lord (Ability 2)
 		byte oldValue = (byte)(data[41] & 0xFF);
-		byte newValue = (byte)(oldValue | 0x20);
+		byte newValue = isLord ? (byte)(oldValue | 0x20) : (byte)(oldValue & 0xDF);
 		data[41] = newValue;
 		
 		// Give Sword of Seals lock (Ability 3)
 		oldValue = (byte)(data[42] & 0xFF);
-		newValue = (byte)(oldValue | 0x01);
+		newValue = isLord ? (byte)(oldValue | 0x01) : (byte)(oldValue & 0xFE);
 		data[42] = newValue; 
 		
 		wasModified = true;

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
@@ -444,10 +444,10 @@ public class FE7Character implements GBAFECharacterData {
 	}
 	
 	// We technically don't need this, but might as well make it complete.
-	public void setIsLord() {
+	public void setIsLord(boolean isLord) {
 		assert !isReadOnly : "Attempted to modify a locked character.";
 		byte oldValue = (byte)(data[41] & 0xFF);
-		byte newValue = (byte)(oldValue | 0x20);
+		byte newValue = isLord ? (byte)(oldValue | 0x20) : (byte)(oldValue & 0xDF);
 		data[41] = newValue;
 		wasModified = true;
 	}

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
@@ -434,10 +434,10 @@ public class FE8Character implements GBAFECharacterData {
 	}
 	
 	// We technically don't need this, but might as well make it complete.
-	public void setIsLord() {
+	public void setIsLord(boolean isLord) {
 		assert !isReadOnly : "Attempted to modify a locked character.";
 		byte oldValue = (byte)(data[41] & 0xFF);
-		byte newValue = (byte)(oldValue | 0x20);
+		byte newValue = isLord ? (byte)(oldValue | 0x20) : (byte)(oldValue & 0xDF);
 		data[41] = newValue;
 		wasModified = true;
 	}

--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -95,9 +95,7 @@ public class ClassRandomizer {
 			for (GBAFECharacterData linked : charactersData.linkedCharactersForCharacter(character)) {
 				determinedClasses.put(linked.getID(), targetClass);
 				updateCharacterToClass(inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, classData, chapterData, itemData, textData, false, rng);
-				if (isLordCharacter) {
-					linked.setIsLord();
-				}
+				linked.setIsLord(isLordCharacter);
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
@@ -427,6 +427,8 @@ public class RecruitmentRandomizer {
 			linkedSlot.setDescriptionIndex(fill.getDescriptionIndex());
 			linkedSlot.setFaceID(fill.getFaceID());
 			
+			linkedSlot.setIsLord(characterData.isLordCharacterID(slotReference.getID()));
+			
 			int targetLevel = linkedSlot.getLevel();
 			int sourceLevel = fill.getLevel();
 			


### PR DESCRIPTION
Fixed #35 - Fixed an issue where the lord flag was not assigned appropriately to a character if class randomization was disabled.