### PR TITLE
[Issue #118] Fixed issues with minion inventory being empty/invalid

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2849,6 +2849,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		case SHAMAN:
 		case SHAMAN_F:
 			usableItems.addAll(Item.allDark);
+			break;
 		case SUMMONER:
 		case SUMMONER_F:
 		case NECROMANCER:

--- a/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
@@ -347,7 +347,7 @@ public class ItemDataLoader {
 	}
 	
 	public GBAFEItemData getSidegradeWeapon(GBAFEClassData targetClass, GBAFEItemData originalWeapon, boolean strict, Random rng) {
-		if (!isWeapon(originalWeapon)) {
+		if (!isWeapon(originalWeapon) && originalWeapon.getType() != WeaponType.STAFF) {
 			return null;
 		}
 		
@@ -365,7 +365,7 @@ public class ItemDataLoader {
 	}
 	
 	public GBAFEItemData getSidegradeWeapon(GBAFECharacterData character, GBAFEItemData originalWeapon, boolean strict, Random rng) {
-		if (!isWeapon(originalWeapon)) {
+		if (!isWeapon(originalWeapon) && originalWeapon.getType() != WeaponType.STAFF) {
 			return null;
 		}
 		


### PR DESCRIPTION
Fixed #118 

* Fixed an issue where staves were not being considered valid items for sidegrading.
* Fixed an issue where FE8 Shamans were mistakenly including staves in their list of weapons.