### PR TITLE
[Issue #133] Fixed conflicts with character growths and blood bonuses

### DIFF
--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4BloodRandomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4BloodRandomizer.java
@@ -25,9 +25,11 @@ public class FE4BloodRandomizer {
 	
 	static final int rngSalt = 12321;
 	
-	public static void randomizeHolyBloodGrowthBonuses(HolyBloodOptions options, HolyBloodLoader bloodData, Random rng) {
+	public static void randomizeHolyBloodGrowthBonuses(HolyBloodOptions options, HolyBloodLoader bloodData, CharacterDataLoader charData, Random rng) {
 		List<FE4HolyBlood> bloodList = bloodData.allHolyBlood();
 		Set<Integer> generatedHashes = new HashSet<Integer>();
+		
+		transferBloodToGrowths(charData, bloodData);
 		
 		for (FE4HolyBlood blood : bloodList) {
 			int growthRemaining = options.growthTotal;
@@ -132,6 +134,84 @@ public class FE4BloodRandomizer {
 			blood.setDEFGrowthBonus(defBonus);
 			blood.setRESGrowthBonus(resBonus);
 		}
+		
+		transferGrowthsToBlood(charData, bloodData);
+	}
+	
+	private static void transferBloodToGrowths(CharacterDataLoader charData, HolyBloodLoader bloodData) {
+		for (FE4StaticCharacter staticGen1 : charData.getGen1Characters()) {
+			bloodGrowthsTransfer(staticGen1, bloodData, false);
+		}
+		for (FE4StaticCharacter staticGen2 : charData.getGen2CommonCharacters()) {
+			bloodGrowthsTransfer(staticGen2, bloodData, false);
+		}
+		for (FE4StaticCharacter subChar : charData.getGen2SubstituteCharacters()) {
+			bloodGrowthsTransfer(subChar, bloodData, false);
+		}
+		// Holy bosses are also static characters, but their growths don't really matter...
+	}
+	
+	private static void transferGrowthsToBlood(CharacterDataLoader charData, HolyBloodLoader bloodData) {
+		for (FE4StaticCharacter staticGen1 : charData.getGen1Characters()) {
+			bloodGrowthsTransfer(staticGen1, bloodData, true);
+		}
+		for (FE4StaticCharacter staticGen2 : charData.getGen2CommonCharacters()) {
+			bloodGrowthsTransfer(staticGen2, bloodData, true);
+		}
+		for (FE4StaticCharacter subChar : charData.getGen2SubstituteCharacters()) {
+			bloodGrowthsTransfer(subChar, bloodData, true);
+		}
+	}
+	
+	private static void bloodGrowthsTransfer(FE4StaticCharacter staticChar, HolyBloodLoader bloodData, boolean subtract) {
+		List<FE4Data.HolyBloodSlot1> slot1Blood = FE4Data.HolyBloodSlot1.slot1HolyBlood(staticChar.getHolyBlood1Value());
+		List<FE4Data.HolyBloodSlot2> slot2Blood = FE4Data.HolyBloodSlot2.slot2HolyBlood(staticChar.getHolyBlood2Value());
+		List<FE4Data.HolyBloodSlot3> slot3Blood = FE4Data.HolyBloodSlot3.slot3HolyBlood(staticChar.getHolyBlood3Value());
+		
+		slot1Blood.stream().forEach(fe4Blood -> {
+			int multiplier = fe4Blood.isMajor() ? 2 : 1;
+			if (subtract) { multiplier *= -1; }
+			
+			FE4HolyBlood blood = bloodData.holyBloodByType(fe4Blood.bloodType());
+			staticChar.setHPGrowth(Math.max(0, staticChar.getHPGrowth() + blood.getHPGrowthBonus() * multiplier));
+			staticChar.setSTRGrowth(Math.max(0, staticChar.getSTRGrowth() + blood.getSTRGrowthBonus() * multiplier));
+			staticChar.setMAGGrowth(Math.max(0, staticChar.getMAGGrowth() + blood.getMAGGrowthBonus() * multiplier));
+			staticChar.setSKLGrowth(Math.max(0, staticChar.getSKLGrowth() + blood.getSKLGrowthBonus() * multiplier));
+			staticChar.setSPDGrowth(Math.max(0, staticChar.getSPDGrowth() + blood.getSPDGrowthBonus() * multiplier));
+			staticChar.setDEFGrowth(Math.max(0, staticChar.getDEFGrowth() + blood.getDEFGrowthBonus() * multiplier));
+			staticChar.setRESGrowth(Math.max(0, staticChar.getRESGrowth() + blood.getRESGrowthBonus() * multiplier));
+			staticChar.setLCKGrowth(Math.max(0, staticChar.getLCKGrowth() + blood.getLCKGrowthBonus() * multiplier));
+		});
+		
+		slot2Blood.stream().forEach(fe4Blood -> {
+			int multiplier = fe4Blood.isMajor() ? 2 : 1;
+			if (subtract) { multiplier *= -1; }
+			
+			FE4HolyBlood blood = bloodData.holyBloodByType(fe4Blood.bloodType());
+			staticChar.setHPGrowth(Math.max(0, staticChar.getHPGrowth() + blood.getHPGrowthBonus() * multiplier));
+			staticChar.setSTRGrowth(Math.max(0, staticChar.getSTRGrowth() + blood.getSTRGrowthBonus() * multiplier));
+			staticChar.setMAGGrowth(Math.max(0, staticChar.getMAGGrowth() + blood.getMAGGrowthBonus() * multiplier));
+			staticChar.setSKLGrowth(Math.max(0, staticChar.getSKLGrowth() + blood.getSKLGrowthBonus() * multiplier));
+			staticChar.setSPDGrowth(Math.max(0, staticChar.getSPDGrowth() + blood.getSPDGrowthBonus() * multiplier));
+			staticChar.setDEFGrowth(Math.max(0, staticChar.getDEFGrowth() + blood.getDEFGrowthBonus() * multiplier));
+			staticChar.setRESGrowth(Math.max(0, staticChar.getRESGrowth() + blood.getRESGrowthBonus() * multiplier));
+			staticChar.setLCKGrowth(Math.max(0, staticChar.getLCKGrowth() + blood.getLCKGrowthBonus() * multiplier));
+		});
+		
+		slot3Blood.stream().forEach(fe4Blood -> {
+			int multiplier = fe4Blood.isMajor() ? 2 : 1;
+			if (subtract) { multiplier *= -1; }
+			
+			FE4HolyBlood blood = bloodData.holyBloodByType(fe4Blood.bloodType());
+			staticChar.setHPGrowth(Math.max(0, staticChar.getHPGrowth() + blood.getHPGrowthBonus() * multiplier));
+			staticChar.setSTRGrowth(Math.max(0, staticChar.getSTRGrowth() + blood.getSTRGrowthBonus() * multiplier));
+			staticChar.setMAGGrowth(Math.max(0, staticChar.getMAGGrowth() + blood.getMAGGrowthBonus() * multiplier));
+			staticChar.setSKLGrowth(Math.max(0, staticChar.getSKLGrowth() + blood.getSKLGrowthBonus() * multiplier));
+			staticChar.setSPDGrowth(Math.max(0, staticChar.getSPDGrowth() + blood.getSPDGrowthBonus() * multiplier));
+			staticChar.setDEFGrowth(Math.max(0, staticChar.getDEFGrowth() + blood.getDEFGrowthBonus() * multiplier));
+			staticChar.setRESGrowth(Math.max(0, staticChar.getRESGrowth() + blood.getRESGrowthBonus() * multiplier));
+			staticChar.setLCKGrowth(Math.max(0, staticChar.getLCKGrowth() + blood.getLCKGrowthBonus() * multiplier));
+		});
 	}
 	
 	private static Integer hashValue(int hp, int str, int mag, int skl, int spd, int lck, int def, int res) {

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4ClassRandomizer.java
@@ -1970,15 +1970,6 @@ public class FE4ClassRandomizer {
 					
 					majorBloodType = newMajorBlood;
 				}
-				
-				character.setHPGrowth(character.getHPGrowth() - bloodData.holyBloodByType(majorBloodType).getHPGrowthBonus() * 2);
-				character.setSTRGrowth(character.getSTRGrowth() - bloodData.holyBloodByType(majorBloodType).getSTRGrowthBonus() * 2);
-				character.setMAGGrowth(character.getMAGGrowth() - bloodData.holyBloodByType(majorBloodType).getMAGGrowthBonus() * 2);
-				character.setSKLGrowth(character.getSKLGrowth() - bloodData.holyBloodByType(majorBloodType).getSKLGrowthBonus() * 2);
-				character.setSPDGrowth(character.getSPDGrowth() - bloodData.holyBloodByType(majorBloodType).getSPDGrowthBonus() * 2);
-				character.setDEFGrowth(character.getDEFGrowth() - bloodData.holyBloodByType(majorBloodType).getDEFGrowthBonus() * 2);
-				character.setRESGrowth(character.getRESGrowth() - bloodData.holyBloodByType(majorBloodType).getRESGrowthBonus() * 2);
-				character.setLCKGrowth(character.getLCKGrowth() - bloodData.holyBloodByType(majorBloodType).getLCKGrowthBonus() * 2);
 			}
 			
 			// Look for Minor blood now.
@@ -2051,7 +2042,36 @@ public class FE4ClassRandomizer {
 				}
 			}
 			
+			// Swap STR/MAG if necessary before we start subtracting growths.
+			boolean wasSTRBased = oldClass.primaryAttackIsStrength();
+			boolean wasMAGBased = oldClass.primaryAttackIsMagic();
+			
+			boolean isSTRBased = targetClass.primaryAttackIsStrength();
+			boolean isMAGBased = targetClass.primaryAttackIsMagic();
+			
+			if ((wasSTRBased && !wasMAGBased && isMAGBased && !isSTRBased) || (wasMAGBased && !wasSTRBased && isSTRBased && !isMAGBased)) {
+				// Swap in the case that we've randomized across the STR/MAG split.
+				int oldSTR = character.getSTRGrowth();
+				character.setSTRGrowth(character.getMAGGrowth());
+				character.setMAGGrowth(oldSTR);
+				
+				oldSTR = character.getBaseSTR();
+				character.setBaseSTR(character.getBaseMAG());
+				character.setBaseMAG(oldSTR);
+			}
+			
 			// Adjust growths back down based on blood selected.
+			if (majorBloodType != null) {
+				character.setHPGrowth(character.getHPGrowth() - bloodData.holyBloodByType(majorBloodType).getHPGrowthBonus() * 2);
+				character.setSTRGrowth(character.getSTRGrowth() - bloodData.holyBloodByType(majorBloodType).getSTRGrowthBonus() * 2);
+				character.setMAGGrowth(character.getMAGGrowth() - bloodData.holyBloodByType(majorBloodType).getMAGGrowthBonus() * 2);
+				character.setSKLGrowth(character.getSKLGrowth() - bloodData.holyBloodByType(majorBloodType).getSKLGrowthBonus() * 2);
+				character.setSPDGrowth(character.getSPDGrowth() - bloodData.holyBloodByType(majorBloodType).getSPDGrowthBonus() * 2);
+				character.setDEFGrowth(character.getDEFGrowth() - bloodData.holyBloodByType(majorBloodType).getDEFGrowthBonus() * 2);
+				character.setRESGrowth(character.getRESGrowth() - bloodData.holyBloodByType(majorBloodType).getRESGrowthBonus() * 2);
+				character.setLCKGrowth(character.getLCKGrowth() - bloodData.holyBloodByType(majorBloodType).getLCKGrowthBonus() * 2);
+			}
+			
 			for (HolyBlood newBlood : newMinorBlood) {
 				character.setHPGrowth(character.getHPGrowth() - bloodData.holyBloodByType(newBlood).getHPGrowthBonus());
 				character.setSTRGrowth(character.getSTRGrowth() - bloodData.holyBloodByType(newBlood).getSTRGrowthBonus());
@@ -2066,23 +2086,6 @@ public class FE4ClassRandomizer {
 			character.setHolyBlood1Value(FE4Data.HolyBloodSlot1.valueForSlot1HolyBlood(slot1Blood));
 			character.setHolyBlood2Value(FE4Data.HolyBloodSlot2.valueForSlot2HolyBlood(slot2Blood));
 			character.setHolyBlood3Value(FE4Data.HolyBloodSlot3.valueForSlot3HolyBlood(slot3Blood));
-		}
-		
-		boolean wasSTRBased = oldClass.primaryAttackIsStrength();
-		boolean wasMAGBased = oldClass.primaryAttackIsMagic();
-		
-		boolean isSTRBased = targetClass.primaryAttackIsStrength();
-		boolean isMAGBased = targetClass.primaryAttackIsMagic();
-		
-		if ((wasSTRBased && !wasMAGBased && isMAGBased && !isSTRBased) || (wasMAGBased && !wasSTRBased && isSTRBased && !isMAGBased)) {
-			// Swap in the case that we've randomized across the STR/MAG split.
-			int oldSTR = character.getSTRGrowth();
-			character.setSTRGrowth(character.getMAGGrowth());
-			character.setMAGGrowth(oldSTR);
-			
-			oldSTR = character.getBaseSTR();
-			character.setBaseSTR(character.getBaseMAG());
-			character.setBaseMAG(oldSTR);
 		}
 		
 		// Verify equipment.

--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -420,7 +420,7 @@ public class FE4Randomizer extends Randomizer {
 			if (bloodOptions.randomizeGrowthBonuses) {
 				updateStatusString("Randomizing Holy Blood Growth Bonuses...");
 				Random rng = new Random(SeedGenerator.generateSeedValue(seed, FE4BloodRandomizer.rngSalt + 1));
-				FE4BloodRandomizer.randomizeHolyBloodGrowthBonuses(bloodOptions, bloodData, rng);
+				FE4BloodRandomizer.randomizeHolyBloodGrowthBonuses(bloodOptions, bloodData, charData, rng);
 				bloodData.commit();
 			}
 			if (bloodOptions.randomizeWeaponBonuses) {


### PR DESCRIPTION
Fixed #133.

* Fixed an issue where STR/MAG adjust when randomizing classes was interfering with the growth transfer when allowing blood to randomize. 
* Fixed an issue where it was possible to end up with 0 growth unintentionally if blood growth bonuses are randomized.