### PR TITLE
[Issue #31] Restricted recruitable enemies from receiving player-only weapons.

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -983,6 +983,8 @@ public class FE4Data {
 		public static final Set<Character> Gen2SubstituteCharacters = new HashSet<Character>(Arrays.asList(DALVIN, ASAELLO, CHARLOT, HAWK, TRISTAN, DEIMNE, AMID, DAISY, CREIDNE, MUIRNE,
 				HERMINA, LINDA, LAYLEA, JEANNE));
 		
+		public static final Set<Character> RecruitableEnemyCharacters = new HashSet<Character>(Arrays.asList(AYRA, JAMKE, CHULAINN, BEOWOLF, ERINYS, ASAELLO, FEBAIL, ALTENA, TINE, IUCHAR, IUCHARBA, HANNIBAL, LINDA));
+		
 		public static final Set<Character> Gen1Bosses = new HashSet<Character>(Arrays.asList(
 				DIMAGGIO, GERRARD,
 				CIMBAETH, MUNNIR, SANDIMA,

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4ClassRandomizer.java
@@ -1754,6 +1754,13 @@ public class FE4ClassRandomizer {
 			usableSet.removeAll(FE4Data.Item.statusSet);
 		}
 		
+		FE4Data.Character fe4Char = FE4Data.Character.valueOf(character.getCharacterID());
+		
+		// Remove any player only weapons for characters that can start as enemies (i.e. Berserk Sword, Berserk Staff)
+		if (FE4Data.Character.RecruitableEnemyCharacters.contains(fe4Char)) {
+			usableSet.removeAll(FE4Data.Item.playerOnlySet);
+		}
+		
 		List<FE4Data.Item> usableItems = usableSet.stream().sorted(FE4Data.Item.defaultComparator).collect(Collectors.toList());
 		
 		// Remove Hel, if it's in here.
@@ -1764,7 +1771,6 @@ public class FE4ClassRandomizer {
 		boolean isHealer = targetClass.isHealer();
 		// If we're not prioritizing healing staves, we don't need any special logic that relies on this being a healing class.
 		if (!prioritizeHealingStavesForHealers) { isHealer = false; }
-		FE4Data.Character fe4Char = FE4Data.Character.valueOf(character.getCharacterID());
 		
 		Set<FE4Data.Item> healingStaves = new HashSet<Item>(FE4Data.Item.healingStaves);
 		healingStaves.retainAll(usableItems);


### PR DESCRIPTION
Fixed #31 - Fixed an issue where recruitable enemies can spawn with player-only weapons (i.e. berserk weapons).