### PR TITLE
[Feature #68] Added control for random effect chance

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -448,7 +448,7 @@ public class GBARandomizer extends Randomizer {
 			if (weapons.shouldAddEffects && weapons.effectsList != null) {
 				updateStatusString("Adding random effects to weapons...");
 				Random rng = new Random(SeedGenerator.generateSeedValue(seed, WeaponsRandomizer.rngSalt + 4));
-				WeaponsRandomizer.randomizeEffects(weapons.effectsList, itemData, textData, weapons.noEffectIronWeapons, rng);
+				WeaponsRandomizer.randomizeEffects(weapons.effectsList, itemData, textData, weapons.noEffectIronWeapons, weapons.effectChance, rng);
 			}
 		}
 	}
@@ -765,10 +765,9 @@ public class GBARandomizer extends Randomizer {
 			rk.addHeaderItem("Randomize Weapon Durability", "NO");
 		}
 		if (weapons.shouldAddEffects) {
-			rk.addHeaderItem("Add Random Effects", "YES");
+			rk.addHeaderItem("Add Random Effects", "YES (" + weapons.effectChance + "%)");
 			StringBuilder sb = new StringBuilder();
 			sb.append("<ul>\n");
-			if (weapons.effectsList.none) { sb.append("<li>No Effect</li>\n"); }
 			if (weapons.effectsList.statBoosts) { sb.append("<li>Stat Boosts</li>\n"); }
 			if (weapons.effectsList.effectiveness) { sb.append("<li>Effectiveness</li>\n"); }
 			if (weapons.effectsList.unbreakable) { sb.append("<li>Unbreakable</li>\n"); }

--- a/Universal FE Randomizer/src/random/gba/randomizer/WeaponsRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/WeaponsRandomizer.java
@@ -96,12 +96,11 @@ public class WeaponsRandomizer {
 		itemsData.commit();
 	}
 	
-	public static void randomizeEffects(WeaponEffectOptions effectOptions, ItemDataLoader itemsData, TextLoader textData, Boolean ignoreIronWeapons, Random rng) {
+	public static void randomizeEffects(WeaponEffectOptions effectOptions, ItemDataLoader itemsData, TextLoader textData, Boolean ignoreIronWeapons, int effectChance, Random rng) {
 		GBAFEItemData[] allWeapons = itemsData.getAllWeapons();
 		
 		Set<WeaponEffects> enabledEffects = new HashSet<WeaponEffects>();
 		
-		if (effectOptions.none) { enabledEffects.add(WeaponEffects.NONE); }
 		if (effectOptions.statBoosts) { enabledEffects.add(WeaponEffects.STAT_BOOSTS); }
 		if (effectOptions.effectiveness) { enabledEffects.add(WeaponEffects.EFFECTIVENESS); }
 		if (effectOptions.unbreakable) { enabledEffects.add(WeaponEffects.UNBREAKABLE); }
@@ -116,7 +115,9 @@ public class WeaponsRandomizer {
 		
 		for (GBAFEItemData weapon : allWeapons) {
 			if (ignoreIronWeapons && itemsData.isBasicWeapon(weapon.getID())) { continue; }
-			weapon.applyRandomEffect(enabledEffects, itemsData, textData, itemsData.spellAnimations, rng);
+			if (rng.nextInt(100) < effectChance) {
+				weapon.applyRandomEffect(enabledEffects, itemsData, textData, itemsData.spellAnimations, rng);
+			}
 		}
 		
 		itemsData.commit();

--- a/Universal FE Randomizer/src/ui/WeaponEffectSelectionView.java
+++ b/Universal FE Randomizer/src/ui/WeaponEffectSelectionView.java
@@ -16,7 +16,6 @@ public class WeaponEffectSelectionView extends Composite {
 		public void onSelectionChanged();
 	}
 	
-	private Button noneCheckBox;
 	private Button statBoostsCheckBox;
 	private Button effectivenessCheckBox;
 	private Button unbreakableCheckBox;
@@ -56,16 +55,6 @@ public class WeaponEffectSelectionView extends Composite {
 	}
 	
 	protected void buildView(GameType type) {
-		noneCheckBox = new Button(this, SWT.CHECK);
-		noneCheckBox.setText("None");
-		noneCheckBox.setToolTipText("Allows random weapons to remain as they were and not receive a random effect.");
-		noneCheckBox.addListener(SWT.Selection, new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				notifySelectionChange();
-			}
-		});
-		
 		statBoostsCheckBox = new Button(this, SWT.CHECK);
 		statBoostsCheckBox.setText("Stat Boosts");
 		statBoostsCheckBox.setToolTipText("Allows random weapons to grant minor stat boosts. (+5 to a random stat).");
@@ -187,7 +176,7 @@ public class WeaponEffectSelectionView extends Composite {
 	public void setEnabled(boolean enabled) {
 		super.setEnabled(enabled);
 		
-		noneCheckBox.setEnabled(enabled);
+		//noneCheckBox.setEnabled(enabled);
 		statBoostsCheckBox.setEnabled(enabled);
 		effectivenessCheckBox.setEnabled(enabled);
 		unbreakableCheckBox.setEnabled(enabled);
@@ -207,7 +196,7 @@ public class WeaponEffectSelectionView extends Composite {
 	
 	public void selectAll() {
 		squelchCallbacks = true;
-		noneCheckBox.setSelection(true);
+		//noneCheckBox.setSelection(true);
 		statBoostsCheckBox.setSelection(true);
 		effectivenessCheckBox.setSelection(true);
 		unbreakableCheckBox.setSelection(true);
@@ -226,7 +215,7 @@ public class WeaponEffectSelectionView extends Composite {
 	
 	public void deselectAll() {
 		squelchCallbacks = true;
-		noneCheckBox.setSelection(false);
+		//noneCheckBox.setSelection(false);
 		statBoostsCheckBox.setSelection(false);
 		effectivenessCheckBox.setSelection(false);
 		unbreakableCheckBox.setSelection(false);
@@ -248,12 +237,12 @@ public class WeaponEffectSelectionView extends Composite {
 	}
 	
 	public WeaponEffectOptions getOptions() {
-		return new WeaponEffectOptions(noneEnabled, statBoostsEnabled, effectivenessEnabled, unbreakableEnabled, braveEnabled, reverseEnabled, rangeEnabled, criticalEnabled, magicEnabled, poisonEnabled, eclipseEnabled, devilEnabled);
+		return new WeaponEffectOptions(statBoostsEnabled, effectivenessEnabled, unbreakableEnabled, braveEnabled, reverseEnabled, rangeEnabled, criticalEnabled, magicEnabled, poisonEnabled, eclipseEnabled, devilEnabled);
 	}
 	
 	public void setOptions(WeaponEffectOptions options) {
 		if (options != null) {
-			noneCheckBox.setSelection(options.none != null ? options.none : false);
+			//noneCheckBox.setSelection(options.none != null ? options.none : false);
 			statBoostsCheckBox.setSelection(options.statBoosts != null ? options.statBoosts : false);
 			effectivenessCheckBox.setSelection(options.effectiveness != null ? options.effectiveness : false);
 			unbreakableCheckBox.setSelection(options.unbreakable != null ? options.unbreakable : false);
@@ -271,7 +260,7 @@ public class WeaponEffectSelectionView extends Composite {
 	}
 	
 	public void notifySelectionChange() {
-		noneEnabled = noneCheckBox.getSelection();
+		//noneEnabled = noneCheckBox.getSelection();
 		statBoostsEnabled = statBoostsCheckBox.getSelection();
 		effectivenessEnabled = effectivenessCheckBox.getSelection();
 		unbreakableEnabled = unbreakableCheckBox.getSelection();

--- a/Universal FE Randomizer/src/ui/WeaponsView.java
+++ b/Universal FE Randomizer/src/ui/WeaponsView.java
@@ -39,7 +39,9 @@ public class WeaponsView extends Composite {
 	private MinMaxControl durabilityRangeControl;
 	
 	private Button enableRandomEffectsButton;
-	private Button noEffectsForIronButton;;
+	private Button noEffectsForIronButton;
+	private Label effectChanceLabel;
+	private Spinner effectChanceSpinner;
 	private WeaponEffectSelectionView effectsSelectionView;
 	
 	public WeaponsView(Composite parent, int style, GameType type) {
@@ -332,6 +334,26 @@ public class WeaponsView extends Composite {
 		ironData.top = new FormAttachment(enableRandomEffectsButton, 5);
 		noEffectsForIronButton.setLayoutData(ironData);
 		
+		effectChanceSpinner = new Spinner(container, SWT.NONE);
+		effectChanceSpinner.setToolTipText("Sets the chance of an effect being added to a weapon.");
+		effectChanceSpinner.setEnabled(false);
+		effectChanceSpinner.setValues(25, 1, 100, 0, 1, 5);
+		effectChanceSpinner.setEnabled(false);
+		
+		effectChanceLabel = new Label(container, SWT.NONE);
+		effectChanceLabel.setText("Effect Chance:");
+		effectChanceLabel.setEnabled(false);
+		
+		FormData spinnerData = new FormData();
+		spinnerData.left = new FormAttachment(effectChanceLabel, 10);
+		spinnerData.top = new FormAttachment(noEffectsForIronButton, 5);
+		effectChanceSpinner.setLayoutData(spinnerData);
+		
+		FormData labelData = new FormData();
+		labelData.left = new FormAttachment(noEffectsForIronButton, 0, SWT.LEFT);
+		labelData.top = new FormAttachment(effectChanceSpinner, 0, SWT.CENTER);
+		effectChanceLabel.setLayoutData(labelData);
+		
 		updateWeaponEffectSelectionViewForGame(type);
 	}
 	
@@ -343,7 +365,7 @@ public class WeaponsView extends Composite {
 		
 		FormData effectData = new FormData();
 		effectData.left = new FormAttachment(noEffectsForIronButton, 10, SWT.LEFT);
-		effectData.top = new FormAttachment(noEffectsForIronButton, 5);
+		effectData.top = new FormAttachment(effectChanceSpinner, 5);
 		effectData.bottom = new FormAttachment(100, -5);
 		effectData.width = 280;
 		effectsSelectionView.setLayoutData(effectData);
@@ -353,6 +375,9 @@ public class WeaponsView extends Composite {
 			public void onSelectionChanged() {
 				if (effectsSelectionView.isAllDisabled()) {
 					enableRandomEffectsButton.setSelection(false);
+					noEffectsForIronButton.setEnabled(false);
+					effectChanceLabel.setEnabled(false);
+					effectChanceSpinner.setEnabled(false);
 					effectsSelectionView.setEnabled(false);
 				}
 			}
@@ -368,6 +393,8 @@ public class WeaponsView extends Composite {
 				Boolean enabled = enableRandomEffectsButton.getSelection();
 				effectsSelectionView.setEnabled(enabled);
 				noEffectsForIronButton.setEnabled(enabled);
+				effectChanceLabel.setEnabled(enabled);
+				effectChanceSpinner.setEnabled(enabled);
 				if (enabled) {
 					effectsSelectionView.selectAll();
 					noEffectsForIronButton.setSelection(true);
@@ -398,7 +425,7 @@ public class WeaponsView extends Composite {
 			durabilityOptions = new MinMaxVarOption(durabilityRangeControl.getMinMaxOption(), durabilityVarianceSpinner.getSelection());
 		}
 		
-		return new WeaponOptions(mightOptions, hitOptions, weightOptions, durabilityOptions, enableRandomEffectsButton.getSelection(), effectsSelectionView.getOptions(), noEffectsForIronButton.getSelection());
+		return new WeaponOptions(mightOptions, hitOptions, weightOptions, durabilityOptions, enableRandomEffectsButton.getSelection(), effectChanceSpinner.getSelection(), effectsSelectionView.getOptions(), noEffectsForIronButton.getSelection());
 	}
 	
 	public void setWeaponOptions(WeaponOptions options) {
@@ -445,8 +472,11 @@ public class WeaponsView extends Composite {
 				enableRandomEffectsButton.setSelection(true);
 				effectsSelectionView.setEnabled(true);
 				noEffectsForIronButton.setEnabled(true);
+				effectChanceSpinner.setEnabled(true);
+				effectChanceLabel.setEnabled(true);
 				effectsSelectionView.setOptions(options.effectsList);
 				noEffectsForIronButton.setSelection(options.noEffectIronWeapons);
+				effectChanceSpinner.setSelection(options.effectChance);
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/ui/model/WeaponEffectOptions.java
+++ b/Universal FE Randomizer/src/ui/model/WeaponEffectOptions.java
@@ -2,7 +2,6 @@ package ui.model;
 
 public class WeaponEffectOptions {
 
-	public final Boolean none;
 	public final Boolean statBoosts;
 	public final Boolean effectiveness;
 	public final Boolean unbreakable;
@@ -15,11 +14,10 @@ public class WeaponEffectOptions {
 	public final Boolean eclipse;
 	public final Boolean devil;
 	
-	public WeaponEffectOptions(Boolean none, Boolean statBoosts, Boolean effectiveness, Boolean unbreakable, Boolean brave,
+	public WeaponEffectOptions(Boolean statBoosts, Boolean effectiveness, Boolean unbreakable, Boolean brave,
 			Boolean reverseTriangle, Boolean extendedRange, Boolean highCritical, Boolean magicDamage, Boolean poison,
 			Boolean eclipse, Boolean devil) {
 		super();
-		this.none = none;
 		this.statBoosts = statBoosts;
 		this.effectiveness = effectiveness;
 		this.unbreakable = unbreakable;

--- a/Universal FE Randomizer/src/ui/model/WeaponOptions.java
+++ b/Universal FE Randomizer/src/ui/model/WeaponOptions.java
@@ -10,6 +10,7 @@ public class WeaponOptions {
 	
 	public final Boolean shouldAddEffects;
 	public final Boolean noEffectIronWeapons;
+	public final int effectChance;
 	public final WeaponEffectOptions effectsList;
 	
 	public WeaponOptions(MinMaxVarOption mightOptions, 
@@ -18,6 +19,7 @@ public class WeaponOptions {
 			MinMaxVarOption weightOptions, 
 			MinMaxVarOption durabilityOptions, 
 			Boolean shouldAddEffects,
+			int effectChance,
 			WeaponEffectOptions effects,
 			Boolean noIrons) {
 		super();
@@ -30,6 +32,7 @@ public class WeaponOptions {
 		this.shouldAddEffects = shouldAddEffects;
 		effectsList = effects;
 		noEffectIronWeapons = noIrons;
+		this.effectChance = effectChance;
 	}
 	
 }


### PR DESCRIPTION
Fixed #68.

* Added a control to specify what fraction of weapons gain special effects.
* Removed "None" from the list of effects possible (since the new control can set that now).