### PR TITLE
[Issue #63] Fixed a case where promotion options weren't defaulting to any option in FE4.

### DIFF
--- a/Universal FE Randomizer/src/ui/fe4/FE4PromotionView.java
+++ b/Universal FE Randomizer/src/ui/fe4/FE4PromotionView.java
@@ -140,6 +140,8 @@ public class FE4PromotionView extends Composite {
 		} else {
 			currentMode = options.promotionMode;
 			
+			if (currentMode == null) { currentMode = FE4PromotionOptions.Mode.STRICT; }
+			
 			strictButton.setSelection(currentMode == FE4PromotionOptions.Mode.STRICT);
 			
 			looseButton.setSelection(currentMode == FE4PromotionOptions.Mode.LOOSE);


### PR DESCRIPTION
Fixed #63 - Fixed an issue where no promotion options were being selected on the first time on FE4 randomization.