### PR TITLE
[Issue #65] Retain holy weapons in FE6 in Yodel's inventory.

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -2197,7 +2197,7 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 	
 	public Set<GBAFEItem> specialItemsToRetain() {
-		return new HashSet<GBAFEItem>(Arrays.asList(Item.MEMBER_CARD));
+		return new HashSet<GBAFEItem>(Arrays.asList(Item.MEMBER_CARD, Item.MURGLEIS, Item.MALTET, Item.HOLY_MAIDEN));
 	}
 
 	public Set<GBAFEItem> itemKitForSpecialClass(int classID, Random rng) {


### PR DESCRIPTION
Fixed #65 - Retain Murgleis, Maltet, and the Saint's Staff in Yodel's inventory in FE6.