### PR TITLE
[Issue #199] Fixed hanging on randomizing classes for FE9

### DIFF
--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -339,30 +339,32 @@ public class FE9ClassRandomizer {
 								for (WeaponType type : types) {
 									DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Type: " + type.toString() + " (" + weaponLevelsMap.get(type) + ")");
 								}
-								for (int i = 0; i < weaponCount; i++) {
-									WeaponType randomUsableType = types.get(rng.nextInt(types.size()));
-									DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Selected type: " + randomUsableType.toString());
-									WeaponRank usableRank = equippedRanks.size() > i ? equippedRanks.get(i) : weaponLevelsMap.get(randomUsableType);
-									List<FE9Item> replacements = itemData.weaponsOfRankAndType(usableRank, randomUsableType);
-									if (replacements.isEmpty()) {
-										WeaponRank adjacentRank = usableRank.lowerRank();
-										if (adjacentRank == WeaponRank.NONE && usableRank.higherRank().isLowerThan(weaponLevelsMap.get(randomUsableType))) {
-											adjacentRank = usableRank.higherRank();
+								if (!types.isEmpty()) {
+									for (int i = 0; i < weaponCount; i++) {
+										WeaponType randomUsableType = types.get(rng.nextInt(types.size()));
+										DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Selected type: " + randomUsableType.toString());
+										WeaponRank usableRank = equippedRanks.size() > i ? equippedRanks.get(i) : weaponLevelsMap.get(randomUsableType);
+										List<FE9Item> replacements = itemData.weaponsOfRankAndType(usableRank, randomUsableType);
+										if (replacements.isEmpty()) {
+											WeaponRank adjacentRank = usableRank.lowerRank();
+											if (adjacentRank == WeaponRank.NONE && usableRank.higherRank().isLowerThan(weaponLevelsMap.get(randomUsableType))) {
+												adjacentRank = usableRank.higherRank();
+											}
+											replacements = itemData.weaponsOfRankAndType(adjacentRank, randomUsableType);
 										}
-										replacements = itemData.weaponsOfRankAndType(adjacentRank, randomUsableType);
-									}
-									List<FE9Item> specialWeapons = itemData.specialWeaponsForJID(targetJID);
-									if (specialWeapons != null) { replacements.addAll(specialWeapons); }
-									
-									DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Possible replacements: ");
-									for (FE9Item weapon : replacements) {
-										DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "\t" + itemData.iidOfItem(weapon));
-									}
-									
-									if (!replacements.isEmpty()) {
-										FE9Item weapon = replacements.get(rng.nextInt(replacements.size()));
-										DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Selected: " + itemData.iidOfItem(weapon));
-										weapons.add(weapon);
+										List<FE9Item> specialWeapons = itemData.specialWeaponsForJID(targetJID);
+										if (specialWeapons != null) { replacements.addAll(specialWeapons); }
+										
+										DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Possible replacements: ");
+										for (FE9Item weapon : replacements) {
+											DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "\t" + itemData.iidOfItem(weapon));
+										}
+										
+										if (!replacements.isEmpty()) {
+											FE9Item weapon = replacements.get(rng.nextInt(replacements.size()));
+											DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Selected: " + itemData.iidOfItem(weapon));
+											weapons.add(weapon);
+										}
 									}
 								}
 							}

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9EnemyBuffer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9EnemyBuffer.java
@@ -111,7 +111,7 @@ public class FE9EnemyBuffer {
 				};
 		int count = 0;
 		for (FE9Data.Chapter chapter : FE9Data.Chapter.allChapters()) {
-			int delta = (int)(factors[count++] * buffAmount);
+			int delta = (int)(factors[Math.min(count++, factors.length - 1)] * buffAmount);
 			FE9Data.Character[] bosses = chapter.bossCharactersForChapter();
 			for (FE9Data.Character character : bosses) {
 				FE9Character boss = charData.characterWithID(character.getPID());

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -208,7 +208,7 @@ public class FE9Randomizer extends Randomizer {
 				FE9GrowthRandomizer.randomizeGrowthsByDelta(growthOptions.deltaOption.variance, growthOptions.adjustSTRMAGSplit, charData, classData, rng);
 				break;
 			case FULL:
-				FE9GrowthRandomizer.randomizeGrowthsFully(growthOptions.fullOption.minValue, growthOptions.fullOption.minValue, growthOptions.adjustHP, growthOptions.adjustSTRMAGSplit, charData, classData, rng);
+				FE9GrowthRandomizer.randomizeGrowthsFully(growthOptions.fullOption.minValue, growthOptions.fullOption.maxValue, growthOptions.adjustHP, growthOptions.adjustSTRMAGSplit, charData, classData, rng);
 				break;
 			}
 			charData.commit();

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -173,7 +173,10 @@ public class FE9Randomizer extends Randomizer {
 			ChangelogAsset.registerAssets(changelogBuilder);
 			
 		} catch (GCNISOException e1) {
-			notifyError("Failed to load character data.");
+			notifyError("Failed to load data from the ISO.\n\n" + e1.getMessage());
+			return;
+		} catch (Exception e) {
+			notifyError(e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); 
 			return;
 		}
 		


### PR DESCRIPTION
Fixed #199 - Fixed an issue where assigning a heron to a class would crash due to having no weapon types available. Also made it so that if an exception is thrown during randomization, it notifies the user instead of appearing stuck. 