### PR TITLE
[Issue #142] Fixed Strict Matching for Enemy Inventory

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
@@ -2,8 +2,9 @@ package fedata.gba;
 
 import fedata.general.FELockableData;
 import fedata.general.FEModifiableData;
+import fedata.general.FEPrintableData;
 
-public interface GBAFECharacterData extends FEModifiableData, FELockableData {
+public interface GBAFECharacterData extends FEModifiableData, FELockableData, FEPrintableData {
 	
 	public Boolean isClassRestricted();
 	

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
@@ -4,8 +4,9 @@ import java.util.Comparator;
 
 import fedata.gba.general.WeaponRank;
 import fedata.general.FEModifiableData;
+import fedata.general.FEPrintableData;
 
-public interface GBAFEClassData extends FEModifiableData {
+public interface GBAFEClassData extends FEModifiableData, FEPrintableData {
 	
 	static Comparator<GBAFEClassData> defaultComparator = new Comparator<GBAFEClassData>() {
 		@Override

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEItemData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEItemData.java
@@ -7,10 +7,11 @@ import fedata.gba.general.WeaponEffects;
 import fedata.gba.general.WeaponRank;
 import fedata.gba.general.WeaponType;
 import fedata.general.FEModifiableData;
+import fedata.general.FEPrintableData;
 import random.gba.loader.ItemDataLoader;
 import random.gba.loader.TextLoader;
 
-public interface GBAFEItemData extends FEModifiableData {
+public interface GBAFEItemData extends FEModifiableData, FEPrintableData {
 	
 	// Info
 	public int getNameIndex();

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
@@ -45,6 +45,8 @@ public class FE6Character implements GBAFECharacterData {
 	
 	private Boolean isReadOnly = false;
 	
+	private String debugString = "Uninitialized";
+	
 	public FE6Character(byte[] data, long originalOffset, Boolean isClassRestricted) {
 		super();
 		this.originalData = data;
@@ -58,6 +60,14 @@ public class FE6Character implements GBAFECharacterData {
 			return new FE6Character(Arrays.copyOf(this.originalData, this.originalData.length), this.originalOffset, this.isClassRestricted);
 		}
 		return new FE6Character(Arrays.copyOf(this.data, this.data.length), this.originalOffset, this.isClassRestricted);
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 	
 	public void lock() {

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Class.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Class.java
@@ -23,6 +23,8 @@ public class FE6Class implements GBAFEClassData {
 	int promoDEF;
 	int promoRES;
 	
+	private String debugString = "Uninitialized";
+	
 	public FE6Class(byte[] data, long originalOffset, GBAFEClassData demotedClass) {
 		super();
 		this.originalData = data;
@@ -37,6 +39,14 @@ public class FE6Class implements GBAFEClassData {
 			promoDEF = getBaseDEF() - demotedClass.getBaseDEF();
 			promoRES = getBaseRES() - demotedClass.getBaseRES();
 		}
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 	
 	public int getNameIndex() {

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1826,7 +1826,14 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses) {
-		return new FE6Character(data, offset, hasLimitedClasses);
+		FE6Character charData = new FE6Character(data, offset, hasLimitedClasses);
+		Character fe6Char = Character.valueOf(charData.getID());
+		if (fe6Char != null) {
+			charData.initializeDisplayString(fe6Char.toString());
+		} else {
+			charData.initializeDisplayString("Unregistered [0x" + Integer.toHexString(charData.getID()) + "]");
+		}
+		return charData;
 	}
 	
 	// Class Provider Methods
@@ -1948,7 +1955,14 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFEClassData classDataWithData(byte[] data, long offset, GBAFEClassData demotedClass) {
-		return new FE6Class(data, offset, demotedClass);
+		FE6Class classData = new FE6Class(data, offset, demotedClass);
+		CharacterClass fe6Class = CharacterClass.valueOf(classData.getID());
+		if (fe6Class != null) {
+			classData.initializeDisplayString(fe6Class.toString());
+		} else {
+			classData.initializeDisplayString("Unregistered [0x" + Integer.toHexString(classData.getID()) + "]");
+		}
+		return classData;
 	}
 	
 	// Item Provider Methods
@@ -2314,7 +2328,14 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 	
 	public GBAFEItemData itemDataWithData(byte[] data, long offset, int itemID) {
-		return new FE6Item(data, offset);
+		FE6Item item = new FE6Item(data, offset);
+		Item fe6Item = Item.valueOf(item.getID());
+		if (fe6Item != null) {
+			item.initializeDisplayString(fe6Item.toString());
+		} else {
+			item.initializeDisplayString("Unregistered [0x" + Integer.toHexString(item.getID()) + "]");
+		}
+		return item;
 	}
 
 	public List<GBAFEClass> knightCavEffectivenessClasses() {

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1814,6 +1814,10 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public boolean isValidCharacter(GBAFECharacter character) {
 		return character != Character.NONE;
 	}
+	
+	public GBAFECharacter nullCharacter() {
+		return Character.NONE;
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE6Character.Affinity.values().length];

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1810,6 +1810,10 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		
 		return character;
 	}
+	
+	public boolean isValidCharacter(GBAFECharacter character) {
+		return character != Character.NONE;
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE6Character.Affinity.values().length];

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Item.java
@@ -31,11 +31,21 @@ public class FE6Item implements GBAFEItemData {
 	private Boolean wasModified = false;
 	private Boolean hasChanges = false;
 	
+	private String debugString = "Uninitialized";
+	
 	public FE6Item(byte[] data, long originalOffset) {
 		super();
 		this.originalData = data;
 		this.data = data;
 		this.originalOffset = originalOffset;
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 	
 	public int getNameIndex() {

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
@@ -45,6 +45,8 @@ public class FE7Character implements GBAFECharacterData {
 	
 	private Boolean isReadOnly = false;
 	
+	private String debugString = "Uninitialized";
+	
 	public FE7Character(byte[] data, long originalOffset, Boolean isClassRestricted) {
 		super();
 		this.originalData = data;
@@ -58,6 +60,14 @@ public class FE7Character implements GBAFECharacterData {
 			return new FE7Character(Arrays.copyOf(this.originalData, this.originalData.length), this.originalOffset, this.isClassRestricted);
 		}
 		return new FE7Character(Arrays.copyOf(this.data, this.data.length), this.originalOffset, this.isClassRestricted);
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 	
 	public void lock() {

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Class.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Class.java
@@ -15,12 +15,22 @@ public class FE7Class implements GBAFEClassData {
 	
 	private Boolean wasModified = false;
 	private Boolean hasChanges = false;
+	
+	private String debugString = "Uninitialized";
 
 	public FE7Class(byte[] data, long originalOffset) {
 		super();
 		this.originalData = data;
 		this.data = data;
 		this.originalOffset = originalOffset;
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 
 	public int getNameIndex() {

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2342,7 +2342,14 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses) {
-		return new FE7Character(data, offset, hasLimitedClasses);
+		FE7Character charData = new FE7Character(data, offset, hasLimitedClasses);
+		Character fe7Char = Character.valueOf(charData.getID());
+		if (fe7Char != null) {
+			charData.initializeDisplayString(fe7Char.toString());
+		} else {
+			charData.initializeDisplayString("Unregistered [0x" + Integer.toHexString(charData.getID()) + "]");
+		}
+		return charData;
 	}
 	
 	// Class Provider Methods
@@ -2463,7 +2470,14 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFEClassData classDataWithData(byte[] data, long offset, GBAFEClassData demotedClass) {
-		return new FE7Class(data, offset);
+		FE7Class charClass = new FE7Class(data, offset);
+		CharacterClass fe7Class = CharacterClass.valueOf(charClass.getID());
+		if (fe7Class != null) {
+			charClass.initializeDisplayString(fe7Class.toString());
+		} else {
+			charClass.initializeDisplayString("Unregistered [0x" + Integer.toHexString(charClass.getID()) + "]");
+		}
+		return charClass;
 	}
 	
 	// Item Provider Methods
@@ -2829,7 +2843,14 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFEItemData itemDataWithData(byte[] data, long offset, int itemID) {
-		return new FE7Item(data, offset);
+		FE7Item item = new FE7Item(data, offset);
+		Item fe7Item = Item.valueOf(item.getID());
+		if (fe7Item != null) {
+			item.initializeDisplayString(fe7Item.toString());
+		} else {
+			item.initializeDisplayString("Unregistered [0x" + Integer.toHexString(item.getID()) + "]");
+		}
+		return item;
 	}
 
 	public List<GBAFEClass> knightCavEffectivenessClasses() {

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2326,6 +2326,10 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		
 		return character;
 	}
+	
+	public boolean isValidCharacter(GBAFECharacter character) {
+		return character != Character.NONE;
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE7Character.Affinity.values().length];

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2330,6 +2330,10 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public boolean isValidCharacter(GBAFECharacter character) {
 		return character != Character.NONE;
 	}
+	
+	public GBAFECharacter nullCharacter() {
+		return Character.NONE;
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE7Character.Affinity.values().length];

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Item.java
@@ -30,12 +30,22 @@ public class FE7Item implements GBAFEItemData {
 	
 	private Boolean wasModified = false;
 	private Boolean hasChanges = false;
+	
+	private String debugString = "Uninitialized";
 
 	public FE7Item(byte[] data, long originalOffset) {
 		super();
 		this.originalData = data;
 		this.data = data;
 		this.originalOffset = originalOffset;
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 
 	public int getNameIndex() {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
@@ -45,6 +45,8 @@ public class FE8Character implements GBAFECharacterData {
 	
 	private Boolean isReadOnly = false;
 	
+	private String debugString = "Uninitialized";
+	
 	public FE8Character(byte[] data, long originalOffset, Boolean isClassRestricted) {
 		super();
 		this.originalData = data;
@@ -59,6 +61,14 @@ public class FE8Character implements GBAFECharacterData {
 		}
 		
 		return new FE8Character(Arrays.copyOf(this.data, this.data.length), this.originalOffset, this.isClassRestricted);
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 	
 	public void lock() {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Class.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Class.java
@@ -16,11 +16,21 @@ public class FE8Class implements GBAFEClassData {
 	private Boolean wasModified = false;
 	private Boolean hasChanges = false;
 	
+	private String debugString = "Uninitialized";
+	
 	public FE8Class(byte[] data, long originalOffset) {
 		super();
 		this.originalData = data;
 		this.data = data;
 		this.originalOffset = originalOffset;
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 
 	public int getNameIndex() {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2499,7 +2499,14 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses) {
-		return new FE8Character(data, offset, hasLimitedClasses);
+		FE8Character character = new FE8Character(data, offset, hasLimitedClasses);
+		Character fe8Char = Character.valueOf(character.getID());
+		if (fe8Char != null) {
+			character.initializeDisplayString(fe8Char.toString());
+		} else {
+			character.initializeDisplayString("Unregistered [0x" + Integer.toHexString(character.getID()) + "]");
+		}
+		return character;
 	}
 
 	// Class Provider Methods
@@ -2622,7 +2629,14 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public GBAFEClassData classDataWithData(byte[] data, long offset, GBAFEClassData demotedClass) {
-		return new FE8Class(data, offset);
+		FE8Class charClass = new FE8Class(data, offset);
+		CharacterClass fe8Class = CharacterClass.valueOf(charClass.getID());
+		if (fe8Class != null) {
+			charClass.initializeDisplayString(fe8Class.toString());
+		} else {
+			charClass.initializeDisplayString("Unregistered [0x" + Integer.toHexString(charClass.getID()) + "]");
+		}
+		return charClass;
 	}
 	
 	// Item Provider Methods
@@ -3055,7 +3069,14 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 	
 	public GBAFEItemData itemDataWithData(byte[] data, long offset, int itemID) {
-		return new FE8Item(data, offset, itemID);
+		FE8Item item = new FE8Item(data, offset, itemID);
+		Item fe8Item = Item.valueOf(item.getID());
+		if (fe8Item != null) {
+			item.initializeDisplayString(fe8Item.toString());
+		} else {
+			item.initializeDisplayString("Unregistered [0x" + Integer.toHexString(item.getID()) + "]");
+		}
+		return item;
 	}
 
 	public List<GBAFEClass> knightCavEffectivenessClasses() {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2483,6 +2483,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		
 		return character;
 	}
+	
+	public boolean isValidCharacter(GBAFECharacter character) {
+		return character != Character.NONE;
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE8Character.Affinity.values().length];

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2487,6 +2487,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public boolean isValidCharacter(GBAFECharacter character) {
 		return character != Character.NONE;
 	}
+	
+	public GBAFECharacter nullCharacter() {
+		return Character.NONE;
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE8Character.Affinity.values().length];

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Item.java
@@ -33,6 +33,8 @@ public class FE8Item implements GBAFEItemData {
 	private Boolean wasModified = false;
 	private Boolean hasChanges = false;
 	
+	private String debugString = "Uninitialized";
+	
 	// FE8 items don't embed their item ID, so we need it passed in on creation.
 	public FE8Item(byte[] data, long originalOffset, int itemID) {
 		super();
@@ -40,6 +42,14 @@ public class FE8Item implements GBAFEItemData {
 		this.data = data;
 		this.originalOffset = originalOffset;
 		this.itemID = itemID;
+	}
+	
+	public void initializeDisplayString(String debugString) {
+		this.debugString = debugString;
+	}
+	
+	public String displayString() {
+		return debugString;
 	}
 
 	public int getNameIndex() {

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
@@ -32,6 +32,7 @@ public interface GBAFECharacterProvider {
 	public Set<GBAFECharacter> mustPromote();
 	
 	public GBAFECharacter characterWithID(int characterID);
+	public boolean isValidCharacter(GBAFECharacter character);
 	
 	public int[] affinityValues();
 	

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
@@ -33,6 +33,7 @@ public interface GBAFECharacterProvider {
 	
 	public GBAFECharacter characterWithID(int characterID);
 	public boolean isValidCharacter(GBAFECharacter character);
+	public GBAFECharacter nullCharacter();
 	
 	public int[] affinityValues();
 	

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
@@ -1,5 +1,6 @@
 package fedata.gba.general;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -21,15 +22,26 @@ public interface GBAFEItemProvider {
 		public final WeaponRank darkRank;
 		public final WeaponRank staffRank;
 		
-		public WeaponRanks(GBAFECharacterData character, GBAFEItemProvider provider) {
-			swordRank = provider.rankWithValue(character.getSwordRank());
-			lanceRank = provider.rankWithValue(character.getLanceRank());
-			axeRank = provider.rankWithValue(character.getAxeRank());
-			bowRank = provider.rankWithValue(character.getBowRank());
-			animaRank = provider.rankWithValue(character.getAnimaRank());
-			lightRank = provider.rankWithValue(character.getLightRank());
-			darkRank = provider.rankWithValue(character.getDarkRank());
-			staffRank = provider.rankWithValue(character.getStaffRank());
+		public WeaponRanks(GBAFECharacterData character, GBAFEClassData characterClass, GBAFEItemProvider provider) {
+			if (characterClass == null) {
+				swordRank = provider.rankWithValue(character.getSwordRank());
+				lanceRank = provider.rankWithValue(character.getLanceRank());
+				axeRank = provider.rankWithValue(character.getAxeRank());
+				bowRank = provider.rankWithValue(character.getBowRank());
+				animaRank = provider.rankWithValue(character.getAnimaRank());
+				lightRank = provider.rankWithValue(character.getLightRank());
+				darkRank = provider.rankWithValue(character.getDarkRank());
+				staffRank = provider.rankWithValue(character.getStaffRank());
+			} else {
+				swordRank = provider.rankWithValue(character.getSwordRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getSwordRank()) : provider.rankWithValue(character.getSwordRank());
+				lanceRank = provider.rankWithValue(character.getLanceRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getLanceRank()) : provider.rankWithValue(character.getLanceRank());
+				axeRank = provider.rankWithValue(character.getAxeRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getAxeRank()) : provider.rankWithValue(character.getAxeRank());
+				bowRank = provider.rankWithValue(character.getBowRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getBowRank()) : provider.rankWithValue(character.getBowRank());
+				animaRank = provider.rankWithValue(character.getAnimaRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getAnimaRank()) : provider.rankWithValue(character.getAnimaRank());
+				lightRank = provider.rankWithValue(character.getLightRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getLightRank()) : provider.rankWithValue(character.getLightRank());
+				darkRank = provider.rankWithValue(character.getDarkRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getDarkRank()) : provider.rankWithValue(character.getDarkRank());
+				staffRank = provider.rankWithValue(character.getStaffRank()) == WeaponRank.NONE ? provider.rankWithValue(characterClass.getStaffRank()) : provider.rankWithValue(character.getStaffRank());
+			}
 		}
 		
 		public WeaponRanks(GBAFEClassData characterClass, GBAFEItemProvider provider) {
@@ -41,6 +53,34 @@ public interface GBAFEItemProvider {
 			lightRank = provider.rankWithValue(characterClass.getLightRank());
 			darkRank = provider.rankWithValue(characterClass.getDarkRank());
 			staffRank = provider.rankWithValue(characterClass.getStaffRank());
+		}
+		
+		public List<WeaponType> getTypes() {
+			List<WeaponType> types = new ArrayList<WeaponType>();
+			if (swordRank != WeaponRank.NONE) { types.add(WeaponType.SWORD); }
+			if (lanceRank != WeaponRank.NONE) { types.add(WeaponType.LANCE); }
+			if (axeRank != WeaponRank.NONE) { types.add(WeaponType.AXE); }
+			if (bowRank != WeaponRank.NONE) { types.add(WeaponType.BOW); }
+			if (lightRank != WeaponRank.NONE) { types.add(WeaponType.LIGHT); }
+			if (darkRank != WeaponRank.NONE) { types.add(WeaponType.DARK); }
+			if (animaRank != WeaponRank.NONE) { types.add(WeaponType.ANIMA); }
+			if (staffRank != WeaponRank.NONE) { types.add(WeaponType.STAFF); }
+			return types;
+		}
+		
+		public WeaponRank rankForType(WeaponType type) {
+			switch (type) {
+			case SWORD: return swordRank;
+			case LANCE: return lanceRank;
+			case AXE: return axeRank;
+			case BOW: return bowRank;
+			case ANIMA: return animaRank;
+			case LIGHT: return lightRank;
+			case DARK: return darkRank;
+			case STAFF: return staffRank;
+			default:
+				return WeaponRank.NONE;
+			}
 		}
 	}
 	

--- a/Universal FE Randomizer/src/fedata/general/FEPrintableData.java
+++ b/Universal FE Randomizer/src/fedata/general/FEPrintableData.java
@@ -1,0 +1,7 @@
+package fedata.general;
+
+public interface FEPrintableData {
+	
+	public String displayString();
+
+}

--- a/Universal FE Randomizer/src/random/gba/loader/ChapterLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ChapterLoader.java
@@ -342,10 +342,10 @@ public class ChapterLoader {
 			sb.append("<tr><td>Character ID</td><td>0x" + Integer.toHexString(chapterUnit.getCharacterNumber()).toUpperCase() + "</td></tr>\n");
 		} else {
 			// This is a somewhat important character.
-			sb.append("<tr><td>Character ID</td><td>" + textData.getStringAtIndex(character.getNameIndex(), true) + "</td></tr>\n");
+			sb.append("<tr><td>Character ID</td><td>" + textData.getStringAtIndex(character.getNameIndex(), true) + " [0x" + Integer.toHexString(chapterUnit.getCharacterNumber()).toUpperCase() + "]</td></tr>\n");
 		}
 		
-		sb.append("<tr><td>Class</td><td>" + (charClass != null ? textData.getStringAtIndex(charClass.getNameIndex(), true) + (classData.isFemale(charClass.getID()) ? " (F)" : "") : "Unknown (0x" + Integer.toHexString(chapterUnit.getStartingClass()) + ")") + "</td></tr>\n");
+		sb.append("<tr><td>Class</td><td>" + (charClass != null ? textData.getStringAtIndex(charClass.getNameIndex(), true) + (classData.isFemale(charClass.getID()) ? " (F)" : "") + " [0x" + Integer.toHexString(charClass.getID()).toUpperCase() + "]" : "Unknown (0x" + Integer.toHexString(chapterUnit.getStartingClass()) + ")") + "</td></tr>\n");
 		sb.append("<tr><td>Loading Coordinates</td><td>(" + chapterUnit.getLoadingX() + ", " + chapterUnit.getLoadingY() + ")</td></tr>\n");
 		sb.append("<tr><td>Starting Coordinates</td><td>(" + chapterUnit.getStartingX() + ", " + chapterUnit.getStartingY() + ")</td></tr>\n");
 		GBAFEItemData item1 = itemData.itemWithID(chapterUnit.getItem1());

--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -26,6 +26,8 @@ public class CharacterDataLoader {
 	private Map<Integer, GBAFECharacterData> characterMap = new HashMap<Integer, GBAFECharacterData>();
 	private Map<Integer, GBAFECharacterData> counterMap = new HashMap<Integer, GBAFECharacterData>();
 	
+	private GBAFECharacterData nullCharacterData = null;
+	
 	// FE7 (probably FE6 and FE8 in some cases as well) likes to use character data
 	// for weapon ranks, instead of relying on class data. This means we have to adopt
 	// a more consistent change in determining minion classes.
@@ -47,6 +49,10 @@ public class CharacterDataLoader {
 			} else {
 				minionData.put(i, characterData);
 			}
+			
+			if (character == provider.nullCharacter()) {
+				nullCharacterData = characterData;
+			}
 		}
 		Map<Integer, GBAFECharacter> counters = provider.counters();
 		for (int characterID : counters.keySet()) {
@@ -59,7 +65,16 @@ public class CharacterDataLoader {
 	}
 	
 	public GBAFECharacterData characterWithID(int characterID) {
-		return characterMap.get(characterID);
+		GBAFECharacterData charData = characterMap.get(characterID);
+		if (charData == null) {
+			charData = minionData.get(characterID);
+		}
+		
+		if (charData == null) {
+			return nullCharacterData;
+		}
+		
+		return charData;
 	}
 	
 	public GBAFECharacterData[] playableCharacters() {

--- a/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
@@ -181,8 +181,8 @@ public class ItemDataLoader {
 		return provider.rankWithValue(value);
 	}
 	
-	public WeaponRanks ranksForCharacter(GBAFECharacterData character) {
-		return new WeaponRanks(character, provider);
+	public WeaponRanks ranksForCharacter(GBAFECharacterData character, GBAFEClassData charClass) {
+		return new WeaponRanks(character, charClass, provider);
 	}
 	
 	public WeaponRanks ranksForClass(GBAFEClassData charClass) {
@@ -364,12 +364,12 @@ public class ItemDataLoader {
 		return itemMap.get(itemList.get(rng.nextInt(itemList.size())).getID());
 	}
 	
-	public GBAFEItemData getSidegradeWeapon(GBAFECharacterData character, GBAFEItemData originalWeapon, boolean strict, Random rng) {
+	public GBAFEItemData getSidegradeWeapon(GBAFECharacterData character, GBAFEClassData charClass, GBAFEItemData originalWeapon, boolean strict, Random rng) {
 		if (!isWeapon(originalWeapon) && originalWeapon.getType() != WeaponType.STAFF) {
 			return null;
 		}
 		
-		Set<GBAFEItem> potentialItems = provider.comparableWeaponsForClass(character.getClassID(), new WeaponRanks(character, provider), originalWeapon, strict);
+		Set<GBAFEItem> potentialItems = provider.comparableWeaponsForClass(character.getClassID(), new WeaponRanks(character, charClass, provider), originalWeapon, strict);
 		if (potentialItems.isEmpty()) { 
 			potentialItems = provider.basicWeaponsForClass(character.getClassID());
 			

--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -17,6 +17,7 @@ import fedata.gba.GBAFEChapterUnitData;
 import fedata.gba.GBAFECharacterData;
 import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
+import fedata.gba.general.GBAFEItemProvider.WeaponRanks;
 import fedata.gba.general.WeaponRank;
 import fedata.gba.general.WeaponType;
 import fedata.general.FEBase.GameType;
@@ -219,6 +220,22 @@ public class ClassRandomizer {
 			separateMonsters = options.separateMonsters;
 		}
 		
+		// Before we start, make all classes naturally have A rank so that weapons can transfer more easily.
+		// Somehow, some enemies, despite all signs of them only being able to use up to C rank weapons,
+		// are able to use A rank somehow in some cases. Since I don't know why this is,
+		// we're going to modify all classes to have A rank in all areas. Characters with lower ranks will override it
+		// which includes all playable characters.
+		for (GBAFEClassData charClass : classData.allClasses()) {
+			if (charClass.getSwordRank() > 0) { charClass.setSwordRank(WeaponRank.A); }
+			if (charClass.getLanceRank() > 0) { charClass.setLanceRank(WeaponRank.A); }
+			if (charClass.getAxeRank() > 0) { charClass.setAxeRank(WeaponRank.A); }
+			if (charClass.getBowRank() > 0) { charClass.setBowRank(WeaponRank.A); }
+			if (charClass.getAnimaRank() > 0) { charClass.setAnimaRank(WeaponRank.A); }
+			if (charClass.getLightRank() > 0) { charClass.setLightRank(WeaponRank.A); }
+			if (charClass.getDarkRank() > 0) { charClass.setDarkRank(WeaponRank.A); }
+			if (charClass.getStaffRank() > 0) { charClass.setStaffRank(WeaponRank.A); }
+		}
+		
 		for (GBAFEChapterData chapter : chapterData.allChapters()) {
 			GBAFECharacterData lordCharacter = charactersData.characterWithID(chapter.lordLeaderID());
 			GBAFEClassData lordClass = classData.classForID(lordCharacter.getClassID());
@@ -232,6 +249,7 @@ public class ClassRandomizer {
 				// Finally, also make sure the starting class is valid. Classes we don't recognize, we shouldn't touch.
 				if (!charactersData.isBossCharacterID(characterID) && /*charactersData.isBossCharacterID(leaderID) &&*/ !charactersData.isPlayableCharacterID(characterID) && 
 						charactersData.canChangeCharacterID(characterID) && classData.isValidClass(classID)) {
+					
 					GBAFEClassData originalClass = classData.classForID(classID);
 					if (originalClass == null) {
 						continue;
@@ -241,27 +259,50 @@ public class ClassRandomizer {
 						continue;
 					}
 					
-					Boolean shouldRestrictToSafeClasses = !chapter.isClassSafe();
-					Boolean shouldMakeEasy = chapter.shouldBeSimplified();
-					GBAFEClassData loseToClass = shouldMakeEasy ? lordClass : null;
-					GBAFEClassData[] possibleClasses = hasMonsters ? 
-							classData.potentialClasses(originalClass, !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, true, false, false, shouldRestrictToSafeClasses, loseToClass) :
-						classData.potentialClasses(originalClass, false, false, false, forceChange, true, false, false, shouldRestrictToSafeClasses, loseToClass);
-					if (possibleClasses.length == 0) {
+					GBAFECharacterData minionCharacterData = charactersData.minionCharacterWithID(characterID);
+					if (minionCharacterData == null) {
 						continue;
 					}
 					
-					int randomIndex = rng.nextInt(possibleClasses.length);
-					GBAFEClassData targetClass = possibleClasses[randomIndex];
+					GBAFEClassData targetClass = null;
+					boolean characterHasWeaponRanks = !itemData.ranksForCharacter(minionCharacterData, null).getTypes().isEmpty();
 					
-					if (classData.isFlying(originalClass.getID()) == false && classData.isFlying(targetClass.getID())) {
-						// If this is a new flier, roll one more time. 
-						// Reduce the number of non-flying minions that become fliers.
-						randomIndex = rng.nextInt(possibleClasses.length);
-						targetClass = possibleClasses[randomIndex];
+					// If he's been modified already, we use the same class.
+					// Otherwise, we randomize the class.
+					if (characterHasWeaponRanks) {
+						if (minionCharacterData.wasModified()) {
+							targetClass = classData.classForID(minionCharacterData.getClassID());
+						}
 					}
 					
-					updateMinionToClass(inventoryOptions, chapterUnit, targetClass, classData, itemData, rng);
+					if (targetClass != null) {
+						updateMinionToClass(inventoryOptions, chapterUnit, minionCharacterData, targetClass, classData, itemData, rng);
+					} else {
+						Boolean shouldRestrictToSafeClasses = !chapter.isClassSafe();
+						Boolean shouldMakeEasy = chapter.shouldBeSimplified();
+						GBAFEClassData loseToClass = shouldMakeEasy ? lordClass : null;
+						GBAFEClassData[] possibleClasses = hasMonsters ? 
+								classData.potentialClasses(originalClass, !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, true, false, false, shouldRestrictToSafeClasses, loseToClass) :
+							classData.potentialClasses(originalClass, false, false, false, forceChange, true, false, false, shouldRestrictToSafeClasses, loseToClass);
+						if (possibleClasses.length == 0) {
+							continue;
+						}
+						
+						int randomIndex = rng.nextInt(possibleClasses.length);
+						targetClass = possibleClasses[randomIndex];
+						
+						if (classData.isFlying(originalClass.getID()) == false && classData.isFlying(targetClass.getID())) {
+							// If this is a new flier, roll one more time. 
+							// Reduce the number of non-flying minions that become fliers.
+							randomIndex = rng.nextInt(possibleClasses.length);
+							targetClass = possibleClasses[randomIndex];
+						}
+						if (characterHasWeaponRanks) {
+							updateMinionCharacterToClass(inventoryOptions, chapterUnit, minionCharacterData, originalClass, targetClass, classData, itemData, rng);
+						} else {
+							updateMinionToClass(inventoryOptions, chapterUnit, minionCharacterData, targetClass, classData, itemData, rng);
+						}
+					}
 				}
 			}
 		}
@@ -356,12 +397,20 @@ public class ClassRandomizer {
 	}
 	
 	// TODO: Offer an option for sidegrade strictness?
-	private static void updateMinionToClass(ItemAssignmentOptions inventoryOptions, GBAFEChapterUnitData chapterUnit, GBAFEClassData targetClass, ClassDataLoader classData, ItemDataLoader itemData, Random rng) {
+	private static void updateMinionToClass(ItemAssignmentOptions inventoryOptions, GBAFEChapterUnitData chapterUnit, GBAFECharacterData minionCharacter, GBAFEClassData targetClass, ClassDataLoader classData, ItemDataLoader itemData, Random rng) {
 		DebugPrinter.log(DebugPrinter.Key.CLASS_RANDOMIZER, "Updating minion from class 0x" + Integer.toHexString(chapterUnit.getStartingClass()) + " to class 0x" + Integer.toHexString(targetClass.getID()));
 		DebugPrinter.log(DebugPrinter.Key.CLASS_RANDOMIZER, "Starting Inventory: [0x" + Integer.toHexString(chapterUnit.getItem1()) + ", 0x" + Integer.toHexString(chapterUnit.getItem2()) + ", 0x" + Integer.toHexString(chapterUnit.getItem3()) + ", 0x" + Integer.toHexString(chapterUnit.getItem4()) + "]");
 		chapterUnit.setStartingClass(targetClass.getID());
-		validateMinionInventory(inventoryOptions, chapterUnit, classData, itemData, rng);
+		validateMinionInventory(inventoryOptions, chapterUnit, targetClass, classData, itemData, rng);
 		DebugPrinter.log(DebugPrinter.Key.CLASS_RANDOMIZER, "Minion update complete. Inventory: [0x" + Integer.toHexString(chapterUnit.getItem1()) + ", 0x" + Integer.toHexString(chapterUnit.getItem2()) + ", 0x" + Integer.toHexString(chapterUnit.getItem3()) + ", 0x" + Integer.toHexString(chapterUnit.getItem4()) + "]");
+	}
+	
+	private static void updateMinionCharacterToClass(ItemAssignmentOptions inventoryOptions, GBAFEChapterUnitData chapterUnit, GBAFECharacterData minionCharacter, GBAFEClassData sourceClass, GBAFEClassData targetClass, ClassDataLoader classData, ItemDataLoader itemData, Random rng) {
+		// Write this into the character data.
+		minionCharacter.setClassID(targetClass.getID());
+		transferWeaponLevels(minionCharacter, sourceClass, targetClass, rng);
+		chapterUnit.setStartingClass(targetClass.getID());
+		validateMinionInventory(inventoryOptions, chapterUnit, minionCharacter, classData, itemData, rng);
 	}
 	
 	public static void validateFormerThiefInventory(GBAFEChapterUnitData chapterUnit, ItemDataLoader itemData) {
@@ -446,60 +495,270 @@ public class ClassRandomizer {
 		chapterUnit.giveItems(requiredItemIDs);
 	}
 	
-	private static void validateMinionInventory(ItemAssignmentOptions inventoryOptions, GBAFEChapterUnitData chapterUnit, ClassDataLoader classData, ItemDataLoader itemData, Random rng) {
+	private static void validateMinionInventory(ItemAssignmentOptions inventoryOptions, GBAFEChapterUnitData chapterUnit, GBAFEClassData targetClass, ClassDataLoader classData, ItemDataLoader itemData, Random rng) {
 		int classID = chapterUnit.getStartingClass();
 		GBAFEClassData unitClass = classData.classForID(classID);
+		
+		boolean canAttack = classData.canClassAttack(classID);
+		boolean isHealer = unitClass.getStaffRank() > 0;
+		
+		boolean limitStaves = isHealer && canAttack;
+		boolean hasStaff = false;
+		boolean hasWeapon = false;
+		boolean hasItems = false;
+		
+		GBAFEItemData replacementItem = null;
+		
 		if (unitClass != null) {
 			int item1ID = chapterUnit.getItem1();
 			GBAFEItemData item1 = itemData.itemWithID(item1ID);
+			if (!hasItems) { hasItems = item1 != null; }
 			if (item1 != null && (itemData.isWeapon(item1) || item1.getType() == WeaponType.STAFF)) {
 				if (!unitClass.canUseWeapon(item1)) {
-					GBAFEItemData replacementItem = itemData.getSidegradeWeapon(unitClass, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					replacementItem = itemData.getSidegradeWeapon(unitClass, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+						replacementItem = null; // We'll handle this later.
+					}
 					if (replacementItem != null) {
 						chapterUnit.setItem1(replacementItem.getID());
 					} else {
 						chapterUnit.setItem1(0);
 					}
+					item1 = replacementItem;
 				}
+			}
+			
+			if (item1 != null) {
+				if (!hasStaff) { hasStaff = item1.getType() == WeaponType.STAFF; }
+				if (!hasWeapon) { hasWeapon = itemData.isWeapon(item1); }
 			}
 			
 			int item2ID = chapterUnit.getItem2();
 			GBAFEItemData item2 = itemData.itemWithID(item2ID);
+			if (!hasItems) { hasItems = item2 != null; }
 			if (item2 != null && (itemData.isWeapon(item2) || item2.getType() == WeaponType.STAFF)) {
 				if (!unitClass.canUseWeapon(item2)) {
-					GBAFEItemData replacementItem = itemData.getSidegradeWeapon(unitClass, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					replacementItem = itemData.getSidegradeWeapon(unitClass, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+						replacementItem = null; // We'll handle this later.
+					}
 					if (replacementItem != null) {
 						chapterUnit.setItem2(replacementItem.getID());
 					} else {
 						chapterUnit.setItem2(0);
 					}
+					item2 = replacementItem;
 				}
+			}
+			
+			if (item2 != null) {
+				if (!hasStaff) { hasStaff = item2.getType() == WeaponType.STAFF; }
+				if (!hasWeapon) { hasWeapon = itemData.isWeapon(item2); }
 			}
 			
 			int item3ID = chapterUnit.getItem3();
 			GBAFEItemData item3 = itemData.itemWithID(item3ID);
+			if (!hasItems) { hasItems = item3 != null; }
 			if (item3 != null && (itemData.isWeapon(item3) || item3.getType() == WeaponType.STAFF)) {
 				if (!unitClass.canUseWeapon(item3)) {
-					GBAFEItemData replacementItem = itemData.getSidegradeWeapon(unitClass, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					replacementItem = itemData.getSidegradeWeapon(unitClass, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+						replacementItem = null; // We'll handle this later.
+					}
 					if (replacementItem != null) {
 						chapterUnit.setItem3(replacementItem.getID());
 					} else {
 						chapterUnit.setItem3(0);
 					}
+					item3 = replacementItem;
 				}
+			}
+			
+			if (item3 != null) {
+				if (!hasStaff) { hasStaff = item3.getType() == WeaponType.STAFF; }
+				if (!hasWeapon) { hasWeapon = itemData.isWeapon(item3); }
 			}
 			
 			int item4ID = chapterUnit.getItem4();
 			GBAFEItemData item4 = itemData.itemWithID(item4ID);
+			if (!hasItems) { hasItems = item4 != null; }
 			if (item4 != null && (itemData.isWeapon(item4) || item4.getType() == WeaponType.STAFF)) {
 				if (!unitClass.canUseWeapon(item4)) {
-					GBAFEItemData replacementItem = itemData.getSidegradeWeapon(unitClass, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					replacementItem = itemData.getSidegradeWeapon(unitClass, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+					if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+						replacementItem = null; // We'll handle this later.
+					}
 					if (replacementItem != null) {
 						chapterUnit.setItem4(replacementItem.getID());
 					} else {
 						chapterUnit.setItem4(0);
 					}
+					item4 = replacementItem;
 				}
+			}
+			
+			if (item4 != null) {
+				if (!hasStaff) { hasStaff = item4.getType() == WeaponType.STAFF; }
+				if (!hasWeapon) { hasWeapon = itemData.isWeapon(item4); }
+			}
+			
+			// Sanity check.
+			if (hasItems) {
+				if (canAttack) {
+					if (!hasWeapon) {
+						// Make sure enemies that can attack have weapons.
+						WeaponRanks ranks = itemData.ranksForClass(unitClass);
+						List<WeaponType> types = ranks.getTypes();
+						types.remove(WeaponType.STAFF);
+						if (!types.isEmpty()) {
+							for(;;) {
+								WeaponType randomType = types.get(rng.nextInt(types.size()));
+								GBAFEItemData[] candidates = itemData.itemsOfTypeAndBelowRank(randomType, ranks.rankForType(randomType), false, false);
+								if (candidates.length > 0) {
+									GBAFEItemData randomWeapon = candidates[rng.nextInt(candidates.length)];
+									chapterUnit.giveItems(new int[] {randomWeapon.getID()});
+									break;
+								}
+							}
+						}
+					}
+				}
+				if (isHealer && !canAttack) {
+					assert hasStaff : "No staff for healer.";
+				}
+			}
+		}
+	}
+	
+	private static void validateMinionInventory(ItemAssignmentOptions inventoryOptions, GBAFEChapterUnitData chapterUnit, GBAFECharacterData minionCharacter, ClassDataLoader classData, ItemDataLoader itemData, Random rng) {
+		int classID = chapterUnit.getStartingClass();
+		GBAFEClassData unitClass = classData.classForID(classID);
+		
+		boolean canAttack = classData.canClassAttack(classID);
+		boolean isHealer = unitClass.getStaffRank() > 0;
+		
+		boolean limitStaves = isHealer && canAttack;
+		boolean hasStaff = false;
+		boolean hasWeapon = false;
+		boolean hasItems = false;
+		
+		GBAFEItemData replacementItem = null;
+		
+		int item1ID = chapterUnit.getItem1();
+		GBAFEItemData item1 = itemData.itemWithID(item1ID);
+		if (!hasItems) { hasItems = item1 != null; }
+		if (item1 != null && (itemData.isWeapon(item1) || item1.getType() == WeaponType.STAFF)) {
+			if (!canCharacterUseItem(minionCharacter, item1, itemData)) {
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+					replacementItem = null; // We'll handle this later.
+				}
+				if (replacementItem != null) {
+					chapterUnit.setItem1(replacementItem.getID());
+				} else {
+					chapterUnit.setItem1(0);
+				}
+				item1 = replacementItem;
+			}
+		}
+		
+		if (item1 != null) {
+			if (!hasStaff) { hasStaff = item1.getType() == WeaponType.STAFF; }
+			if (!hasWeapon) { hasWeapon = itemData.isWeapon(item1); }
+		}
+		
+		int item2ID = chapterUnit.getItem2();
+		GBAFEItemData item2 = itemData.itemWithID(item2ID);
+		if (!hasItems) { hasItems = item2 != null; }
+		if (item2 != null && (itemData.isWeapon(item2) || item2.getType() == WeaponType.STAFF)) {
+			if (!canCharacterUseItem(minionCharacter, item2, itemData)) {
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+					replacementItem = null; // We'll handle this later.
+				}
+				if (replacementItem != null) {
+					chapterUnit.setItem2(replacementItem.getID());
+				} else {
+					chapterUnit.setItem2(0);
+				}
+				item2 = replacementItem;
+			}
+		}
+		
+		if (item2 != null) {
+			if (!hasStaff) { hasStaff = item2.getType() == WeaponType.STAFF; }
+			if (!hasWeapon) { hasWeapon = itemData.isWeapon(item2); }
+		}
+		
+		int item3ID = chapterUnit.getItem3();
+		GBAFEItemData item3 = itemData.itemWithID(item3ID);
+		if (!hasItems) { hasItems = item3 != null; }
+		if (item3 != null && (itemData.isWeapon(item3) || item3.getType() == WeaponType.STAFF)) {
+			if (!canCharacterUseItem(minionCharacter, item3, itemData)) {
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+					replacementItem = null; // We'll handle this later.
+				}
+				if (replacementItem != null) {
+					chapterUnit.setItem3(replacementItem.getID());
+				} else {
+					chapterUnit.setItem3(0);
+				}
+				item3 = replacementItem;
+			}
+		}
+		
+		if (item3 != null) {
+			if (!hasStaff) { hasStaff = item3.getType() == WeaponType.STAFF; }
+			if (!hasWeapon) { hasWeapon = itemData.isWeapon(item3); }
+		}
+		
+		int item4ID = chapterUnit.getItem4();
+		GBAFEItemData item4 = itemData.itemWithID(item4ID);
+		if (!hasItems) { hasItems = item4 != null; }
+		if (item4 != null && (itemData.isWeapon(item4) || item4.getType() == WeaponType.STAFF)) {
+			if (!canCharacterUseItem(minionCharacter, item4, itemData)) {
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
+					replacementItem = null; // We'll handle this later.
+				}
+				if (replacementItem != null) {
+					chapterUnit.setItem4(replacementItem.getID());
+				} else {
+					chapterUnit.setItem4(0);
+				}
+				item4 = replacementItem;
+			}
+		}
+		
+		if (item4 != null) {
+			if (!hasStaff) { hasStaff = item4.getType() == WeaponType.STAFF; }
+			if (!hasWeapon) { hasWeapon = itemData.isWeapon(item4); }
+		}
+		
+		// Sanity check.
+		if (hasItems) {
+			if (canAttack) {
+				if (!hasWeapon) {
+					// Make sure enemies that can attack have weapons.
+					WeaponRanks ranks = itemData.ranksForCharacter(minionCharacter, unitClass);
+					List<WeaponType> types = ranks.getTypes();
+					types.remove(WeaponType.STAFF);
+					if (!types.isEmpty()) {
+						for(;;) {
+							WeaponType randomType = types.get(rng.nextInt(types.size()));
+							GBAFEItemData[] candidates = itemData.itemsOfTypeAndBelowRank(randomType, ranks.rankForType(randomType), false, false);
+							if (candidates.length > 0) {
+								GBAFEItemData randomWeapon = candidates[rng.nextInt(candidates.length)];
+								chapterUnit.giveItems(new int[] {randomWeapon.getID()});
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (isHealer && !canAttack) {
+				assert hasStaff : "No staff for healer.";
 			}
 		}
 	}
@@ -538,7 +797,7 @@ public class ClassRandomizer {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE) {
 						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -568,7 +827,7 @@ public class ClassRandomizer {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE) {
 						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -598,7 +857,7 @@ public class ClassRandomizer {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE) {
 						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -628,7 +887,7 @@ public class ClassRandomizer {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE) {
 						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -711,6 +970,18 @@ public class ClassRandomizer {
 		if (character.getLightRank() > 0) { ranks.add(character.getLightRank()); }
 		if (character.getDarkRank() > 0) { ranks.add(character.getDarkRank()); }
 		if (character.getStaffRank() > 0) { ranks.add(character.getStaffRank()); }
+		
+		if (ranks.isEmpty()) {
+			// Fall back to the source class.
+			if (sourceClass.getSwordRank() > 0) { ranks.add(sourceClass.getSwordRank()); }
+			if (sourceClass.getLanceRank() > 0) { ranks.add(sourceClass.getLanceRank()); }
+			if (sourceClass.getAxeRank() > 0) { ranks.add(sourceClass.getAxeRank()); }
+			if (sourceClass.getBowRank() > 0) { ranks.add(sourceClass.getBowRank()); }
+			if (sourceClass.getAnimaRank() > 0) { ranks.add(sourceClass.getAnimaRank()); }
+			if (sourceClass.getLightRank() > 0) { ranks.add(sourceClass.getLightRank()); }
+			if (sourceClass.getDarkRank() > 0) { ranks.add(sourceClass.getDarkRank()); }
+			if (sourceClass.getStaffRank() > 0) { ranks.add(sourceClass.getStaffRank()); }
+		}
 		
 		Collections.sort(ranks);
 		


### PR DESCRIPTION
Fixed #142.

* Added logic to pull in class ranks when determining usable weapons for bosses. This resolves Paul and Jasmine (and a few other characters) not having weapon ranks coded into their character data, instead relying on class defaults.
* Added logic to pull in character ranks when determining usable weapons for minions. Minions generally rely on class data, but in some instances, they rely on specially coded character data for the specific character.
* Modified logic to default all classes to A rank in their weapon ranks. This has no effect on characters that specify their own weapon rank data (as most playable characters do) since those will overwrite the class defaults. This simplifies transferring higher rank weapons (B and A rank). Some enemies in the game can use these high rank weapons despite not having anything in their class or character data to specify otherwise. This just formalizes that into class defaults.