### PR TITLE
[Feature #67] Include Creature Campaign in Randomized Recruitment

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1713,6 +1713,10 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		return new HashSet<GBAFECharacter>(Character.allLinkedCharactersFor(Character.valueOf(characterID)));
 	}
 	
+	public Set<GBAFECharacter> extraCharacters() {
+		return new HashSet<GBAFECharacter>();
+	}
+	
 	public Set<GBAFECharacter> charactersExcludedFromRandomRecruitment() {
 		return new HashSet<GBAFECharacter>(Arrays.asList(Character.FA));
 	}

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2221,6 +2221,10 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		return new HashSet<GBAFECharacter>(Character.allLinkedCharactersFor(Character.valueOf(characterID)));
 	}
 	
+	public Set<GBAFECharacter> extraCharacters() {
+		return new HashSet<GBAFECharacter>();
+	}
+	
 	public Set<GBAFECharacter> charactersExcludedFromRandomRecruitment() {
 		return new HashSet<GBAFECharacter>(Arrays.asList(Character.ATHOS));
 	}

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -196,6 +196,12 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			case LYON_CH17:
 			case LYON_FINAL:
 				return LYON.ID;
+			case ISMAIRE_NPC:
+				return ISMAIRE.ID;
+			case FADO_NPC:
+				return FADO.ID;
+			case HAYDEN_NPC:
+				return HAYDEN.ID;
 			default: return characterID;
 			}
 		}
@@ -222,6 +228,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		public static Set<Character> requiresPromotion = new HashSet<Character>(Arrays.asList(EIRIKA, EPHRAIM));
 		
 		public static Set<Character> doNotBuff = new HashSet<Character>(Arrays.asList(VALTER_PROLOGUE)); // This is scripted, and Seth shouldn't die here.
+		public static Set<Character> safeCreatureCampaignCharacters = new HashSet<Character>(Arrays.asList(FADO, GLEN, HAYDEN, ISMAIRE));
 		
 		// Playable characters only.
 		public static Map<Character, Set<Integer>> charactersWithMultiplePortraits = createMultiPortraitMap();
@@ -2383,6 +2390,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 
 	public Set<GBAFECharacter> linkedCharacters(int characterID) {
 		return new HashSet<GBAFECharacter>(Character.allLinkedCharactersFor(Character.valueOf(characterID)));
+	}
+	
+	public Set<GBAFECharacter> extraCharacters() {
+		return new HashSet<GBAFECharacter>(Character.safeCreatureCampaignCharacters);
 	}
 	
 	public Set<GBAFECharacter> charactersExcludedFromRandomRecruitment() {

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
@@ -15,6 +15,7 @@ public interface GBAFECharacterProvider {
 	public Map<Integer, GBAFECharacter> counters();
 	
 	public Set<GBAFECharacter> allPlayableCharacters();
+	public Set<GBAFECharacter> extraCharacters();
 	public Set<GBAFECharacter> allBossCharacters();
 	public Set<GBAFECharacter> linkedCharacters(int characterID);
 	

--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -55,8 +55,11 @@ public class CharacterDataLoader {
 		return feCharactersFromSet(provider.allPlayableCharacters());
 	}
 	
-	public List<GBAFECharacterData> canonicalPlayableCharacters() {
+	public List<GBAFECharacterData> canonicalPlayableCharacters(boolean includeExtras) {
 		List<GBAFECharacterData> charList = new ArrayList<GBAFECharacterData>(Arrays.asList(playableCharacters()));
+		if (includeExtras) {
+			charList.addAll(Arrays.asList(feCharactersFromSet(provider.extraCharacters())));
+		}
 		return charList.stream().filter(character -> {
 			return provider.canonicalID(character.getID()) == character.getID();
 		}).collect(Collectors.toList());
@@ -177,7 +180,7 @@ public class CharacterDataLoader {
 	}
 	
 	public void recordCharacters(RecordKeeper rk, Boolean isInitial, ClassDataLoader classData, TextLoader textData) {
-		for (GBAFECharacterData character : playableCharacters()) {
+		for (GBAFECharacterData character : canonicalPlayableCharacters(true)) {
 			recordCharacter(rk, character, isInitial, classData, textData);
 		}
 		for (GBAFECharacterData boss : bossCharacters()) {

--- a/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
@@ -196,6 +196,21 @@ public class PaletteLoader {
 					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Palette size: " + Integer.toString(palette.getOriginalCompressedLength()) + " bytes");
 				}
 			}
+			for (FE8Data.Character character : FE8Data.Character.safeCreatureCampaignCharacters) {
+				int charID = FE8Data.Character.canonicalIDForCharacterID(character.ID);
+				Map<Integer, PaletteV2> referenceMap = new HashMap<Integer, PaletteV2>();
+				referencePalettesV2.put(charID, referenceMap);
+				for (PaletteInfo paletteInfo : FE8Data.Palette.palettesForCharacter(charID)) {
+					int classID = paletteInfo.getClassID();
+					PaletteV2 palette = new PaletteV2(handler, paletteInfo);
+					paletteByPaletteIDV2.put(paletteInfo.getPaletteID(), palette);
+					referenceMap.put(classID, new PaletteV2(handler, paletteInfo));
+					FE8Data.CharacterClass fe8class = FE8Data.CharacterClass.valueOf(classID);
+					FE8Data.Character fe8char = FE8Data.Character.valueOf(charID);
+					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Initializing Character 0x" + Integer.toHexString(charID) + " (" + fe8char.toString() + ")" + " with palette at offset 0x" + Long.toHexString(paletteInfo.getOffset()) + " (Class: " + Integer.toHexString(classID) + " (" + fe8class.toString() + "))");
+					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Palette size: " + Integer.toString(palette.getOriginalCompressedLength()) + " bytes");
+				}
+			}
 			for (FE8Data.Character boss : FE8Data.Character.allBossCharacters) {
 				int charID = FE8Data.Character.canonicalIDForCharacterID(boss.ID);
 				Map<Integer, PaletteV2> referenceMap = new HashMap<Integer, PaletteV2>();

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -513,7 +513,7 @@ public class GBARandomizer extends Randomizer {
 	private void makeFinalAdjustments(String seed) {
 		// Fix the palettes based on final classes.
 		if (needsPaletteFix) {
-			PaletteHelper.synchronizePalettes(gameType, charData, classData, paletteData, characterMap, freeSpace);
+			PaletteHelper.synchronizePalettes(gameType, recruitOptions != null ? recruitOptions.includeExtras : false, charData, classData, paletteData, characterMap, freeSpace);
 		}
 		
 		// Hack in mode select without needing clear data for FE7.

--- a/Universal FE Randomizer/src/random/gba/randomizer/PaletteHelper.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/PaletteHelper.java
@@ -19,8 +19,8 @@ import util.WhyDoesJavaNotHaveThese;
 
 public class PaletteHelper {
 	
-	public static void synchronizePalettes(GameType type, CharacterDataLoader charData, ClassDataLoader classData, PaletteLoader paletteData, Map<GBAFECharacterData, GBAFECharacterData> slotToReference, FreeSpaceManager freeSpace) {
-		for (GBAFECharacterData playableCharacter : charData.canonicalPlayableCharacters()) {
+	public static void synchronizePalettes(GameType type, boolean includeExtras, CharacterDataLoader charData, ClassDataLoader classData, PaletteLoader paletteData, Map<GBAFECharacterData, GBAFECharacterData> slotToReference, FreeSpaceManager freeSpace) {
+		for (GBAFECharacterData playableCharacter : charData.canonicalPlayableCharacters(includeExtras)) {
 			int characterID = playableCharacter.getID();
 			int classID = playableCharacter.getClassID();
 			

--- a/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
@@ -43,7 +43,7 @@ public class RecruitmentRandomizer {
 			Random rng) {
 		
 		// Figure out mapping first.
-		List<GBAFECharacterData> characterPool = new ArrayList<GBAFECharacterData>(characterData.canonicalPlayableCharacters());
+		List<GBAFECharacterData> characterPool = new ArrayList<GBAFECharacterData>(characterData.canonicalPlayableCharacters(options.includeExtras));
 		characterPool.removeIf(character -> (characterData.charactersExcludedFromRandomRecruitment().contains(character)));
 		
 		Map<Integer, GBAFECharacterData> referenceData = characterPool.stream().map(character -> {

--- a/Universal FE Randomizer/src/ui/MainView.java
+++ b/Universal FE Randomizer/src/ui/MainView.java
@@ -525,7 +525,7 @@ public class MainView implements FileFlowDelegate {
 			enemyData.right = new FormAttachment(classView, 0, SWT.RIGHT);
 			enemyView.setLayoutData(enemyData);
 			
-			recruitView = new RecruitmentView(container, SWT.NONE);
+			recruitView = new RecruitmentView(container, SWT.NONE, type);
 			recruitView.setSize(200, 200);
 			recruitView.setVisible(false);
 			

--- a/Universal FE Randomizer/src/ui/RecruitmentView.java
+++ b/Universal FE Randomizer/src/ui/RecruitmentView.java
@@ -11,6 +11,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Listener;
 
+import fedata.general.FEBase.GameType;
 import ui.model.RecruitmentOptions;
 import ui.model.RecruitmentOptions.BaseStatAutolevelType;
 import ui.model.RecruitmentOptions.GrowthAdjustmentMode;
@@ -36,8 +37,9 @@ public class RecruitmentView extends Composite {
 	private Button relativeButton;
 	
 	private Button crossGenderButton;
+	private Button includeExtras;
 	
-	public RecruitmentView(Composite parent, int style) {
+	public RecruitmentView(Composite parent, int style, GameType type) {
 		super(parent, style);
 		
 		FillLayout layout = new FillLayout();
@@ -75,6 +77,10 @@ public class RecruitmentView extends Composite {
 				autolevelTypeContainer.setEnabled(enableButton.getSelection() && autolevelButton.getSelection());
 				autolevelOriginalButton.setEnabled(enableButton.getSelection() && autolevelButton.getSelection());
 				autolevelNewButton.setEnabled(enableButton.getSelection() && autolevelButton.getSelection());
+				
+				if (includeExtras != null) {
+					includeExtras.setEnabled(enableButton.getSelection());
+				}
 			}
 		});
 		
@@ -230,6 +236,20 @@ public class RecruitmentView extends Composite {
 		optionData.left = new FormAttachment(basesContainer, 0, SWT.LEFT);
 		optionData.top = new FormAttachment(basesContainer, 10);
 		crossGenderButton.setLayoutData(optionData);
+		
+		if (type == GameType.FE8) {
+			// Option to include Creature Campaign
+			includeExtras = new Button(container, SWT.CHECK);
+			includeExtras.setText("Include Creature Campaign NPCs");
+			includeExtras.setToolTipText("Includes NPCs from the creature campaign into the pool.\nSpecifically: Glen, Fado, Hayden, and Ismaire.");
+			includeExtras.setEnabled(false);
+			includeExtras.setSelection(false);
+			
+			optionData = new FormData();
+			optionData.left = new FormAttachment(crossGenderButton, 0, SWT.LEFT);
+			optionData.top = new FormAttachment(crossGenderButton, 5);
+			includeExtras.setLayoutData(optionData);
+		}
 	}
 	
 	public RecruitmentOptions getRecruitmentOptions() {
@@ -249,8 +269,10 @@ public class RecruitmentView extends Composite {
 		else if (slotGrowthButton.getSelection()) { growthMode = GrowthAdjustmentMode.USE_SLOT; }
 		else if (slotRelativeGrowthButton.getSelection()) { growthMode = GrowthAdjustmentMode.RELATIVE_TO_SLOT; }
 		
+		boolean extras = includeExtras != null ? includeExtras.getSelection() : false;
+		
 		if (isEnabled && basesMode != null && growthMode != null) {
-			return new RecruitmentOptions(growthMode, basesMode, autolevel, crossGenderButton.getSelection());
+			return new RecruitmentOptions(growthMode, basesMode, autolevel, crossGenderButton.getSelection(), extras);
 		} else {
 			return null;
 		}
@@ -276,6 +298,9 @@ public class RecruitmentView extends Composite {
 			relativeButton.setEnabled(false);
 			
 			crossGenderButton.setEnabled(false);
+			if (includeExtras != null) {
+				includeExtras.setEnabled(false);
+			}
 		} else {
 			enableButton.setSelection(true);
 			
@@ -307,6 +332,11 @@ public class RecruitmentView extends Composite {
 			autolevelNewButton.setEnabled(autolevelButton.getSelection());
 			
 			crossGenderButton.setSelection(options.allowCrossGender);
+			
+			if (includeExtras != null) {
+				includeExtras.setEnabled(true);
+				includeExtras.setSelection(options.includeExtras);
+			}
 		}
 	}
 }

--- a/Universal FE Randomizer/src/ui/model/RecruitmentOptions.java
+++ b/Universal FE Randomizer/src/ui/model/RecruitmentOptions.java
@@ -17,12 +17,15 @@ public class RecruitmentOptions {
 	
 	public final boolean allowCrossGender;
 	
-	public RecruitmentOptions(GrowthAdjustmentMode growthMode, StatAdjustmentMode baseMode, BaseStatAutolevelType autolevel, boolean crossGender) {
+	public final boolean includeExtras;
+	
+	public RecruitmentOptions(GrowthAdjustmentMode growthMode, StatAdjustmentMode baseMode, BaseStatAutolevelType autolevel, boolean crossGender, boolean includeExtras) {
 		super();
 		this.growthMode = growthMode;
 		this.baseMode = baseMode;
 		this.autolevelMode = autolevel;
 		
 		this.allowCrossGender = crossGender;
+		this.includeExtras = includeExtras;
 	}
 }


### PR DESCRIPTION
Fixed #67 - Added the option to include creature campaign NPCs (Fado, Glen, Hayden, and Ismaire) to the pool for random recruitment.