### PR TITLE
[Issue #176] Reduced maximum durability for GBAFE

### DIFF
--- a/Universal FE Randomizer/src/ui/WeaponsView.java
+++ b/Universal FE Randomizer/src/ui/WeaponsView.java
@@ -290,8 +290,8 @@ public class WeaponsView extends Composite {
 
 		durabilityRangeControl = new MinMaxControl(durabilityParamContainer, SWT.NONE, "Min Uses:", "Max Uses:");
 
-		durabilityRangeControl.getMinSpinner().setValues(15, 1, 99, 0, 1, 5);
-		durabilityRangeControl.getMaxSpinner().setValues(60, 1, 99, 0, 1, 5);
+		durabilityRangeControl.getMinSpinner().setValues(15, 1, 63, 0, 1, 5);
+		durabilityRangeControl.getMaxSpinner().setValues(60, 1, 63, 0, 1, 5);
 		durabilityRangeControl.setEnabled(false);
 
 		FormData durabilityRangeControlData = new FormData();


### PR DESCRIPTION
Fixed #176 - Updated the maximum weapon durability selectable for GBAFE to be 63. This is due to a limitation of the save format for GBAFE games. They seem to only use 6 bits to save durability information for weapons in the save data. This means that any weapon that attempts to save its durability will have its most significant 2 bits cut off. Based on empirical testing, 6 bits seems to be saved, as a 99 durability weapon, when saved, will load as having 35 durability. (99 is 0x63 in hex. If you truncate the two most significant bits, you get 0x23, which is 35 in decimal.)