### PR TITLE
[Feature #114] Let Dew and Edain consistently escape Marpha

### DIFF
--- a/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
+++ b/Universal FE Randomizer/src/fedata/snes/fe4/FE4Data.java
@@ -1040,14 +1040,8 @@ public class FE4Data {
 		
 		// These enemies are probably part of the Ch. 5 scene, which will not work properly if they're not mages because it tries to play a fire mage animation from the map.
 		public static final Set<Character> DoNotTouchEnemies = new HashSet<Character>(Arrays.asList(
-				CH5_COMMANDER_1,
-				CH5_ROT_RITTER_1, 
-				CH5_COMMANDER_2,
-				CH5_ROT_RITTER_2,
-				CH5_COMMANDER_3,
-				CH5_ROT_RITTER_3,
-				CH5_COMMANDER_4,
-				CH5_ROT_RITTER_4
+				CH1_VERDANE_COMMANDER_1, CH1_VERDANE_ARMY_5, // Dew and Edain need to outrun these guys in Chapter 1.
+				CH5_COMMANDER_1, CH5_ROT_RITTER_1, CH5_COMMANDER_2, CH5_ROT_RITTER_2, CH5_COMMANDER_3, CH5_ROT_RITTER_3, CH5_COMMANDER_4, CH5_ROT_RITTER_4 // Chapter 5 epilogue scene
 				));
 		
 		// Midir will make the game confused if he can't attack in his opening scene.


### PR DESCRIPTION
Fixed #114 - Added Chapter 1 Marpha pursuit squad to the do-not-touch list for minions, to allow Dew and Edain to escape.