### PR TITLE
[Issue #62] Give A rank Light magic to sages naturally

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -2588,6 +2588,18 @@ public class FE4Data {
 				default: return false;
 				}
 			}
+			
+			public String displayString() {
+				switch (this) {
+				case NONE: return "-";
+				case C: return "C";
+				case B: return "B";
+				case A: return "A";
+				case PRF: return "S";
+				}
+				
+				return "?";
+			}
 		}
 		
 		public enum ItemType {

--- a/Universal FE Randomizer/src/random/snes/fe4/loader/ClassDataLoader.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/loader/ClassDataLoader.java
@@ -99,6 +99,17 @@ public class ClassDataLoader {
 		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Base DEF", Integer.toString(classObject.getBaseDEF()));
 		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Base RES", Integer.toString(classObject.getBaseRES()));
 		
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Sword Rank", classObject.getSwordRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Lance Rank", classObject.getLanceRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Axe Rank", classObject.getAxeRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Bow Rank", classObject.getBowRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Fire Rank", classObject.getFireRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Thunder Rank", classObject.getThunderRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Wind Rank", classObject.getWindRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Light Rank", classObject.getLightRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Dark Rank", classObject.getDarkRank().displayString());
+		recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Staff Rank", classObject.getStaffRank().displayString());
+		
 		List<FE4Class.ClassSkills> slot1 = classObject.getSlot1ClassSkills();
 		if (slot1.isEmpty()) {
 			recordData(rk, isInitial, RecordKeeperCategoryKey, name, "Class Skills 1", "None");

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -355,6 +355,9 @@ public class FE4Randomizer extends Randomizer {
 		if (jeanne.getEquipment1() == FE4Data.JeanneNannaOldStartingInventoryID) { jeanne.setEquipment1(FE4Data.JeanneNannaNewStartingInventoryID); }
 		else if (jeanne.getEquipment2() == FE4Data.JeanneNannaOldStartingInventoryID) { jeanne.setEquipment2(FE4Data.JeanneNannaNewStartingInventoryID); }
 		else if (jeanne.getEquipment3() == FE4Data.JeanneNannaOldStartingInventoryID) { jeanne.setEquipment3(FE4Data.JeanneNannaNewStartingInventoryID); }
+		
+		// Give A rank Light magic to Sages.
+		classData.classForID(FE4Data.CharacterClass.SAGE.ID).setLightRank(WeaponRank.A);
 	}
 	
 	private void randomizeGrowthsIfNecessary(String seed) {
@@ -513,9 +516,6 @@ public class FE4Randomizer extends Randomizer {
 		
 		// Remove Charm from Princess
 		classData.classForID(FE4Data.CharacterClass.PRINCESS.ID).setSlot2ClassSkills(new ArrayList<ClassSkills>());
-		
-		// Give A rank Light magic to Sages.
-		classData.classForID(FE4Data.CharacterClass.SAGE.ID).setLightRank(WeaponRank.A);
 		
 		// Gotta fix Oifey's promotion so that he doesn't somehow promote even though he's already promoted.
 		promotionMapper.setPromotionForCharacter(FE4Data.Character.OIFEY, FE4Data.CharacterClass.NONE);

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import fedata.snes.fe4.FE4ChildCharacter;
 import fedata.snes.fe4.FE4Class.ClassSkills;
+import fedata.snes.fe4.FE4Data.Item.WeaponRank;
 import fedata.snes.fe4.FE4Data;
 import fedata.snes.fe4.FE4StaticCharacter;
 import io.DiffApplicator;
@@ -512,6 +513,9 @@ public class FE4Randomizer extends Randomizer {
 		
 		// Remove Charm from Princess
 		classData.classForID(FE4Data.CharacterClass.PRINCESS.ID).setSlot2ClassSkills(new ArrayList<ClassSkills>());
+		
+		// Give A rank Light magic to Sages.
+		classData.classForID(FE4Data.CharacterClass.SAGE.ID).setLightRank(WeaponRank.A);
 		
 		// Gotta fix Oifey's promotion so that he doesn't somehow promote even though he's already promoted.
 		promotionMapper.setPromotionForCharacter(FE4Data.Character.OIFEY, FE4Data.CharacterClass.NONE);


### PR DESCRIPTION
Fixed #62 - Added logic to give sages A rank light magic to preserve Light Priestess promotion ranks.