### PR TITLE
[Issue #26] Fixed issues with 0x2 and 0x67 in FE4.

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -72,7 +72,7 @@ public class FE4Data {
 	public static final int PromotionTableEntrySize = 1; // Each item is 1 byte (the class ID). The order is baked in, following the character IDs - 1 (because Sigurd is 1).
 	
 	// All player weapons are tracked by kills and usage, so they need special treatment here.
-	// While weapon stats are located elsewhere, these define which item is in which "slot" so to sepak.
+	// While weapon stats are located elsewhere, these define which item is in which "slot" so to speak.
 	public static final long PlayerItemMappingTableOffset = 0x3F688;
 	public static final int PlayerItemMappingTableCount = 145; // We only have 144 items to work with, technically. Don't use item 0.
 	public static final int PlayerItemMappingTableItemSize = 1; // Each item is a byte, representing the item ID in that slot. The index is how the items are referred to afterwards.
@@ -114,16 +114,23 @@ public class FE4Data {
 	public static final int Chapter8ShopSteelLanceInventoryID = 0x34;
 	public static final int DeirdreAuraInventoryID = 0x60;
 	
+	// Ethlyn's appearance in Ch. 5 gives her two items that aren't well documented: 0x2 (Iron Sword) and 0x67 (Mend).
+	// 0x2 is isolated from the rest of the game, but is programmatically inherited by Leif.
+	// 0x67 is the starting equipment for Nanna/Jeanne, and will be randomized by her, which might cause problems. Additionally, 0x67 is also found in the shop in Ch. 8. It's also possible for Leif to inherit this if he could.
+	// The solution then is to give Nanna/Jeanne a new inventory item to split it up. 0x67 will still fall into the Ch. 8 shop, but Jeanne and Nanna won't be able to give Ethlyn a problematic weapon now.
+	public static final int JeanneNannaOldStartingInventoryID = 0x67;
+	public static final int JeanneNannaNewStartingInventoryID = 0x40;
+	// We should also assign Leif 0x2 so that he can randomize that weapon. Ideally it's something both of them can use, but otherwise, defer to Leif.
+	public static final int LeifEthlynSharedInventoryID = 0x02;
+	
 	// Remove 0x34 from the Ch. 8 shop.
 	public static final long Chapter8ShopListOffset = 0x6F54CL;
 	public static final byte[] Chapter8ShopOldListByteArray = new byte[] {0x08, 0x1C, 0x23, 0x29, 0x32, 0x33, 0x34, 0x44, 0x47, 0x4A, 0x50, 0x55, 0x58, 0x65, 0x72, 0x06, 0x30, 0x48, 0x5D, 0x64, 0x67};
 	public static final byte[] Chapter8ShopNewListByteArray = new byte[] {0x08, 0x1C, 0x23, 0x29, 0x32, 0x33, 0x44, 0x47, 0x4A, 0x50, 0x55, 0x58, 0x65, 0x72, 0x06, 0x30, 0x48, 0x5D, 0x64, 0x67, (byte)0xFF};
-	public static final byte[] Chapter8ShopNewListWithFillByteArray = new byte[] {0x08, 0x1C, 0x23, 0x29, 0x32, 0x33, 0x40, 0x44, 0x47, 0x4A, 0x50, 0x55, 0x58, 0x65, 0x72, 0x06, 0x30, 0x48, 0x5D, 0x64, 0x67};
 	
 	// These don't seem to be used by anybody in the game. Free holy weapons? Or free staves!
 	// The last two may or may not work. They're empty right now, but they may be serving as terminator bytes.
-	public static final List<Integer> UnusedInventoryIDs = new ArrayList<Integer>(Arrays.asList(0x12, 0x40, 0x8D, 0x8E));
-	public static final List<Integer> UnusedInventoryIDsWithFill = new ArrayList<Integer>(Arrays.asList(0x12, 0x8D, 0x8E));
+	public static final List<Integer> UnusedInventoryIDs = new ArrayList<Integer>(Arrays.asList(0x12, 0x8D, 0x8E));
 	
 	public static class EventGift {
 		public Character recipient;

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -139,6 +140,8 @@ public class FE4Randomizer extends Randomizer {
 		
 		RecordKeeper recordKeeper = initializeRecordKeeper();
 		recordKeeper.addHeaderItem("Randomizer Seed Phrase", seed);
+		
+		try { makeInitialAdjustments(); } catch (Exception e) { notifyError("Encountered error while making initial adjustments.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
 		
 		updateStatusString("Randomizing...");
 		try { randomizeClassesIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing classes.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
@@ -342,6 +345,19 @@ public class FE4Randomizer extends Randomizer {
 		classData = new ClassDataLoader(handler, isHeadered);
 	}
 	
+	// These changes are made after data loaders are set up but before any randomization happens.
+	private void makeInitialAdjustments() {
+		// Fix Jeanne/Nanna's inventory so that it splits from Ethlyn's Ch. 5 inventory.
+		FE4ChildCharacter nanna = charData.getChildCharacter(FE4Data.Character.NANNA);
+		if (nanna.getEquipment1() == FE4Data.JeanneNannaOldStartingInventoryID) { nanna.setEquipment1(FE4Data.JeanneNannaNewStartingInventoryID); }
+		else if (nanna.getEquipment2() == FE4Data.JeanneNannaOldStartingInventoryID) { nanna.setEquipment2(FE4Data.JeanneNannaNewStartingInventoryID); }
+		
+		FE4StaticCharacter jeanne = charData.getStaticCharacter(FE4Data.Character.JEANNE);
+		if (jeanne.getEquipment1() == FE4Data.JeanneNannaOldStartingInventoryID) { jeanne.setEquipment1(FE4Data.JeanneNannaNewStartingInventoryID); }
+		else if (jeanne.getEquipment2() == FE4Data.JeanneNannaOldStartingInventoryID) { jeanne.setEquipment2(FE4Data.JeanneNannaNewStartingInventoryID); }
+		else if (jeanne.getEquipment3() == FE4Data.JeanneNannaOldStartingInventoryID) { jeanne.setEquipment3(FE4Data.JeanneNannaNewStartingInventoryID); }
+	}
+	
 	private void randomizeGrowthsIfNecessary(String seed) {
 		if (growthOptions != null) {
 			updateStatusString("Randomizing growths...");
@@ -515,6 +531,54 @@ public class FE4Randomizer extends Randomizer {
 			int equip1 = lex.getEquipment1();
 			FE4Data.Item item1 = itemMapper.getItemAtIndex(equip1);
 			diffCompiler.addDiff(new Diff(FE4Data.LexHeroAxeEventItemRequirementOffset - (isHeadered ? 0 : 0x200), 1, new byte[] {(byte)item1.ID}, new byte[] {FE4Data.LexHeroAxeEventItemRequirementOldID}));
+			
+			// Handle item 0x2. It's Leif's starting equipment but it's not specifically coded to be because it's part of Ethlyn's kit in Ch. 5.
+			// See if there's a weapon they can both use. Otherwise, defer to Leif.
+			FE4StaticCharacter ethlyn = charData.getStaticCharacter(FE4Data.Character.ETHLYN);
+			FE4ChildCharacter leif = charData.getChildCharacter(FE4Data.Character.LEIF);
+			
+			FE4Data.CharacterClass ethlynClass = FE4Data.CharacterClass.valueOf(ethlyn.getClassID());
+			FE4Data.CharacterClass leifClass = FE4Data.CharacterClass.valueOf(leif.getClassID());
+			
+			List<FE4Data.HolyBloodSlot1> slot1Blood = FE4Data.HolyBloodSlot1.slot1HolyBlood(ethlyn.getHolyBlood1Value());
+			List<FE4Data.HolyBloodSlot2> slot2Blood = FE4Data.HolyBloodSlot2.slot2HolyBlood(ethlyn.getHolyBlood2Value());
+			List<FE4Data.HolyBloodSlot3> slot3Blood = FE4Data.HolyBloodSlot3.slot3HolyBlood(ethlyn.getHolyBlood3Value());
+			
+			Set<FE4Data.Item> ethlynUsableSet = new HashSet<FE4Data.Item>(Arrays.asList(ethlynClass.usableItems(slot1Blood, slot2Blood, slot3Blood)));
+			
+			// Leif also gets Quan's minor blood.
+			FE4StaticCharacter quan = charData.getStaticCharacter(FE4Data.Character.QUAN);
+			FE4Data.HolyBloodSlot1.slot1HolyBlood(quan.getHolyBlood1Value()).stream().forEach(blood -> {
+				FE4Data.HolyBloodSlot1 bloodToAdd = FE4Data.HolyBloodSlot1.blood(blood.bloodType(), false); 	
+				if (slot1Blood.contains(bloodToAdd)) {
+					slot1Blood.remove(bloodToAdd);
+					slot1Blood.add(FE4Data.HolyBloodSlot1.blood(blood.bloodType(), true));
+				}
+			});
+			FE4Data.HolyBloodSlot2.slot2HolyBlood(quan.getHolyBlood2Value()).stream().forEach(blood -> {
+				FE4Data.HolyBloodSlot2 bloodToAdd = FE4Data.HolyBloodSlot2.blood(blood.bloodType(), false); 	
+				if (slot2Blood.contains(bloodToAdd)) {
+					slot2Blood.remove(bloodToAdd);
+					slot2Blood.add(FE4Data.HolyBloodSlot2.blood(blood.bloodType(), true));
+				}
+			});
+			FE4Data.HolyBloodSlot3.slot3HolyBlood(quan.getHolyBlood3Value()).stream().forEach(blood -> {
+				FE4Data.HolyBloodSlot3 bloodToAdd = FE4Data.HolyBloodSlot3.blood(blood.bloodType(), false); 	
+				if (slot3Blood.contains(bloodToAdd)) {
+					slot3Blood.remove(bloodToAdd);
+					slot3Blood.add(FE4Data.HolyBloodSlot3.blood(blood.bloodType(), true));
+				}
+			});
+			
+			Set<FE4Data.Item> leifUsableSet = new HashSet<FE4Data.Item>(Arrays.asList(leifClass.usableItems(slot1Blood, slot2Blood, slot3Blood)));
+			
+			if (!Collections.disjoint(ethlynUsableSet, leifUsableSet)) {
+				leifUsableSet.retainAll(ethlynUsableSet);
+			}
+			
+			Random rng = new Random(SeedGenerator.generateSeedValue(seed, 0));
+			List<FE4Data.Item> usableList = leifUsableSet.stream().sorted(FE4Data.Item.defaultComparator).collect(Collectors.toList());
+			itemMapper.setItemAtIndex(FE4Data.LeifEthlynSharedInventoryID, usableList.get(rng.nextInt(usableList.size())));
 		}
 		
 		if (classOptions.randomizeBlood || bloodOptions.giveHolyBlood) {


### PR DESCRIPTION
Fixed #26 

* Added special case for item 0x2 to be set post randomization to be of something Leif and Ethlyn can use (when possible possible).
* Replaced 0x67 in Jeanne/Nanna's starting inventory with 0x40 and left 0x67 unrandomized.