### PR TITLE
[Issue #185] Added player only weapon list for GBAFE

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -900,6 +900,8 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 				HALBERD, TOMAHAWK, POISON_BOW, KILLER_BOW, BRAVE_BOW, SHORT_BOW, LONGBOW, AIRCALIBUR, BOLTING, PURGE, NOSFERATU, ECLIPSE, PHYSIC, FORTIFY, RESTORE, WARP, RESCUE, TORCH_STAFF, HAMMERNE, UNLOCK, BARRIER,
 				SILENCE, SLEEP, BERSERK, HOLY_MAIDEN));
 		
+		public static Set<Item> playerOnlySet = new HashSet<Item>(Arrays.asList(TORCH_STAFF, UNLOCK, RESTORE, HAMMERNE, BARRIER, RESCUE, WARP, TINA_STAFF));
+		
 		// These must be of lower rank than the siege tomes set, and each weapon type needs to have an equivalent analogue.
 		public static Set<Item> siegeReplacementSet = new HashSet<Item>(Arrays.asList(NOSFERATU, DIVINE, ELFIRE));
 		
@@ -1818,6 +1820,26 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public GBAFECharacter nullCharacter() {
 		return Character.NONE;
 	}
+	
+	public boolean isEnemyAtAnyPoint(int characterID) {
+		Character character = Character.valueOf(characterID);
+		switch (character) {
+		case RUTGER:
+		case FIR:
+		case SHIN:
+		case GONZALES:
+		case KLEIN:
+		case THITO:
+		case CASS:
+		case PERCIVAL:
+		case GARET:
+		case HUGH:
+		case ZEISS:
+			return true;
+		default:
+			return !allPlayableCharacters().contains(character);
+		}
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE6Character.Affinity.values().length];
@@ -2312,6 +2334,10 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		return new HashSet<GBAFEItem>(kit);
 	}
 	
+	public Set<GBAFEItem> playerOnlyWeapons() {
+		return new HashSet<GBAFEItem>(Item.playerOnlySet);
+	}
+
 	public String statBoostStringForWeapon(GBAFEItem weapon) {
 		if (weapon == Item.DURANDAL) { return "+5 Strength"; }
 		if (weapon == Item.BINDING_BLADE) { return "+5 Defense, Resistance"; }

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2332,6 +2332,24 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public GBAFECharacter nullCharacter() {
 		return Character.NONE;
 	}
+	
+	public boolean isEnemyAtAnyPoint(int characterID) {
+		Character character = Character.valueOf(characterID);
+		switch (character) {
+		case DORCAS:
+		case GUY:
+		case RAVEN:
+		case DART:
+		case LEGAULT:
+		case HEATH:
+		case GEITZ:
+		case HARKEN:
+		case VAIDA:
+			return true;
+		default:
+			return !allPlayableCharacters().contains(character);
+		}
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE7Character.Affinity.values().length];
@@ -2826,6 +2844,10 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		Set<Item> kit = Item.specialClassKit(classID, rng);
 		if (kit == null) { return new HashSet<GBAFEItem>(); }
 		return new HashSet<GBAFEItem>(kit);
+	}
+	
+	public Set<GBAFEItem> playerOnlyWeapons() {
+		return new HashSet<GBAFEItem>();
 	}
 	
 	public String statBoostStringForWeapon(GBAFEItem weapon) {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2491,6 +2491,20 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public GBAFECharacter nullCharacter() {
 		return Character.NONE;
 	}
+	
+	public boolean isEnemyAtAnyPoint(int characterID) {
+		Character character = Character.valueOf(characterID);
+		switch (character) {
+		case JOSHUA:
+		case AMELIA:
+		case MARISA:
+		case CORMAG:
+		case RENNAC:
+			return true;
+		default:
+			return !allPlayableCharacters().contains(character);
+		}
+	}
 
 	public int[] affinityValues() {
 		int[] values = new int[FE8Character.Affinity.values().length];
@@ -3050,6 +3064,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		Set<Item> kit = Item.specialClassKit(classID, rng);
 		if (kit == null) { return new HashSet<GBAFEItem>(); }
 		return new HashSet<GBAFEItem>(kit);
+	}
+	
+	public Set<GBAFEItem> playerOnlyWeapons() {
+		return new HashSet<GBAFEItem>();
 	}
 	
 	public String statBoostStringForWeapon(GBAFEItem weapon) {

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
@@ -35,6 +35,8 @@ public interface GBAFECharacterProvider {
 	public boolean isValidCharacter(GBAFECharacter character);
 	public GBAFECharacter nullCharacter();
 	
+	public boolean isEnemyAtAnyPoint(int characterID);
+	
 	public int[] affinityValues();
 	
 	public int canonicalID(int characterID);

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
@@ -114,6 +114,7 @@ public interface GBAFEItemProvider {
 	public Set<GBAFEItem> thiefItemsToRemove();
 	public Set<GBAFEItem> specialItemsToRetain();
 	public Set<GBAFEItem> itemKitForSpecialClass(int classID, Random rng);
+	public Set<GBAFEItem> playerOnlyWeapons();
 	
 	public String statBoostStringForWeapon(GBAFEItem weapon);
 	public String effectivenessStringForWeapon(GBAFEItem weapon, Boolean shortString);

--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -143,6 +143,10 @@ public class CharacterDataLoader {
 		return provider.characterWithID(characterID).canBuff();
 	}
 	
+	public boolean isEnemyAtAnyPoint(int characterID) {
+		return provider.isEnemyAtAnyPoint(characterID);
+	}
+	
 	public int[] validAffinityValues() {
 		return provider.affinityValues();
 	}

--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -128,7 +128,7 @@ public class ClassRandomizer {
 			
 			for (GBAFECharacterData linked : charactersData.linkedCharactersForCharacter(character)) {
 				determinedClasses.put(linked.getID(), targetClass);
-				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, classData, chapterData, itemData, textData, false, rng);
+				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, charactersData, classData, chapterData, itemData, textData, false, rng);
 				linked.setIsLord(isLordCharacter);
 			}
 		}
@@ -198,7 +198,7 @@ public class ClassRandomizer {
 			
 			for (GBAFECharacterData linked : charactersData.linkedCharactersForCharacter(character)) {
 				determinedClasses.put(linked.getID(), targetClass);
-				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, classData, chapterData, itemData, textData, forceBasicWeaponry && linked.getID() == character.getID(), rng);
+				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, charactersData, classData, chapterData, itemData, textData, forceBasicWeaponry && linked.getID() == character.getID(), rng);
 				if (shouldNerf) { // Halve skill, speed, defense, and resistance if we need to make sure he loses to us.
 					linked.setBaseSKL(linked.getBaseSKL() >> 1);
 					linked.setBaseSPD(linked.getBaseSPD() >> 1);
@@ -309,7 +309,7 @@ public class ClassRandomizer {
 		}
 	}
 
-	private static void updateCharacterToClass(ClassOptions classOptions, ItemAssignmentOptions inventoryOptions, GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass, Boolean ranged, Boolean melee, ClassDataLoader classData, ChapterLoader chapterData, ItemDataLoader itemData, TextLoader textData, Boolean forceBasicWeapons, Random rng) {
+	private static void updateCharacterToClass(ClassOptions classOptions, ItemAssignmentOptions inventoryOptions, GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass, Boolean ranged, Boolean melee, CharacterDataLoader charData, ClassDataLoader classData, ChapterLoader chapterData, ItemDataLoader itemData, TextLoader textData, Boolean forceBasicWeapons, Random rng) {
 		
 		character.prepareForClassRandomization();
 		character.setClassID(targetClass.getID());
@@ -337,7 +337,7 @@ public class ClassRandomizer {
 		for (GBAFEChapterData chapter : chapterData.allChapters()) {
 			GBAFEChapterItemData reward = chapter.chapterItemGivenToCharacter(character.getID());
 			if (reward != null) {
-				GBAFEItemData item = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
+				GBAFEItemData item = itemData.getRandomWeaponForCharacter(character, ranged, melee, false, rng);
 				reward.setItemID(item.getID());
 			}
 			
@@ -347,7 +347,7 @@ public class ClassRandomizer {
 						System.err.println("Class mismatch for character with ID " + character.getID() + ". Expected Class " + sourceClass.getID() + " but found " + chapterUnit.getStartingClass());
 					}
 					chapterUnit.setStartingClass(targetClass.getID());
-					validateCharacterInventory(inventoryOptions, character, targetClass, chapterUnit, ranged, melee, classData, itemData, textData, forceBasicWeapons, rng);
+					validateCharacterInventory(inventoryOptions, character, targetClass, chapterUnit, ranged, melee, charData, classData, itemData, textData, forceBasicWeapons, rng);
 					if (classData.isThief(sourceClass.getID())) {
 						validateFormerThiefInventory(chapterUnit, itemData);
 					}
@@ -658,7 +658,7 @@ public class ClassRandomizer {
 		if (!hasItems) { hasItems = item1 != null; }
 		if (item1 != null && (itemData.isWeapon(item1) || item1.getType() == WeaponType.STAFF)) {
 			if (!canCharacterUseItem(minionCharacter, item1, itemData)) {
-				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item1, true, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
 					replacementItem = null; // We'll handle this later.
 				}
@@ -681,7 +681,7 @@ public class ClassRandomizer {
 		if (!hasItems) { hasItems = item2 != null; }
 		if (item2 != null && (itemData.isWeapon(item2) || item2.getType() == WeaponType.STAFF)) {
 			if (!canCharacterUseItem(minionCharacter, item2, itemData)) {
-				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item2, true, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
 					replacementItem = null; // We'll handle this later.
 				}
@@ -704,7 +704,7 @@ public class ClassRandomizer {
 		if (!hasItems) { hasItems = item3 != null; }
 		if (item3 != null && (itemData.isWeapon(item3) || item3.getType() == WeaponType.STAFF)) {
 			if (!canCharacterUseItem(minionCharacter, item3, itemData)) {
-				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item3, true, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
 					replacementItem = null; // We'll handle this later.
 				}
@@ -727,7 +727,7 @@ public class ClassRandomizer {
 		if (!hasItems) { hasItems = item4 != null; }
 		if (item4 != null && (itemData.isWeapon(item4) || item4.getType() == WeaponType.STAFF)) {
 			if (!canCharacterUseItem(minionCharacter, item4, itemData)) {
-				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+				replacementItem = itemData.getSidegradeWeapon(minionCharacter, unitClass, item4, true, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 				if ((isHealer && limitStaves && hasStaff) && replacementItem.getType() == WeaponType.STAFF) {
 					replacementItem = null; // We'll handle this later.
 				}
@@ -772,7 +772,7 @@ public class ClassRandomizer {
 		}
 	}
 	
-	public static void validateCharacterInventory(ItemAssignmentOptions inventoryOptions, GBAFECharacterData character, GBAFEClassData charClass, GBAFEChapterUnitData chapterUnit, Boolean ranged, Boolean melee, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData, Boolean forceBasic, Random rng) {
+	public static void validateCharacterInventory(ItemAssignmentOptions inventoryOptions, GBAFECharacterData character, GBAFEClassData charClass, GBAFEChapterUnitData chapterUnit, Boolean ranged, Boolean melee, CharacterDataLoader charData, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData, Boolean forceBasic, Random rng) {
 		int item1ID = chapterUnit.getItem1();
 		GBAFEItemData item1 = itemData.itemWithID(item1ID);
 		int item2ID = chapterUnit.getItem2();
@@ -804,9 +804,9 @@ public class ClassRandomizer {
 				GBAFEItemData replacementItem = itemData.getBasicWeaponForCharacter(character, ranged, false, rng);
 				if (!forceBasic) {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE || ranged || melee) {
-						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
+						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, charData.isEnemyAtAnyPoint(character.getID()), rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, charClass, item1, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item1, charData.isEnemyAtAnyPoint(character.getID()), inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -834,9 +834,9 @@ public class ClassRandomizer {
 				GBAFEItemData replacementItem = itemData.getBasicWeaponForCharacter(character, ranged, false, rng);
 				if (!forceBasic) {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE || ranged || melee) {
-						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
+						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, charData.isEnemyAtAnyPoint(character.getID()), rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, charClass, item2, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item2, charData.isEnemyAtAnyPoint(character.getID()), inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -864,9 +864,9 @@ public class ClassRandomizer {
 				GBAFEItemData replacementItem = itemData.getBasicWeaponForCharacter(character, ranged, false, rng);
 				if (!forceBasic) {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE || ranged || melee) {
-						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
+						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, charData.isEnemyAtAnyPoint(character.getID()), rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, charClass, item3, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item3, charData.isEnemyAtAnyPoint(character.getID()), inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				
@@ -894,9 +894,9 @@ public class ClassRandomizer {
 				GBAFEItemData replacementItem = itemData.getBasicWeaponForCharacter(character, ranged, false, rng);
 				if (!forceBasic) {
 					if (inventoryOptions.weaponPolicy == WeaponReplacementPolicy.ANY_USABLE || ranged || melee) {
-						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, rng);
+						replacementItem = itemData.getRandomWeaponForCharacter(character, ranged, melee, charData.isEnemyAtAnyPoint(character.getID()), rng);
 					} else {
-						replacementItem = itemData.getSidegradeWeapon(character, charClass, item4, inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
+						replacementItem = itemData.getSidegradeWeapon(character, charClass, item4, charData.isEnemyAtAnyPoint(character.getID()), inventoryOptions.weaponPolicy == WeaponReplacementPolicy.STRICT, rng);
 					}
 				}
 				

--- a/Universal FE Randomizer/src/random/gba/randomizer/EnemyBuffer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/EnemyBuffer.java
@@ -2,7 +2,9 @@ package random.gba.randomizer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import fedata.gba.GBAFEChapterData;
 import fedata.gba.GBAFEChapterUnitData;
@@ -203,6 +205,8 @@ public class EnemyBuffer {
 			items.addAll(Arrays.asList(classWeapons));
 		}
 		
-		return items.toArray(new GBAFEItemData[items.size()]);
+		List<GBAFEItemData> filteredList = items.stream().filter(item -> (!itemData.isPlayerOnly(item.getID()))).collect(Collectors.toList());
+		
+		return filteredList.toArray(new GBAFEItemData[filteredList.size()]);
 	}
 }

--- a/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
@@ -845,7 +845,7 @@ public class RecruitmentRandomizer {
 		for (GBAFEChapterData chapter : chapterData.allChapters()) {
 			GBAFEChapterItemData reward = chapter.chapterItemGivenToCharacter(slot.getID());
 			if (reward != null) {
-				GBAFEItemData item = itemData.getRandomWeaponForCharacter(slot, false, false, rng);
+				GBAFEItemData item = itemData.getRandomWeaponForCharacter(slot, false, false, characterData.isEnemyAtAnyPoint(slot.getID()), rng);
 				reward.setItemID(item.getID());
 			}
 			
@@ -854,7 +854,7 @@ public class RecruitmentRandomizer {
 					unit.setStartingClass(targetClass.getID());
 					
 					// Set Inventory.
-					ClassRandomizer.validateCharacterInventory(inventoryOptions, slot, targetClass, unit, characterData.characterIDRequiresRange(slot.getID()), characterData.characterIDRequiresMelee(slot.getID()), classData, itemData, textData, false, rng);
+					ClassRandomizer.validateCharacterInventory(inventoryOptions, slot, targetClass, unit, characterData.characterIDRequiresRange(slot.getID()), characterData.characterIDRequiresMelee(slot.getID()), characterData, classData, itemData, textData, false, rng);
 					if (characterData.isThiefCharacterID(slot.getID())) {
 						ClassRandomizer.validateFormerThiefInventory(unit, itemData);
 					}


### PR DESCRIPTION
Fixed #185 - Added a way to restrict GBA weapons to being player only and added FE6 staves to the player only list. This mechanism exists for all of the GBA games, but only FE6 has weapons (more accurately, staves) added.