### PR TITLE
[Issue #28] Removed Gen 1 Analogue for Altena

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -1108,7 +1108,7 @@ public class FE4Data {
 			
 			case SELIPH: return SIGURD;
 			case LEIF: return ETHLYN;
-			case ALTENA: return QUAN;
+			//case ALTENA: return QUAN; // We don't need to specify this one, since we handle it elsewhere and they don't really match to begin with.
 			default: return null;
 			}
 		}


### PR DESCRIPTION
Fixed #28 - Removed Altena from the analogue case, since her class is already limited to begin with (and her class doesn't really match with Quan's anyway).