### PR TITLE
[Issue #167] Fixed null affinities

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1820,9 +1820,9 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public int[] affinityValues() {
-		int[] values = new int[FE6Character.Affinity.values().length];
+		int[] values = new int[FE6Character.Affinity.validAffinities().length];
 		int i = 0;
-		for (FE6Character.Affinity affinity : FE6Character.Affinity.values()) {
+		for (FE6Character.Affinity affinity : FE6Character.Affinity.validAffinities()) {
 			values[i++] = affinity.value;
 		}
 		

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2334,9 +2334,9 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public int[] affinityValues() {
-		int[] values = new int[FE7Character.Affinity.values().length];
+		int[] values = new int[FE7Character.Affinity.validAffinities().length];
 		int i = 0;
-		for (FE7Character.Affinity affinity : FE7Character.Affinity.values()) {
+		for (FE7Character.Affinity affinity : FE7Character.Affinity.validAffinities()) {
 			values[i++] = affinity.value;
 		}
 		

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2493,9 +2493,9 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public int[] affinityValues() {
-		int[] values = new int[FE8Character.Affinity.values().length];
+		int[] values = new int[FE8Character.Affinity.validAffinities().length];
 		int i = 0;
-		for (FE8Character.Affinity affinity : FE8Character.Affinity.values()) {
+		for (FE8Character.Affinity affinity : FE8Character.Affinity.validAffinities()) {
 			values[i++] = affinity.value;
 		}
 		


### PR DESCRIPTION
Fixed #167 - Fixed an issue where "NONE" was considered a valid affinity. If this was assigned to a playable character with a support level, it will use garbage data to determine the bonuses, usually resulting in hilarious results.