### PR TITLE
[Issue #189] Updated boss weapon ranks logic when randomizing boss classes

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -128,7 +128,7 @@ public class ClassRandomizer {
 			
 			for (GBAFECharacterData linked : charactersData.linkedCharactersForCharacter(character)) {
 				determinedClasses.put(linked.getID(), targetClass);
-				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, classData, chapterData, itemData, textData, false, rng);
+				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, charactersData, classData, chapterData, itemData, textData, false, rng);
 				linked.setIsLord(isLordCharacter);
 			}
 		}
@@ -198,7 +198,7 @@ public class ClassRandomizer {
 			
 			for (GBAFECharacterData linked : charactersData.linkedCharactersForCharacter(character)) {
 				determinedClasses.put(linked.getID(), targetClass);
-				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, classData, chapterData, itemData, textData, forceBasicWeaponry && linked.getID() == character.getID(), rng);
+				updateCharacterToClass(options, inventoryOptions, linked, originalClass, targetClass, characterRequiresRange, characterRequiresMelee, charactersData, classData, chapterData, itemData, textData, forceBasicWeaponry && linked.getID() == character.getID(), rng);
 				if (shouldNerf) { // Halve skill, speed, defense, and resistance if we need to make sure he loses to us.
 					linked.setBaseSKL(linked.getBaseSKL() >> 1);
 					linked.setBaseSPD(linked.getBaseSPD() >> 1);
@@ -309,11 +309,15 @@ public class ClassRandomizer {
 		}
 	}
 
-	private static void updateCharacterToClass(ClassOptions classOptions, ItemAssignmentOptions inventoryOptions, GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass, Boolean ranged, Boolean melee, ClassDataLoader classData, ChapterLoader chapterData, ItemDataLoader itemData, TextLoader textData, Boolean forceBasicWeapons, Random rng) {
+	private static void updateCharacterToClass(ClassOptions classOptions, ItemAssignmentOptions inventoryOptions, GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass, Boolean ranged, Boolean melee, CharacterDataLoader charData, ClassDataLoader classData, ChapterLoader chapterData, ItemDataLoader itemData, TextLoader textData, Boolean forceBasicWeapons, Random rng) {
 		
 		character.prepareForClassRandomization();
 		character.setClassID(targetClass.getID());
-		transferWeaponLevels(character, sourceClass, targetClass, rng);
+		if (charData.isBossCharacterID(character.getID())) {
+			transferBossWeaponLevels(character, sourceClass, targetClass);
+		} else {
+			transferWeaponLevels(character, sourceClass, targetClass, rng);
+		}
 		switch (classOptions.basesTransfer) {
 		case ADJUST_TO_MATCH:
 			applyBaseCorrectionForCharacter(character, sourceClass, targetClass);
@@ -966,6 +970,40 @@ public class ClassRandomizer {
 		}
 		
 		return false;
+	}
+	
+	private static void transferBossWeaponLevels(GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass) {
+		int highestRank = 0;
+		// Start with the class defaults.
+		if (sourceClass.getSwordRank() > highestRank) { highestRank = sourceClass.getSwordRank(); }
+		if (sourceClass.getLanceRank() > highestRank) { highestRank = sourceClass.getLanceRank(); }
+		if (sourceClass.getAxeRank() > highestRank) { highestRank = sourceClass.getAxeRank(); }
+		if (sourceClass.getBowRank() > highestRank) { highestRank = sourceClass.getBowRank(); }
+		if (sourceClass.getAnimaRank() > highestRank) { highestRank = sourceClass.getAnimaRank(); }
+		if (sourceClass.getLightRank() > highestRank) { highestRank = sourceClass.getLightRank(); }
+		if (sourceClass.getDarkRank() > highestRank) { highestRank = sourceClass.getDarkRank(); }
+		if (sourceClass.getStaffRank() > highestRank) { highestRank = sourceClass.getStaffRank(); }
+		
+		// Overwrite with character values if they exist.
+		if (character.getSwordRank() > highestRank) { highestRank = character.getSwordRank(); }
+		if (character.getLanceRank() > highestRank) { highestRank = character.getLanceRank(); }
+		if (character.getAxeRank() > highestRank) { highestRank = character.getAxeRank(); }
+		if (character.getBowRank() > highestRank) { highestRank = character.getBowRank(); }
+		if (character.getAnimaRank() > highestRank) { highestRank = character.getAnimaRank(); }
+		if (character.getLightRank() > highestRank) { highestRank = character.getLightRank(); }
+		if (character.getDarkRank() > highestRank) { highestRank = character.getDarkRank(); }
+		if (character.getStaffRank() > highestRank) { highestRank = character.getStaffRank(); }
+		
+		// Bosses should just have all of their ranks set to the highest rank they normally have.
+		// This greatly simplifies weapon assignment.
+		if (targetClass.getSwordRank() > 0) { character.setSwordRank(highestRank); } else { character.setSwordRank(0); }
+		if (targetClass.getLanceRank() > 0) { character.setLanceRank(highestRank); } else { character.setLanceRank(0); }
+		if (targetClass.getAxeRank() > 0) { character.setAxeRank(highestRank); } else { character.setAxeRank(0); }
+		if (targetClass.getBowRank() > 0) { character.setBowRank(highestRank); } else { character.setBowRank(0); }
+		if (targetClass.getAnimaRank() > 0) { character.setAnimaRank(highestRank); } else { character.setAnimaRank(0); }
+		if (targetClass.getLightRank() > 0) { character.setLightRank(highestRank); } else { character.setLightRank(0); }
+		if (targetClass.getDarkRank() > 0) { character.setDarkRank(highestRank); } else { character.setDarkRank(0); }
+		if (targetClass.getStaffRank() > 0) { character.setStaffRank(highestRank); } else { character.setStaffRank(0); }
 	}
 	
 	private static void transferWeaponLevels(GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass, Random rng) {


### PR DESCRIPTION
Fixed #189 - Updated logic when randomizing bosses to ensure they default to the highest rank they normally have for all weapons. This simplifies weapon assignment and makes sure that they can use the any sidegrade weapon. For example, Cameron is normally a Paladin with B swords, B Lances, and C axes. If he were to change to a Falconknight, he previously would have B rank in one of the weapons and C rank in the other. With this change, he now would have B rank in both, preventing the possibility of him receiving a weapon that he cannot use.