### PR TITLE
[Feature #88] Class Randomization - CON now fits the target class instead of being transferred from the old class

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -300,8 +300,11 @@ public class ClassRandomizer {
 		int resDelta = sourceClass.getBaseRES() - targetClass.getBaseRES();
 		character.setBaseRES(character.getBaseRES() + resDelta);
 		
-		int conDelta = sourceClass.getCON() - targetClass.getCON();
-		character.setConstitution(character.getConstitution() + conDelta);
+		// Only correct CON if it ends up being an invalid (i.e. negative) CON.
+		// This is only really possible if the character had a negative CON adjustment to begin with.
+		if (character.getConstitution() < 0 && Math.abs(character.getConstitution()) > targetClass.getCON()) {
+			character.setConstitution(-1 * targetClass.getCON());
+		}
 	}
 	
 	// TODO: Offer an option for sidegrade strictness?


### PR DESCRIPTION
Fixed #88 - Modified class randomization so that absolute CON is not transferred into the new class.

Old Behavior:

Sophia|Shaman|->|Axe Fighter
-|-|-|-
Personal CON|0||-8
Class CON|3||11
Effective CON|3|=|3

Barth|Knight|->|Pegasus Knight
-|-|-|-
Personal CON|3||11
Class CON|13||5
Effective CON|16|=|16

New Behavior:

Sophia|Shaman|->|Axe Fighter
-|-|-|-
Personal CON|0|=|0
Class CON|3||11
Effective CON|3||11


Barth|Knight|->|Pegasus Knight
-|-|-|-
Personal CON|3|=|3
Class CON|13||5
Effective CON|16||8