### PR TITLE
[Issue #113] Added link between Lex and Schmidt with the Brave Axe.

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -351,7 +351,7 @@ public class FE4Data {
 		/*map.put(Character.SIGURD, 0x27); // Tyrfing*/
 		map.put(Character.FINN_GEN_1, new ArrayList<Integer>(Arrays.asList(0x3B))); // Brave Lance
 		/*map.put(Character.QUAN, 0x3E); // Gae Bolg*/
-		map.put(Character.LEX, new ArrayList<Integer>(Arrays.asList(0x45))); // Brave Axe
+		map.put(Character.LEX, new ArrayList<Integer>(Arrays.asList(0x45))); // Brave Axe (Needs to work with Schmidt (boss) too...)
 		map.put(Character.MIDIR, new ArrayList<Integer>(Arrays.asList(0x4D))); // Brave Bow (Technically needs to work for Jamke too...)
 		/*map.put(Character.BRIGID, 0x4F); // Yewfelle*/
 		/*map.put(Character.LEWYN, 0x5C); // Forseti*/
@@ -376,6 +376,9 @@ public class FE4Data {
 		
 		map.put(Character.MIDIR, Character.JAMKE);
 		map.put(Character.JAMKE, Character.MIDIR);
+		
+		map.put(Character.LEX, Character.SCHMIDT);
+		map.put(Character.SCHMIDT, Character.LEX);
 		
 		return map;
 	}


### PR DESCRIPTION
Fixed #113 - It's possible for Lex to pick up a holy weapon from his lone event with the Brave Axe. This axe normally ends up on Schmidt if it's not passed down, which causes Schmidt to have a holy weapon in Chapter 6 and potentially have a weapon he shouldn't be able to use. This change links Lex and Schmidt's class to make sure they share weapon types, but it also blacklists holy weapons from Lex's events.