### PR TITLE
[Issue #96] Fixed Match Rank option for Weapon Assignment

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -2061,20 +2061,32 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			break;
 		case MAGE:
 		case MAGE_F:
+			usableItems.addAll(Item.allAnima);
+			break;
 		case VALKYRIE:
 		case SAGE:
 		case SAGE_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allAnima);
 			break;
 		case SHAMAN:
 		case SHAMAN_F:
+			usableItems.addAll(Item.allDark);
+			break;
 		case DRUID:
 		case DRUID_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allDark);
 			break;
 		case BISHOP:
 		case BISHOP_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allLight);
+			break;
+		case PRIEST:
+		case TROUBADOUR:
+		case CLERIC:
+			usableItems.addAll(Item.allStaves);
 			break;
 		case CAVALIER:
 		case CAVALIER_F:
@@ -2183,6 +2195,11 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			if (itemsUsableByClass.isEmpty() && !usableByRank.isEmpty()) {
 				itemsUsableByClass = usableByRank;
 			}
+		} else {
+			// Try to match the rank.
+			Set<GBAFEItem> matchRank = new HashSet<GBAFEItem>(itemsUsableByClass);
+			matchRank.removeIf(weapon -> (weapon.getRank() != item.getRank()));
+			if (!matchRank.isEmpty()) { return matchRank; }
 		}
 		
 		return itemsUsableByClass;

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2571,22 +2571,35 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			break;
 		case MAGE:
 		case MAGE_F:
+			usableItems.addAll(Item.allAnima);
+			break;
 		case SAGE:
 		case SAGE_F:
 		case VALKYRIE:
 		case UBER_SAGE:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allAnima);
 			break;
 		case SHAMAN:
 		case SHAMAN_F:
+			usableItems.addAll(Item.allDark);
+			break;
 		case DRUID:
 		case DRUID_F:
 			usableItems.addAll(Item.allDark);
+			usableItems.addAll(Item.allStaves);
 			break;
 		case MONK:
+			usableItems.addAll(Item.allLight);
+			break;
 		case BISHOP:
 		case BISHOP_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allLight);
+			break;
+		case CLERIC:
+		case TROUBADOUR:
+			usableItems.addAll(Item.allStaves);
 			break;
 		case LORD_KNIGHT:
 		case CAVALIER:
@@ -2697,6 +2710,11 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			if (itemsUsableByClass.isEmpty() && !usableByRank.isEmpty()) {
 				itemsUsableByClass = usableByRank;
 			}
+		} else {
+			// Try to match the rank.
+			Set<GBAFEItem> matchRank = new HashSet<GBAFEItem>(itemsUsableByClass);
+			matchRank.removeIf(weapon -> (weapon.getRank() != item.getRank()));
+			if (!matchRank.isEmpty()) { return matchRank; }
 		}
 		
 		return itemsUsableByClass;

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2760,12 +2760,21 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		case PUPIL_2:
 		case MAGE:
 		case MAGE_F:
+			usableItems.addAll(Item.allAnima);
+			break;
+		case PRIEST:
+		case CLERIC:
+		case TROUBADOUR:
+			usableItems.addAll(Item.allStaves);
+			break;
 		case MAGE_KNIGHT:
 		case MAGE_KNIGHT_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allAnima);
 			break;
 		case SAGE:
 		case SAGE_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allAnima);
 			usableItems.addAll(Item.allLight);
 			break;
@@ -2776,20 +2785,26 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			break;
 		case SHAMAN:
 		case SHAMAN_F:
+			usableItems.addAll(Item.allDark);
 		case SUMMONER:
 		case SUMMONER_F:
 		case NECROMANCER:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allDark);
 			break;
 		case DRUID:
 		case DRUID_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allDark);
 			usableItems.addAll(Item.allAnima);
 			break;
 		case MONK:
+			usableItems.addAll(Item.allLight);
+			break;
 		case VALKYRIE:
 		case BISHOP:
 		case BISHOP_F:
+			usableItems.addAll(Item.allStaves);
 			usableItems.addAll(Item.allLight);
 			break;
 		case CAVALIER:
@@ -2886,7 +2901,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		Set<GBAFEItem> usableSet = new HashSet<GBAFEItem>(itemsUsableByClass);
 		
 		final WeaponRank effectiveRank = rank;
-		itemsUsableByClass.removeIf(weapon -> (effectiveRank.isLowerThan(weapon.getRank())));
+		itemsUsableByClass.removeIf(weapon -> (effectiveRank.isLowerThan(weapon.getRank()))); // Remove anything that's higher the weapon passed in.
 		
 		if (strict) {
 			Set<GBAFEItem> usableByRank = new HashSet<GBAFEItem>(itemsUsableByClass);
@@ -2923,6 +2938,11 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			if (itemsUsableByClass.isEmpty() && !usableByRank.isEmpty()) {
 				itemsUsableByClass = usableByRank;
 			}
+		} else {
+			// Try to match the rank.
+			Set<GBAFEItem> matchRank = new HashSet<GBAFEItem>(itemsUsableByClass);
+			matchRank.removeIf(weapon -> (weapon.getRank() != effectiveRank));
+			if (!matchRank.isEmpty()) { return matchRank; }
 		}
 		
 		return itemsUsableByClass;

--- a/Universal FE Randomizer/src/fedata/gba/general/WeaponRank.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/WeaponRank.java
@@ -57,4 +57,13 @@ public enum WeaponRank {
 			return false;
 		}
 	}
+	
+	public String displayString() {
+		switch (this) {
+		case NONE:
+			return "-";
+		default:
+			return this.toString();
+		}
+	}
 }

--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -176,16 +176,16 @@ public class CharacterDataLoader {
 		return characterList;
 	}
 	
-	public void recordCharacters(RecordKeeper rk, Boolean isInitial, ClassDataLoader classData, TextLoader textData) {
+	public void recordCharacters(RecordKeeper rk, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData) {
 		for (GBAFECharacterData character : playableCharacters()) {
-			recordCharacter(rk, character, isInitial, classData, textData);
+			recordCharacter(rk, character, isInitial, classData, itemData, textData);
 		}
 		for (GBAFECharacterData boss : bossCharacters()) {
-			recordCharacter(rk, boss, isInitial, classData, textData);
+			recordCharacter(rk, boss, isInitial, classData, itemData, textData);
 		}
 	}
 	
-	private void recordCharacter(RecordKeeper rk, GBAFECharacterData character, Boolean isInitial, ClassDataLoader classData, TextLoader textData) {
+	private void recordCharacter(RecordKeeper rk, GBAFECharacterData character, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData) {
 		int nameIndex = character.getNameIndex();
 		int classID = character.getClassID();
 		GBAFEClassData charClass = classData.classForID(classID);
@@ -219,6 +219,15 @@ public class CharacterDataLoader {
 			
 			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base CON", Integer.toString(character.getConstitution() + charClass.getCON()));
 			
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Sword Rank", itemData.rankForValue(character.getSwordRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Lance Rank", itemData.rankForValue(character.getLanceRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Axe Rank", itemData.rankForValue(character.getAxeRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Bow Rank", itemData.rankForValue(character.getBowRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Anima Rank", itemData.rankForValue(character.getAnimaRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Light Rank", itemData.rankForValue(character.getLightRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Dark Rank", itemData.rankForValue(character.getDarkRank()).displayString());
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Staff Rank", itemData.rankForValue(character.getStaffRank()).displayString());
+			
 			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Affinity", character.getAffinityName() + " (0x" + Integer.toHexString(character.getAffinityValue()).toUpperCase() + ")");
 		} else {
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Name", name);
@@ -241,6 +250,15 @@ public class CharacterDataLoader {
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base RES", Integer.toString(character.getBaseRES() + charClass.getBaseRES()));
 			
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base CON", Integer.toString(character.getConstitution() + charClass.getCON()));
+			
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Sword Rank", itemData.rankForValue(character.getSwordRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Lance Rank", itemData.rankForValue(character.getLanceRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Axe Rank", itemData.rankForValue(character.getAxeRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Bow Rank", itemData.rankForValue(character.getBowRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Anima Rank", itemData.rankForValue(character.getAnimaRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Light Rank", itemData.rankForValue(character.getLightRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Dark Rank", itemData.rankForValue(character.getDarkRank()).displayString());
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Staff Rank", itemData.rankForValue(character.getStaffRank()).displayString());
 			
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Affinity", character.getAffinityName() + " (0x" + Integer.toHexString(character.getAffinityValue()).toUpperCase() + ")");
 		}

--- a/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import fedata.gba.GBAFECharacterData;
 import fedata.gba.GBAFEClassData;
@@ -176,6 +177,18 @@ public class ItemDataLoader {
 		return provider.getHighestWeaponRankValue();
 	}
 	
+	public WeaponRank rankForValue(int value) {
+		return provider.rankWithValue(value);
+	}
+	
+	public WeaponRanks ranksForCharacter(GBAFECharacterData character) {
+		return new WeaponRanks(character, provider);
+	}
+	
+	public WeaponRanks ranksForClass(GBAFEClassData charClass) {
+		return new WeaponRanks(charClass, provider);
+	}
+	
 	public GBAFEItemData[] getAllWeapons() {
 		return feItemsFromItemSet(provider.allWeapons());
 	}
@@ -339,9 +352,8 @@ public class ItemDataLoader {
 			}
 		}
 		
-		GBAFEItem[] itemsArray = potentialItems.toArray(new GBAFEItem[potentialItems.size()]);
-		int index = rng.nextInt(potentialItems.size());
-		return itemMap.get(itemsArray[index].getID());
+		List<GBAFEItem> itemList = potentialItems.stream().sorted(GBAFEItem.defaultComparator()).collect(Collectors.toList());
+		return itemMap.get(itemList.get(rng.nextInt(itemList.size())).getID());
 	}
 	
 	public GBAFEItemData getSidegradeWeapon(GBAFECharacterData character, GBAFEItemData originalWeapon, boolean strict, Random rng) {
@@ -358,9 +370,8 @@ public class ItemDataLoader {
 			}
 		}
 		
-		GBAFEItem[] itemsArray = potentialItems.toArray(new GBAFEItem[potentialItems.size()]);
-		int index = rng.nextInt(potentialItems.size());
-		return itemMap.get(itemsArray[index].getID());
+		List<GBAFEItem> itemList = potentialItems.stream().sorted(GBAFEItem.defaultComparator()).collect(Collectors.toList());
+		return itemMap.get(itemList.get(rng.nextInt(itemList.size())).getID());
 	}
 	
 	public GBAFEItemData getRandomWeaponForCharacter(GBAFECharacterData character, Boolean ranged, Boolean melee, Random rng) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -647,6 +647,20 @@ public class ClassRandomizer {
 		Boolean applyDarkRank = targetClass.getDarkRank() > 0;
 		Boolean applyStaffRank = targetClass.getStaffRank() > 0;
 		
+		int weaponUsageCount = 0;
+		if (applySwordRank) { weaponUsageCount++; }
+		if (applyLanceRank) { weaponUsageCount++; }
+		if (applyAxeRank) { weaponUsageCount++; }
+		if (applyBowRank) { weaponUsageCount++; }
+		if (applyAnimaRank) { weaponUsageCount++; }
+		if (applyLightRank) { weaponUsageCount++; }
+		if (applyDarkRank) { weaponUsageCount++; }
+		if (applyStaffRank) { weaponUsageCount++; }
+		
+		while (ranks.size() > weaponUsageCount) {
+			ranks.remove(0); // Remove the lowest rank if we have more ranks to work with than slots to fill
+		}
+		
 		int[] targetRanks = new int[] { 0, 0, 0, 0, 0, 0, 0, 0 };
 		
 		if (applySwordRank) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -245,7 +245,7 @@ public class GBARandomizer extends Randomizer {
 			return;
 		}
 		
-		charData.recordCharacters(recordKeeper, false, classData, textData);
+		charData.recordCharacters(recordKeeper, false, classData, itemData, textData);
 		classData.recordClasses(recordKeeper, false, classData, textData);
 		itemData.recordWeapons(recordKeeper, false, classData, textData, targetFileHandler);
 		chapterData.recordChapters(recordKeeper, false, charData, classData, itemData, textData);
@@ -905,7 +905,7 @@ public class GBARandomizer extends Randomizer {
 			}
 		}
 		
-		charData.recordCharacters(rk, true, classData, textData);
+		charData.recordCharacters(rk, true, classData, itemData, textData);
 		classData.recordClasses(rk, true, classData, textData);
 		itemData.recordWeapons(rk, true, classData, textData, handler);
 		chapterData.recordChapters(rk, true, charData, classData, itemData, textData);

--- a/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
@@ -2,6 +2,7 @@ package random.gba.randomizer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -709,6 +710,21 @@ public class RecruitmentRandomizer {
 			target.setStaffRank(targetClass.getStaffRank());
 			
 			return;
+		}
+		
+		int targetWeaponUsage = 0;
+		if (targetClass.getSwordRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getLanceRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getAxeRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getBowRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getLightRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getDarkRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getAnimaRank() > 0) { targetWeaponUsage++; }
+		if (targetClass.getStaffRank() > 0) { targetWeaponUsage++; }
+		
+		Collections.sort(rankValues);
+		while (rankValues.size() > targetWeaponUsage) {
+			rankValues.remove(0); // Remove the lowest rank if we're filling less weapons than we have to work with.
 		}
 		
 		if (targetClass.getSwordRank() > 0) {


### PR DESCRIPTION
Fixed #96 

* Fixed an issue where the option to match rank was allowing lower ranked weapons. This logic has been updated to prioritize items that match rank and only fall back to lower ranks if the item is not available.

Additionally:

* Fixed an issue where later joining characters could join with lower weapon ranks than expected if they transfer more weapon ranks than necessary for their target class.
* Fixed an issue where some unwanted randomization in weapon rank assignment could occur when using the same seed.
* Added logic to show weapon rank assignments for characters in the changelog.