### PR TITLE
[Feature #44] Holy Blood Shuffling

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -1945,7 +1945,7 @@ public class FE4Data {
 			}
 			
 			Set<CharacterClass> workingSet = new HashSet<CharacterClass>();
-			if (promotedClasses.contains(this)) { workingSet.addAll(promotedClasses); }
+			if (isPromoted()) { workingSet.addAll(promotedClasses); }
 			else { workingSet.addAll(unpromotedClasses); }
 			
 			if (!isEnemy) { 
@@ -3074,25 +3074,30 @@ public class FE4Data {
 	}
 	
 	public enum HolyBlood {
-		NONE(Item.NONE, Item.ItemType.NONE),
-		BALDR(Item.TYRFING, Item.ItemType.SWORD), 
-		OD(Item.BALMUNG, Item.ItemType.SWORD), 
-		HEZUL(Item.MYSTLETAINN, Item.ItemType.SWORD), 
-		NJORUN(Item.GAE_BOLG, Item.ItemType.LANCE), 
-		DAIN(Item.GUNGNIR, Item.ItemType.LANCE), 
-		NEIR(Item.HELSWATH, Item.ItemType.AXE), 
-		ULIR(Item.YEWFELLE, Item.ItemType.BOW), 
-		FJALAR(Item.VALFLAME, Item.ItemType.FIRE_MAGIC), 
-		THRUD(Item.MJOLNIR, Item.ItemType.THUNDER_MAGIC), 
-		FORSETI(Item.FORSETI, Item.ItemType.WIND_MAGIC), 
-		NAGA(Item.NAGA, Item.ItemType.LIGHT_MAGIC), 
-		LOPTOUS(Item.LOPTYR, Item.ItemType.DARK_MAGIC), 
-		BRAGI(Item.VALKYRIE, Item.ItemType.STAFF);
+		NONE(Item.NONE, Item.ItemType.NONE, Character.NONE),
+		BALDR(Item.TYRFING, Item.ItemType.SWORD, Character.SIGURD), 
+		OD(Item.BALMUNG, Item.ItemType.SWORD, Character.SHANNAN), 
+		HEZUL(Item.MYSTLETAINN, Item.ItemType.SWORD, Character.ARES), 
+		NJORUN(Item.GAE_BOLG, Item.ItemType.LANCE, Character.QUAN), 
+		DAIN(Item.GUNGNIR, Item.ItemType.LANCE, Character.ARION_CH9), 
+		NEIR(Item.HELSWATH, Item.ItemType.AXE, Character.LOMBARD), 
+		ULIR(Item.YEWFELLE, Item.ItemType.BOW, Character.BRIGID), 
+		FJALAR(Item.VALFLAME, Item.ItemType.FIRE_MAGIC, Character.ARVIS_CH5), 
+		THRUD(Item.MJOLNIR, Item.ItemType.THUNDER_MAGIC, Character.REPTOR), 
+		FORSETI(Item.FORSETI, Item.ItemType.WIND_MAGIC, Character.LEWYN), 
+		NAGA(Item.NAGA, Item.ItemType.LIGHT_MAGIC, Character.JULIA), 
+		LOPTOUS(Item.LOPTYR, Item.ItemType.DARK_MAGIC, Character.JULIUS_FINAL), 
+		BRAGI(Item.VALKYRIE, Item.ItemType.STAFF, Character.CLAUD);
 		
 		public Item holyWeapon;
 		public Item.ItemType weaponType;
+		public Character representative;
 		
-		private HolyBlood(Item weapon, Item.ItemType type) { this.holyWeapon = weapon; this.weaponType = type; }
+		private HolyBlood(Item weapon, Item.ItemType type, Character representative) { 
+			this.holyWeapon = weapon; 
+			this.weaponType = type;
+			this.representative = representative;
+		}
 		
 		// They're not IDs because they're not referenced this way, but they are stored in data in this order.
 		public static List<HolyBlood> orderedByDataTable() {
@@ -3123,6 +3128,21 @@ public class FE4Data {
 			case LOPTOUS: CharacterClass.darkUsers.toArray(new CharacterClass[CharacterClass.darkUsers.size()]);
 			case BRAGI: CharacterClass.staffUsers.toArray(new CharacterClass[CharacterClass.staffUsers.size()]);
 			default: return new CharacterClass[] {};
+			}
+		}
+		
+		public boolean isEnemyBlood() {
+			return !representative.isPlayable();
+		}
+		
+		// These should not be doled out arbitrarily.
+		public boolean isRestricted() {
+			switch (this) {
+			case NAGA:
+			case LOPTOUS:
+				return true;
+			default:
+					return false;
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ import random.snes.fe4.loader.HolyBloodLoader;
 import random.snes.fe4.loader.ItemMapper;
 import random.snes.fe4.loader.PromotionMapper;
 import ui.fe4.FE4ClassOptions;
+import ui.fe4.FE4ClassOptions.BloodOptions;
 import ui.fe4.FE4EnemyBuffOptions;
 import ui.fe4.FE4PromotionOptions;
 import ui.fe4.HolyBloodOptions;
@@ -421,23 +423,24 @@ public class FE4Randomizer extends Randomizer {
 	
 	private void randomizeClassesIfNecessary(String seed) {
 		if (classOptions != null) {
+			Map<FE4Data.HolyBlood, FE4Data.HolyBlood> predeterminedBloodMap = FE4ClassRandomizer.generateBloodMapForBloodShuffle(classOptions, new Random(SeedGenerator.generateSeedValue(seed, FE4ClassRandomizer.rngSalt)));
 			if (classOptions.randomizePlayableCharacters) {
 				updateStatusString("Randomizing player classes...");
 				Random rng = new Random(SeedGenerator.generateSeedValue(seed, FE4ClassRandomizer.rngSalt + 1));
-				FE4ClassRandomizer.randomizePlayableCharacterClasses(classOptions, buffOptions != null ? !buffOptions.majorHolyBloodBosses : true, charData, bloodData, itemMapper, rng);
+				FE4ClassRandomizer.randomizePlayableCharacterClasses(classOptions, buffOptions != null ? !buffOptions.majorHolyBloodBosses : true, charData, bloodData, itemMapper, predeterminedBloodMap, rng);
 				charData.commit();
 				itemMapper.commitChanges();
 			}
 			if (classOptions.randomizeMinions) {
 				updateStatusString("Randomizing minions...");
 				Random rng = new Random(SeedGenerator.generateSeedValue(seed, FE4ClassRandomizer.rngSalt + 2));
-				FE4ClassRandomizer.randomizeMinions(classOptions, charData, itemMapper, rng);
+				FE4ClassRandomizer.randomizeMinions(classOptions, charData, itemMapper, predeterminedBloodMap, rng);
 				charData.commit();
 			}
 			if (classOptions.randomizeBosses) {
 				updateStatusString("Randomizing bosses...");
 				Random rng = new Random(SeedGenerator.generateSeedValue(seed, FE4ClassRandomizer.rngSalt + 3));
-				FE4ClassRandomizer.randomizeBosses(classOptions, charData, itemMapper, rng);
+				FE4ClassRandomizer.randomizeBosses(classOptions, charData, itemMapper, predeterminedBloodMap, rng);
 				charData.commit();
 			}
 			if (classOptions.randomizeArena) {
@@ -587,7 +590,7 @@ public class FE4Randomizer extends Randomizer {
 			itemMapper.setItemAtIndex(FE4Data.LeifEthlynSharedInventoryID, usableList.get(rng.nextInt(usableList.size())));
 		}
 		
-		if (classOptions.randomizeBlood || bloodOptions.giveHolyBlood) {
+		if (classOptions.playerBloodOption != BloodOptions.NO_CHANGE || bloodOptions.giveHolyBlood) {
 			// Hard code Seliph's Holy Blood, based on his parents.
 			// He only has the first two bytes, so drop the other blood (which they should be limited in already).
 			FE4StaticCharacter sigurd = charData.getStaticCharacter(FE4Data.Character.SIGURD);
@@ -849,7 +852,17 @@ public class FE4Randomizer extends Randomizer {
 					break;
 				}
 				
-				rk.addHeaderItem("Randomize Holy Blood", classOptions.randomizeBlood ? "YES" : "NO");
+				switch (classOptions.playerBloodOption) {
+				case NO_CHANGE:
+					rk.addHeaderItem("Player Blood", "No Change");
+					break;
+				case SHUFFLE:
+					rk.addHeaderItem("Player Blood", "Shuffle");
+					break;
+				case RANDOMIZE:
+					rk.addHeaderItem("Player Blood", "Randomize");
+				}
+				
 				switch (classOptions.shopOption) {
 				case DO_NOT_ADJUST:
 					rk.addHeaderItem("Shop Items", "No Change");
@@ -885,7 +898,16 @@ public class FE4Randomizer extends Randomizer {
 			
 			if (classOptions.randomizeBosses) {
 				rk.addHeaderItem("Randomize Bosses", "YES");
-				rk.addHeaderItem("Randomize Boss Holy Blood", classOptions.randomizeBossBlood ? "YES" : "NO");
+				switch (classOptions.bossBloodOption) {
+				case NO_CHANGE:
+					rk.addHeaderItem("Holy Boss Blood", "No Change");
+					break;
+				case SHUFFLE:
+					rk.addHeaderItem("Holy Boss Blood", "Shuffle");
+					break;
+				case RANDOMIZE:
+					rk.addHeaderItem("Holy Boss Blood", "Randomize");
+				}
 			} else {
 				rk.addHeaderItem("Randomize Bosses", "NO");
 			}

--- a/Universal FE Randomizer/src/ui/fe4/FE4ClassOptions.java
+++ b/Universal FE Randomizer/src/ui/fe4/FE4ClassOptions.java
@@ -20,6 +20,12 @@ public class FE4ClassOptions {
 		RANDOMIZE
 	}
 	
+	public enum BloodOptions {
+		NO_CHANGE,
+		SHUFFLE,
+		RANDOMIZE
+	}
+	
 	public final boolean randomizePlayableCharacters;
 	public final boolean includeLords;
 	public final boolean retainHealers;
@@ -28,7 +34,7 @@ public class FE4ClassOptions {
 	public final boolean includeDancers;
 	public final boolean includeJulia;
 	public final ChildOptions childOption;
-	public final boolean randomizeBlood;
+	public final BloodOptions playerBloodOption;
 	public final ShopOptions shopOption;
 	public final boolean adjustConversationWeapons;
 	public final boolean adjustSTRMAG;
@@ -39,9 +45,9 @@ public class FE4ClassOptions {
 	public final boolean randomizeArena;
 	
 	public final boolean randomizeBosses;
-	public final boolean randomizeBossBlood;
+	public final BloodOptions bossBloodOption;
 	
-	public FE4ClassOptions(boolean pcs, boolean lords, boolean healers, boolean horses, boolean thieves, boolean dancers, boolean julia, ChildOptions children, boolean blood, ShopOptions shops, boolean adjustConvoWeapons, boolean adjustSTRMAG, ItemAssignmentOptions itemOptions, boolean minions, boolean arena, boolean bosses, boolean bossBlood) {
+	public FE4ClassOptions(boolean pcs, boolean lords, boolean healers, boolean horses, boolean thieves, boolean dancers, boolean julia, ChildOptions children, BloodOptions playerBlood, ShopOptions shops, boolean adjustConvoWeapons, boolean adjustSTRMAG, ItemAssignmentOptions itemOptions, boolean minions, boolean arena, boolean bosses, BloodOptions bossBlood) {
 		super();
 		this.randomizePlayableCharacters = pcs;
 		this.includeLords = lords;
@@ -51,7 +57,7 @@ public class FE4ClassOptions {
 		this.includeDancers = dancers;
 		this.includeJulia = julia;
 		this.childOption = children;
-		this.randomizeBlood = blood;
+		this.playerBloodOption = playerBlood;
 		this.shopOption = shops;
 		this.adjustConversationWeapons = adjustConvoWeapons;
 		this.adjustSTRMAG = adjustSTRMAG;
@@ -62,6 +68,6 @@ public class FE4ClassOptions {
 		this.randomizeArena = arena;
 		
 		this.randomizeBosses = bosses;
-		this.randomizeBossBlood = bossBlood;
+		this.bossBloodOption = bossBlood;
 	}
 }


### PR DESCRIPTION
Fixed #44 

Added a Blood Shuffling option for FE4. This option is unique in that it has some prerequisites.

Requires:

* Randomize Playable Characters ON
* Randomize Bosses ON

On top of that, selecting shuffle on playable characters or bosses will automatically toggle the other setting to Shuffle as well, as this only makes sense when both are shuffling. If either one is selected otherwise, shuffle will also be deselected in the other case.