### PR TITLE
[Feature #78] Knight Lord Map Sprite

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -113,6 +113,12 @@ public class FE4Data {
 	public static final byte FemaleEmperorStaffAnimationFixOldValue = 0x00;
 	public static final byte FemaleEmperorStaffAnimationFixNewValue = 0x01;
 	
+	// Lord Knight's map sprite is special for Sigurd, but it doesn't need to be.
+	// We can use enable Lord Knight's map sprite to be used for more than just Sigurd.
+	public static final long KnightLordMapSpriteFixOffset = 0x3830CL;
+	public static final byte KnightLordMapSpriteFixOldValue = 0x01;
+	public static final byte KnightLordMapSpriteFixNewValue = 0x00;
+	
 	// Aura shenanigans.
 	// 0x34 is a Steel Lance freely available in Ch. 8 that we can use
 	// This allows us to swap it for Deirdre's Aura, which can side-step the duplicate item issue in gen 2.

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -277,6 +277,9 @@ public class FE4Randomizer extends Randomizer {
 			// Diff to remove 0x34 from the Ch. 8 shop, since we're using it for Deirdre's Aura.
 			diffCompiler.addDiff(new Diff(FE4Data.Chapter8ShopListOffset, FE4Data.Chapter8ShopOldListByteArray.length, FE4Data.Chapter8ShopNewListByteArray, FE4Data.Chapter8ShopOldListByteArray));
 			
+			// Diff to enable Lord Knight's map sprite for more than just Sigurd.
+			diffCompiler.addDiff(new Diff(FE4Data.KnightLordMapSpriteFixOffset, 1, new byte[] {FE4Data.KnightLordMapSpriteFixNewValue}, new byte[] {FE4Data.KnightLordMapSpriteFixOldValue}));
+			
 		} else {
 			// Diffs for allowing Sigurd/Seliph to sieze, regardless of their class.
 			diffCompiler.addDiff(new Diff(0x5E43CL, 4, new byte[] {(byte)0x22, (byte)0x33, (byte)0xA3, (byte)0x84}, new byte[] {(byte)0x22, (byte)0x2D, (byte)0xA0, (byte)0x84}));
@@ -317,6 +320,9 @@ public class FE4Randomizer extends Randomizer {
 			
 			// Diff to remove 0x34 from the Ch. 8 shop, since we're using it for Deirdre's Aura.
 			diffCompiler.addDiff(new Diff(FE4Data.Chapter8ShopListOffset - 0x200, FE4Data.Chapter8ShopOldListByteArray.length, FE4Data.Chapter8ShopNewListByteArray, FE4Data.Chapter8ShopOldListByteArray));
+			
+			// Diff to enable Lord Knight's map sprite for more than just Sigurd.
+			diffCompiler.addDiff(new Diff(FE4Data.KnightLordMapSpriteFixOffset - 0x200, 1, new byte[] {FE4Data.KnightLordMapSpriteFixNewValue}, new byte[] {FE4Data.KnightLordMapSpriteFixOldValue}));
 		}
 	}
 


### PR DESCRIPTION
Fixed #78 - Added a fix for Knight Lord's map sprite to not be unique to Sigurd.