### PR TITLE
[Issue #165] Fixing palettes. Again.

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2106,13 +2106,13 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7, 8}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
 					break;
 				case EIRIKA_MASTER_LORD:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7, 8}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
 					break;
 				case EPHRAIM_LORD:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7, 8}, new int[] {}, new int[] {9, 10}, new int[] {12, 13, 14});
 					break;
 				case EPHRAIM_MASTER_LORD:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {}, new int[] {8, 9}, new int[] {13, 14});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {}, new int[] {9, 10}, new int[] {});
 					break;
 				case TRAINEE:
 				case TRAINEE_2:
@@ -2212,7 +2212,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 3, 9, 5, 10, 11}, new int[] {});
 					break;
 				case PALADIN:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {}, new int[] {8, 9, 10, 11}, new int[] {7}, new int[] {5, 3, 4}); // Secondary is shield (which is blended with white). Tertiary is mane + shield crest.
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {}, new int[] {8, 9, 10, 11}, new int[] {6, 7}, new int[] {5, 3, 4}); // Secondary is shield (which is blended with white). Tertiary is mane + shield crest.
 					break;
 				case PALADIN_F:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 9, 10}, new int[] {5, 3, 4}); // Hair also affects shield. Secondary is mane + shield crest.

--- a/Universal FE Randomizer/src/fedata/gba/general/PaletteColor.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/PaletteColor.java
@@ -73,34 +73,35 @@ public class PaletteColor implements Comparable<PaletteColor> {
 	
 	public static PaletteColor[] coerceColors(PaletteColor[] colors, int numberOfColors) {
 		if (numberOfColors == 0) { return new PaletteColor[] {}; }
-		if (colors.length == numberOfColors) { return colors; }
-		else if (colors.length > numberOfColors) {
-			// Remove dupes first, if any.
-			List<PaletteColor> colorsArray = new ArrayList<PaletteColor>();
-			Set<String> uniqueColors = new HashSet<String>();
-			for (PaletteColor color : colors) {
-				if (uniqueColors.contains(color.toHexString())) { continue; }
-				uniqueColors.add(color.toHexString());
-				colorsArray.add(color);
-			}
-			
+		
+		// Remove dupes first, if any.
+		List<PaletteColor> colorsArray = new ArrayList<PaletteColor>();
+		Set<String> uniqueColors = new HashSet<String>();
+		for (PaletteColor color : colors) {
+			if (uniqueColors.contains(color.toHexString())) { continue; }
+			uniqueColors.add(color.toHexString());
+			colorsArray.add(color);
+		}
+					
+		if (colorsArray.size() == numberOfColors) { return colorsArray.toArray(new PaletteColor[colorsArray.size()]); }
+		else if (colorsArray.size() > numberOfColors) {
 			PaletteColor[] uniqueColorArray = colorsArray.toArray(new PaletteColor[colorsArray.size()]);
 			if (colorsArray.size() == numberOfColors) { return uniqueColorArray; }
 			else if (colorsArray.size() > numberOfColors) { return reduceColors(uniqueColorArray, numberOfColors); }
 			else { 
 				if (colorsArray.isEmpty()) { return new PaletteColor[] {}; }
 				else if (colorsArray.size() == 1) {
-					if (colors[0].brightness > 0.5) { return interpolateColors(new PaletteColor[] {colors[0], darkerColor(colors[0])}, numberOfColors); }
-					else { return interpolateColors(new PaletteColor[] {lighterColor(colors[0]), colors[0]}, numberOfColors); }
+					if (colorsArray.get(0).brightness > 0.5) { return interpolateColors(new PaletteColor[] {colorsArray.get(0), darkerColor(colorsArray.get(0))}, numberOfColors); }
+					else { return interpolateColors(new PaletteColor[] {lighterColor(colorsArray.get(0)), colorsArray.get(0)}, numberOfColors); }
 				} else { return interpolateColors(uniqueColorArray, numberOfColors); }
 			}
 		}
 		else { // (colors.length < numberOfColors) 
-			if (colors.length == 1) { 
-				if (colors[0].brightness > 0.5) { return interpolateColors(new PaletteColor[] {colors[0], darkerColor(colors[0])}, numberOfColors); }
-				else { return interpolateColors(new PaletteColor[] {lighterColor(colors[0]), colors[0]}, numberOfColors); }
+			if (colorsArray.size() == 1) { 
+				if (colorsArray.get(0).brightness > 0.5) { return interpolateColors(new PaletteColor[] {colorsArray.get(0), darkerColor(colorsArray.get(0))}, numberOfColors); }
+				else { return interpolateColors(new PaletteColor[] {lighterColor(colorsArray.get(0)), colorsArray.get(0)}, numberOfColors); }
 			}
-			else { return interpolateColors(colors, numberOfColors); }
+			else { return interpolateColors(colorsArray.toArray(new PaletteColor[colorsArray.size()]), numberOfColors); }
 		}
 	}
 	

--- a/Universal FE Randomizer/src/fedata/gba/general/PaletteV2.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/PaletteV2.java
@@ -103,6 +103,18 @@ public class PaletteV2 {
 		identifier = other.identifier;
 	}
 	
+	public int getNumColors() {
+		return 16;
+	}
+	
+	public PaletteColor colorAtIndex(int index, PaletteType type) {
+		return colorArray[index].getColor(type);
+	}
+	
+	public int getClassID() {
+		return info.classID;
+	}
+	
 	public void overrideOffset(long newOffset) {
 		destinationOffset = newOffset;
 	}

--- a/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import fedata.gba.GBAFECharacterData;
+import fedata.gba.GBAFEClassData;
 import fedata.gba.fe6.FE6Data;
 import fedata.gba.fe7.FE7Data;
 import fedata.gba.fe8.FE8Data;
@@ -26,17 +27,12 @@ import util.Diff;
 import util.DiffCompiler;
 import util.FreeSpaceManager;
 import util.WhyDoesJavaNotHaveThese;
+import util.recordkeeper.RecordKeeper;
 
 public class PaletteLoader {
 	private FEBase.GameType gameType;
 	
-	private static class PaletteEntry {
-		private PaletteV2 unpromotedPalette;
-		private PaletteV2 promotedPalette;
-	}
-	
 	// V2
-	private Map<Integer, PaletteEntry> characterPalettesV2 = new HashMap<Integer, PaletteEntry>(); // FE6 and FE7 only.
 	private Map<Integer, PaletteV2> templatesV2 = new HashMap<Integer, PaletteV2>();
 	private Map<Integer, PaletteV2> paletteByPaletteIDV2 = new HashMap<Integer, PaletteV2>();
 	
@@ -63,10 +59,8 @@ public class PaletteLoader {
 		case FE6:
 			for (FE6Data.Character character : FE6Data.Character.allPlayableCharacters) {
 				int charID = FE6Data.Character.canonicalIDForCharacterID(character.ID);
-				PaletteEntry paletteEntry = new PaletteEntry();
 				Map<Integer, PaletteV2> referenceMap = new HashMap<Integer, PaletteV2>();
 				referencePalettesV2.put(charID, referenceMap);
-				characterPalettesV2.put(charID, paletteEntry);
 				PaletteColor[] supplementalHair = FE6Data.Palette.supplementaryHairColorForCharacter(charID);
 				if (supplementalHair != null) {
 					supplementalHairColors.put(charID, supplementalHair);
@@ -75,8 +69,6 @@ public class PaletteLoader {
 					int classID = paletteInfo.getClassID();
 					PaletteV2 palette = new PaletteV2(handler, paletteInfo);
 					paletteByPaletteIDV2.put(paletteInfo.getPaletteID(), palette);
-					if (classData.isPromotedClass(classID)) { paletteEntry.promotedPalette = palette; }
-					else { paletteEntry.unpromotedPalette = palette; }
 					referenceMap.put(classID, new PaletteV2(handler, paletteInfo));
 					FE6Data.CharacterClass fe6class = FE6Data.CharacterClass.valueOf(classID);
 					FE6Data.Character fe6char = FE6Data.Character.valueOf(charID);
@@ -85,10 +77,8 @@ public class PaletteLoader {
 			}
 			for (FE6Data.Character boss : FE6Data.Character.allBossCharacters) {
 				int charID = FE6Data.Character.canonicalIDForCharacterID(boss.ID);
-				PaletteEntry paletteEntry = new PaletteEntry();
 				Map<Integer, PaletteV2> referenceMap = new HashMap<Integer, PaletteV2>();
 				referencePalettesV2.put(charID, referenceMap);
-				characterPalettesV2.put(charID, paletteEntry);
 				PaletteColor[] supplementalHair = FE6Data.Palette.supplementaryHairColorForCharacter(charID);
 				if (supplementalHair != null) {
 					supplementalHairColors.put(charID, supplementalHair);
@@ -97,8 +87,6 @@ public class PaletteLoader {
 					int classID = paletteInfo.getClassID();
 					PaletteV2 palette = new PaletteV2(handler, paletteInfo);
 					paletteByPaletteIDV2.put(paletteInfo.getPaletteID(), palette);
-					if (classData.isPromotedClass(classID)) { paletteEntry.promotedPalette = palette; }
-					else { paletteEntry.unpromotedPalette = palette; }
 					referenceMap.put(classID, new PaletteV2(handler, paletteInfo));
 					FE6Data.Character fe6char = FE6Data.Character.valueOf(charID);
 					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Initializing Boss 0x" + Integer.toHexString(charID) + " (" + fe6char.toString() + ")" + " with palette at offset 0x" + Long.toHexString(paletteInfo.getOffset()));
@@ -123,10 +111,8 @@ public class PaletteLoader {
 		case FE7:
 			for (FE7Data.Character character : FE7Data.Character.allPlayableCharacters) {
 				int charID = FE7Data.Character.canonicalIDForCharacterID(character.ID);
-				PaletteEntry paletteEntry = new PaletteEntry();
 				Map<Integer, PaletteV2> referenceMap = new HashMap<Integer, PaletteV2>();
 				referencePalettesV2.put(charID, referenceMap);
-				characterPalettesV2.put(charID, paletteEntry);
 				PaletteColor[] supplementalHair = FE7Data.Palette.supplementaryHairColorForCharacter(charID);
 				if (supplementalHair != null) {
 					supplementalHairColors.put(charID, supplementalHair);
@@ -135,8 +121,6 @@ public class PaletteLoader {
 					int classID = paletteInfo.getClassID();
 					PaletteV2 palette = new PaletteV2(handler, paletteInfo);
 					paletteByPaletteIDV2.put(paletteInfo.getPaletteID(), palette);
-					if (classData.isPromotedClass(classID)) { paletteEntry.promotedPalette = palette; }
-					else { paletteEntry.unpromotedPalette = palette; }
 					referenceMap.put(classID, new PaletteV2(handler, paletteInfo));
 					FE7Data.CharacterClass fe7class = FE7Data.CharacterClass.valueOf(classID);
 					FE7Data.Character fe7char = FE7Data.Character.valueOf(charID);
@@ -145,10 +129,8 @@ public class PaletteLoader {
 			}
 			for (FE7Data.Character boss : FE7Data.Character.allBossCharacters) {
 				int charID = FE7Data.Character.canonicalIDForCharacterID(boss.ID);
-				PaletteEntry paletteEntry = new PaletteEntry();
 				Map<Integer, PaletteV2> referenceMap = new HashMap<Integer, PaletteV2>();
 				referencePalettesV2.put(charID, referenceMap);
-				characterPalettesV2.put(charID, paletteEntry);
 				PaletteColor[] supplementalHair = FE7Data.Palette.supplementaryHairColorForCharacter(charID);
 				if (supplementalHair != null) {
 					supplementalHairColors.put(charID, supplementalHair);
@@ -157,8 +139,6 @@ public class PaletteLoader {
 					int classID = paletteInfo.getClassID();
 					PaletteV2 palette = new PaletteV2(handler, paletteInfo);
 					paletteByPaletteIDV2.put(paletteInfo.getPaletteID(), palette);
-					if (classData.isPromotedClass(classID)) { paletteEntry.promotedPalette = palette; }
-					else { paletteEntry.unpromotedPalette = palette; }
 					referenceMap.put(classID, new PaletteV2(handler, paletteInfo));
 					FE7Data.Character fe7char = FE7Data.Character.valueOf(charID);
 					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Initializing Boss 0x" + Integer.toHexString(charID) + " (" + fe7char.toString() + ")" + " with palette at offset 0x" + Long.toHexString(paletteInfo.getOffset()));
@@ -312,64 +292,75 @@ public class PaletteLoader {
 		PaletteColor[] supplementalHair = FE8Data.Palette.supplementaryHairColorForCharacter(referenceID);
 		
 		if (willBecomeTrainee) {
-			int base1 = newPromotion1;
-			int base2 = newPromotion2;
-			int promoted1 = fe8Promotions.getFirstPromotionOptionClassID(newPromotion1);
-			int promoted2 = fe8Promotions.getSecondPromotionOptionClassID(newPromotion1);
-			int promoted3 = fe8Promotions.getFirstPromotionOptionClassID(newPromotion2);
-			int promoted4 = fe8Promotions.getSecondPromotionOptionClassID(newPromotion2);
-			
-			// Adapt every palette over as is.
-			PaletteV2 adaptedTrainee = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			PaletteV2 adaptedBase1 = v2PaletteForClass(base1, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			PaletteV2 adaptedBase2 = v2PaletteForClass(base2, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			PaletteV2 adaptedPromoted1 = v2PaletteForClass(promoted1, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			PaletteV2 adaptedPromoted2 = v2PaletteForClass(promoted2, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			PaletteV2 adaptedPromoted3 = v2PaletteForClass(promoted3, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			PaletteV2 adaptedPromoted4 = v2PaletteForClass(promoted4, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			
-			fe8Mapper.setTraineeClass(newClassID, charID,
-					adaptedTrainee.getCompressedData().length,
-					adaptedBase1.getCompressedData().length,
-					adaptedBase2.getCompressedData().length,
-					adaptedPromoted1.getCompressedData().length,
-					adaptedPromoted2.getCompressedData().length,
-					adaptedPromoted3.getCompressedData().length,
-					adaptedPromoted4.getCompressedData().length);
-			
-			integrateFE8PaletteIfPossible(charID, adaptedTrainee, SlotType.TRAINEE);
-			integrateFE8PaletteIfPossible(charID, adaptedBase1, SlotType.PRIMARY_BASE);
-			integrateFE8PaletteIfPossible(charID, adaptedBase2, SlotType.SECONDARY_BASE);
-			integrateFE8PaletteIfPossible(charID, adaptedPromoted1, SlotType.FIRST_PROMOTION);
-			integrateFE8PaletteIfPossible(charID, adaptedPromoted2, SlotType.SECOND_PROMOTION);
-			integrateFE8PaletteIfPossible(charID, adaptedPromoted3, SlotType.THIRD_PROMOTION);
-			integrateFE8PaletteIfPossible(charID, adaptedPromoted4, SlotType.FOURTH_PROMOTION);
-			
-		} else if (!newClassIsPromoted) {
-			if (newClassHasPromotions && !isBoss) {
-				int promoted1 = newPromotion1;
-				int promoted2 = newPromotion2;
-				PaletteV2 adaptedBase = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-				PaletteV2 adaptedPromotion1 = v2PaletteForClass(promoted1, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-				PaletteV2 adaptedPromotion2 = promoted2 != 0 ? v2PaletteForClass(promoted2, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair) : null;
-				
-				fe8Mapper.setUnpromotedClass(newClassID, charID, !isBoss,
-						adaptedBase.getCompressedData().length,
-						adaptedPromotion1.getCompressedData().length,
-						adaptedPromotion2 != null ? adaptedPromotion2.getCompressedData().length : 0);
-				
-				integrateFE8PaletteIfPossible(charID, adaptedBase, SlotType.PRIMARY_BASE);
-				integrateFE8PaletteIfPossible(charID, adaptedPromotion1, SlotType.FIRST_PROMOTION);
-				if (adaptedPromotion2 != null) { integrateFE8PaletteIfPossible(charID, adaptedPromotion2, SlotType.SECOND_PROMOTION); }		
+			if (fe8Mapper.classIDMappedToCharacterForType(charID, SlotType.TRAINEE) == newClassID) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Same trainee class found. Skipping palette replacement.");
 			} else {
-				PaletteV2 adaptedBase = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-				fe8Mapper.setUnpromotedClass(newClassID, charID, !isBoss, adaptedBase.getCompressedData().length, 0, 0);
-				integrateFE8PaletteIfPossible(charID, adaptedBase, SlotType.PRIMARY_BASE);
+				int base1 = newPromotion1;
+				int base2 = newPromotion2;
+				int promoted1 = fe8Promotions.getFirstPromotionOptionClassID(newPromotion1);
+				int promoted2 = fe8Promotions.getSecondPromotionOptionClassID(newPromotion1);
+				int promoted3 = fe8Promotions.getFirstPromotionOptionClassID(newPromotion2);
+				int promoted4 = fe8Promotions.getSecondPromotionOptionClassID(newPromotion2);
+				
+				// Adapt every palette over as is.
+				PaletteV2 adaptedTrainee = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				PaletteV2 adaptedBase1 = v2PaletteForClass(base1, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				PaletteV2 adaptedBase2 = v2PaletteForClass(base2, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				PaletteV2 adaptedPromoted1 = v2PaletteForClass(promoted1, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				PaletteV2 adaptedPromoted2 = v2PaletteForClass(promoted2, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				PaletteV2 adaptedPromoted3 = v2PaletteForClass(promoted3, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				PaletteV2 adaptedPromoted4 = v2PaletteForClass(promoted4, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				
+				fe8Mapper.setTraineeClass(newClassID, charID,
+						adaptedTrainee.getCompressedData().length,
+						adaptedBase1.getCompressedData().length,
+						adaptedBase2.getCompressedData().length,
+						adaptedPromoted1.getCompressedData().length,
+						adaptedPromoted2.getCompressedData().length,
+						adaptedPromoted3.getCompressedData().length,
+						adaptedPromoted4.getCompressedData().length);
+				
+				integrateFE8PaletteIfPossible(charID, adaptedTrainee, SlotType.TRAINEE);
+				integrateFE8PaletteIfPossible(charID, adaptedBase1, SlotType.PRIMARY_BASE);
+				integrateFE8PaletteIfPossible(charID, adaptedBase2, SlotType.SECONDARY_BASE);
+				integrateFE8PaletteIfPossible(charID, adaptedPromoted1, SlotType.FIRST_PROMOTION);
+				integrateFE8PaletteIfPossible(charID, adaptedPromoted2, SlotType.SECOND_PROMOTION);
+				integrateFE8PaletteIfPossible(charID, adaptedPromoted3, SlotType.THIRD_PROMOTION);
+				integrateFE8PaletteIfPossible(charID, adaptedPromoted4, SlotType.FOURTH_PROMOTION);
+			}
+		} else if (!newClassIsPromoted) {
+			if (fe8Mapper.classIDMappedToCharacterForType(charID, SlotType.PRIMARY_BASE) == newClassID) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Same base class found. Skipping palette replacement.");
+			} else {
+				if (newClassHasPromotions && !isBoss) {
+					int promoted1 = newPromotion1;
+					int promoted2 = newPromotion2;
+					PaletteV2 adaptedBase = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+					PaletteV2 adaptedPromotion1 = v2PaletteForClass(promoted1, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+					PaletteV2 adaptedPromotion2 = promoted2 != 0 ? v2PaletteForClass(promoted2, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair) : null;
+					
+					fe8Mapper.setUnpromotedClass(newClassID, charID, !isBoss,
+							adaptedBase.getCompressedData().length,
+							adaptedPromotion1.getCompressedData().length,
+							adaptedPromotion2 != null ? adaptedPromotion2.getCompressedData().length : 0);
+					
+					integrateFE8PaletteIfPossible(charID, adaptedBase, SlotType.PRIMARY_BASE);
+					integrateFE8PaletteIfPossible(charID, adaptedPromotion1, SlotType.FIRST_PROMOTION);
+					if (adaptedPromotion2 != null) { integrateFE8PaletteIfPossible(charID, adaptedPromotion2, SlotType.SECOND_PROMOTION); }
+				} else {
+					PaletteV2 adaptedBase = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+					fe8Mapper.setUnpromotedClass(newClassID, charID, !isBoss, adaptedBase.getCompressedData().length, 0, 0);
+					integrateFE8PaletteIfPossible(charID, adaptedBase, SlotType.PRIMARY_BASE);
+				}
 			}
 		} else { // New class is promoted
-			PaletteV2 adaptedPromotion = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
-			fe8Mapper.setPromotedClass(newClassID, charID, adaptedPromotion.getCompressedData().length);
-			integrateFE8PaletteIfPossible(charID, adaptedPromotion, SlotType.FIRST_PROMOTION);
+			if (fe8Mapper.classIDMappedToCharacterForType(charID, SlotType.FIRST_PROMOTION) == newClassID) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Same Promoted class found. Skipping palette replacement.");
+			} else {
+				PaletteV2 adaptedPromotion = v2PaletteForClass(newClassID, referencePalettes, isBoss ? PaletteType.ENEMY : PaletteType.PLAYER, supplementalHair);
+				fe8Mapper.setPromotedClass(newClassID, charID, adaptedPromotion.getCompressedData().length);
+				integrateFE8PaletteIfPossible(charID, adaptedPromotion, SlotType.FIRST_PROMOTION);
+			}
 		}
 	}
 	
@@ -444,27 +435,52 @@ public class PaletteLoader {
 		}
 		
 		if (isPromoted) {
-			PaletteV2 adaptedPromotion = v2PaletteForClass(targetClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
-			mapper.setCharacterToPromotedClass(characterID, targetClassID, adaptedPromotion.getCompressedData().length);
-			adaptedPromotion.setIdentifier(character.getPromotedPaletteIndex());
-			change.promotedPalette = adaptedPromotion;
+			int originalPaletteIndex = character.getPromotedPaletteIndex();
+			PaletteV2 originalPalette = paletteByPaletteIDV2.get(originalPaletteIndex);
+			if (originalPalette != null && originalPalette.getClassID() == targetClassID) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Same promoted class found. Skipping adapting palette.");
+			} else {
+				PaletteV2 adaptedPromotion = v2PaletteForClass(targetClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
+				mapper.setCharacterToPromotedClass(characterID, targetClassID, adaptedPromotion.getCompressedData().length);
+				adaptedPromotion.setIdentifier(character.getPromotedPaletteIndex());
+				change.promotedPalette = adaptedPromotion;
+			}
 		} else if (!canPromote) {
-			PaletteV2 adaptedBase = v2PaletteForClass(targetClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
-			mapper.setCharacterToUnpromotedOnlyClass(characterID, targetClassID, adaptedBase.getCompressedData().length);
-			adaptedBase.setIdentifier(character.getUnpromotedPaletteIndex());
-			change.basePalette = adaptedBase;
+			int originalPaletteIndex = character.getUnpromotedPaletteIndex();
+			PaletteV2 originalPalette = paletteByPaletteIDV2.get(originalPaletteIndex);
+			if (originalPalette != null && originalPalette.getClassID() == targetClassID) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Same unpromoted class found. Skipping adapting palette.");
+			} else {
+				PaletteV2 adaptedBase = v2PaletteForClass(targetClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
+				mapper.setCharacterToUnpromotedOnlyClass(characterID, targetClassID, adaptedBase.getCompressedData().length);
+				adaptedBase.setIdentifier(character.getUnpromotedPaletteIndex());
+				change.basePalette = adaptedBase;
+			}
 		} else {
-			PaletteV2 adaptedBase = v2PaletteForClass(targetClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
+			int unpromotedPaletteIndex = character.getUnpromotedPaletteIndex();
+			int promotedPaletteIndex = character.getPromotedPaletteIndex();
+			PaletteV2 unpromotedPalette = paletteByPaletteIDV2.get(unpromotedPaletteIndex);
+			PaletteV2 promotedPalette = paletteByPaletteIDV2.get(promotedPaletteIndex);
+			
 			int promotedClassID = classData.classForID(targetClassID).getTargetPromotionID();
-			PaletteV2 adaptedPromotion = v2PaletteForClass(promotedClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
-			mapper.setCharacterToUnpromotedClass(characterID, targetClassID, adaptedBase.getCompressedData().length, adaptedPromotion.getCompressedData().length);
-			adaptedBase.setIdentifier(character.getUnpromotedPaletteIndex());
-			adaptedPromotion.setIdentifier(character.getPromotedPaletteIndex());
-			change.basePalette = adaptedBase;
-			change.promotedPalette = adaptedPromotion;
+			
+			if ((unpromotedPalette != null && unpromotedPalette.getClassID() == targetClassID) ||
+					(promotedPalette != null && promotedPalette.getClassID() == promotedClassID)) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Same unpromoted class found. Skipping adapting palette.");
+			} else {
+				PaletteV2 adaptedBase = v2PaletteForClass(targetClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
+				PaletteV2 adaptedPromotion = v2PaletteForClass(promotedClassID, referencePalettes, PaletteType.PLAYER, supplementalHairColors.get(referenceID));
+				mapper.setCharacterToUnpromotedClass(characterID, targetClassID, adaptedBase.getCompressedData().length, adaptedPromotion.getCompressedData().length);
+				adaptedBase.setIdentifier(character.getUnpromotedPaletteIndex());
+				adaptedPromotion.setIdentifier(character.getPromotedPaletteIndex());
+				change.basePalette = adaptedBase;
+				change.promotedPalette = adaptedPromotion;
+			}
 		}
 		
-		queuedChanges.add(change);
+		if (change.basePalette != null || change.promotedPalette != null) {
+			queuedChanges.add(change);
+		}
 	}
 	
 	public void flushChangeQueue(CharacterDataLoader charData, FreeSpaceManager freeSpace) {
@@ -557,6 +573,135 @@ public class PaletteLoader {
 				long offsetToWriteTo = baseOffset + (appendedPaletteID * entrySize);
 				byte[] bytesToWrite = WhyDoesJavaNotHaveThese.bytesFromAddress(appendedPalette.getDestinationOffset());
 				compiler.addDiff(new Diff(offsetToWriteTo, bytesToWrite.length, bytesToWrite, new byte[] {0, 0, 0, 0}));
+			}
+		}
+	}
+	
+	private String changelogStringForPalette(PaletteV2 palette) {
+		if (palette == null) { return ""; }
+		StringBuilder sb = new StringBuilder();
+		sb.append("<div style=\"");
+		sb.append("display:flex;");
+		sb.append("flex-wrap:wrap;");
+		sb.append("flex-direction:row;");
+		sb.append("\">");
+		
+		for (int i = 0; i < palette.getNumColors(); i++) {
+			PaletteColor color = palette.colorAtIndex(i, PaletteType.PLAYER);
+			sb.append("<div style=\"");
+			sb.append("flex:0 0 auto;");
+			sb.append("margin:5px;");
+			
+			sb.append("background-color:rgb(" + color.getRedValue() + "," + color.getGreenValue() + "," + color.getBlueValue() + ");");
+			
+			sb.append("\">");
+			
+			sb.append("<p style=\"");
+			sb.append("color:");
+			if (color.getBrightness() > 0.6) {
+				sb.append("black;");
+			} else {
+				sb.append("white;");
+			}
+			sb.append("margin:0px;");
+			sb.append("padding:0px;");
+			sb.append("\">");
+			
+			sb.append(color.getRedValue() + ", " + color.getGreenValue() + ", " + color.getBlueValue());
+			
+			sb.append("</p>");
+			
+			sb.append("</div>");
+		}
+		
+		sb.append("</div>");
+		
+		return sb.toString();
+	}
+	
+	public void recordReferencePalettes(RecordKeeper rk, CharacterDataLoader charData, ClassDataLoader classData, TextLoader textData) {
+		String category = "Debug - Palettes";
+		rk.registerCategory(category);
+		for (GBAFECharacterData character : charData.canonicalPlayableCharacters(true)) {
+			String characterName = textData.getStringAtIndex(character.getNameIndex(), true);
+			Map<Integer, PaletteV2> palettesByClassID = referencePalettesV2.get(character.getID());
+			if (palettesByClassID == null) { continue; }
+			List<Integer> classIDs = palettesByClassID.keySet().stream().sorted().collect(Collectors.toList());
+			
+			for (int classID : classIDs) {
+				GBAFEClassData charClass = classData.classForID(classID);
+				String className = textData.getStringAtIndex(charClass.getNameIndex(), true);
+				boolean isFemale = classData.isFemale(classID);
+				if (isFemale) { className = className + " (F)"; }
+				rk.recordOriginalEntry(category, characterName, className, changelogStringForPalette(palettesByClassID.get(classID)));
+			}
+		}
+	}
+	
+	private void recordPalette(RecordKeeper rk, String category, String characterName, int classID, PaletteV2 palette, ClassDataLoader classData, TextLoader textData) {
+		GBAFEClassData charClass = classData.classForID(classID);
+		String className = textData.getStringAtIndex(charClass.getNameIndex(), true);
+		boolean isFemale = classData.isFemale(classID);
+		if (isFemale) { className = className + " (F)"; }
+		rk.recordUpdatedEntry(category, characterName, className, changelogStringForPalette(palette));
+	}
+	
+	public void recordUpdatedPalettes(RecordKeeper rk, CharacterDataLoader charData, ClassDataLoader classData, TextLoader textData) {
+		String category = "Debug - Palettes";
+		for (Change change : queuedChanges) {
+			GBAFECharacterData character = change.character;
+			String characterName = textData.getStringAtIndex(character.getNameIndex(), true);
+			
+			if (change.basePalette != null) {
+				recordPalette(rk, category, characterName, change.basePalette.getClassID(), change.basePalette, classData, textData);
+			}
+			if (change.promotedPalette != null) {
+				recordPalette(rk, category, characterName, change.promotedPalette.getClassID(), change.promotedPalette, classData, textData);
+			}
+		}
+	}
+	
+	private PaletteV2 paletteForCharacter(GBAFECharacterData character, SlotType type) {
+		int paletteID = fe8Mapper.paletteIDForCharacterInClassType(character.getID(), type);
+		if (paletteID == 0) { return null; }
+		PaletteV2 palette = paletteByPaletteIDV2.get(paletteID);
+		if (palette == null) {
+			palette = newPalettesV2.get(paletteID);
+		}
+		return palette;
+	}
+	
+	public void recordUpdatedFE8Palettes(RecordKeeper rk, CharacterDataLoader charData, ClassDataLoader classData, TextLoader textData) {
+		String category = "Debug - Palettes";
+		for (GBAFECharacterData character : charData.canonicalPlayableCharacters(true)) {
+			String characterName = textData.getStringAtIndex(character.getNameIndex(), true);
+			int traineeClassID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.TRAINEE);
+			if (traineeClassID != 0) {
+				recordPalette(rk, category, characterName, traineeClassID, paletteForCharacter(character, SlotType.TRAINEE), classData, textData);
+			}
+			int firstBaseID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.PRIMARY_BASE);
+			if (firstBaseID != 0) {
+				recordPalette(rk, category, characterName, firstBaseID, paletteForCharacter(character, SlotType.PRIMARY_BASE), classData, textData);
+			}
+			int secondBaseID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.SECONDARY_BASE);
+			if (secondBaseID != 0) {
+				recordPalette(rk, category, characterName, secondBaseID, paletteForCharacter(character, SlotType.SECONDARY_BASE), classData, textData);
+			}
+			int firstPromoID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.FIRST_PROMOTION);
+			if (firstPromoID != 0) {
+				recordPalette(rk, category, characterName, firstPromoID, paletteForCharacter(character, SlotType.FIRST_PROMOTION), classData, textData);
+			}
+			int secondPromoID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.SECOND_PROMOTION);
+			if (secondPromoID != 0) {
+				recordPalette(rk, category, characterName, secondPromoID, paletteForCharacter(character, SlotType.SECOND_PROMOTION), classData, textData);
+			}
+			int thirdPromoID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.THIRD_PROMOTION);
+			if (thirdPromoID != 0) {
+				recordPalette(rk, category, characterName, thirdPromoID, paletteForCharacter(character, SlotType.THIRD_PROMOTION), classData, textData);
+			}
+			int fourthPromoID = fe8Mapper.classIDMappedToCharacterForType(character.getID(), SlotType.FOURTH_PROMOTION);
+			if (fourthPromoID != 0) {
+				recordPalette(rk, category, characterName, fourthPromoID, paletteForCharacter(character, SlotType.FOURTH_PROMOTION), classData, textData);
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -177,6 +177,13 @@ public class GBARandomizer extends Randomizer {
 		RecordKeeper recordKeeper = initializeRecordKeeper();
 		recordKeeper.addHeaderItem("Randomizer Seed Phrase", seed);
 		
+		charData.recordCharacters(recordKeeper, true, classData, itemData, textData);
+		classData.recordClasses(recordKeeper, true, classData, textData);
+		itemData.recordWeapons(recordKeeper, true, classData, textData, handler);
+		chapterData.recordChapters(recordKeeper, true, charData, classData, itemData, textData);
+		
+		paletteData.recordReferencePalettes(recordKeeper, charData, classData, textData);
+		
 		updateStatusString("Randomizing...");
 		try { randomizeGrowthsIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing growths.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
 		updateProgress(0.45);
@@ -252,6 +259,12 @@ public class GBARandomizer extends Randomizer {
 		classData.recordClasses(recordKeeper, false, classData, textData);
 		itemData.recordWeapons(recordKeeper, false, classData, textData, targetFileHandler);
 		chapterData.recordChapters(recordKeeper, false, charData, classData, itemData, textData);
+		
+		if (gameType == FEBase.GameType.FE8) {
+			paletteData.recordUpdatedFE8Palettes(recordKeeper, charData, classData, textData);
+		} else {
+			paletteData.recordUpdatedPalettes(recordKeeper, charData, classData, textData);
+		}
 		
 		recordKeeper.sortKeysInCategory(CharacterDataLoader.RecordKeeperCategoryKey);
 		recordKeeper.sortKeysInCategory(ClassDataLoader.RecordKeeperCategoryKey);
@@ -1046,11 +1059,6 @@ public class GBARandomizer extends Randomizer {
 				break;
 			}
 		}
-		
-		charData.recordCharacters(rk, true, classData, itemData, textData);
-		classData.recordClasses(rk, true, classData, textData);
-		itemData.recordWeapons(rk, true, classData, textData, handler);
-		chapterData.recordChapters(rk, true, charData, classData, itemData, textData);
 		
 		return rk;
 	}


### PR DESCRIPTION
Fixed #165 - Added logic to not do unnecessary work by not generating palettes if characters are not actually changing classes. This should resolve issues where characters have new palettes even if their class has not changed.

Additionally, I updated the logic to always strip out duplicate colors from the list of reference colors. This should result in better color choices in most cases. There were also some minor issues with color indices in FE8 (specifically in the lord palettes and Paladin). There might be more, but we can tackle them as they come.

Also to help, changelogs now have a debug section for palette changes at the end of the log, with colors and their RGB values used.