### PR TITLE
[Issue #204] Assign KEY0 skill as necessary.

### DIFF
--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -406,6 +406,17 @@ public class FE9ClassRandomizer {
 							army.setItem2ForUnit(unit, equipment.size() > 1 ? itemData.iidOfItem(equipment.get(1)) : null);
 							army.setItem3ForUnit(unit, equipment.size() > 2 ? itemData.iidOfItem(equipment.get(2)) : null);
 							army.setItem4ForUnit(unit, equipment.size() > 3 ? itemData.iidOfItem(equipment.get(3)) : null);
+							
+							// Make sure thieves have the ability to unlock stuff.
+							if (classData.isThiefClass(newClass)) {
+								if (army.getSkill1ForUnit(unit) == null) {
+									army.setSkill1ForUnit(unit, FE9Data.Skill.KEY_0.getSID());
+								} else if (army.getSkill2ForUnit(unit) == null) {
+									army.setSkill2ForUnit(unit, FE9Data.Skill.KEY_0.getSID());
+								} else if (army.getSkill3ForUnit(unit) == null) {
+									army.setSkill3ForUnit(unit, FE9Data.Skill.KEY_0.getSID());
+								}
+							}
 						}
 					}
 				}

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -155,6 +155,8 @@ public class FE9Randomizer extends Randomizer {
 			charData.recordOriginalCharacterData(changelogBuilder, characterSection, textData, classData, skillData, itemData);
 			chapterData.recordOriginalChapterData(changelogBuilder, chapterSection, textData, charData, classData, skillData, itemData);
 			
+			makePreRandomizationAdjustments();
+			
 			randomizeClassesIfNecessary(seed);
 			randomizeGrowthsIfNecessary(seed);
 			randomizeBasesIfNecessary(seed);
@@ -191,6 +193,21 @@ public class FE9Randomizer extends Randomizer {
 		});
 		
 		notifyCompletion(null, changelogBuilder);
+	}
+	
+	private void makePreRandomizationAdjustments() {
+		// Remove KEY0 and KEY50 from Sothe and Volke, respectively, if randomize classes is enabled and thieves are also enabled.
+		if (classOptions.randomizePCs && classOptions.includeThieves) {
+			FE9Character sothe = charData.characterWithID(FE9Data.Character.SOTHE.getPID());
+			FE9Character volke = charData.characterWithID(FE9Data.Character.VOLKE.getPID());
+		
+			sothe.setSkill2Pointer(0);
+			//volke.setSkill2Pointer(0); // Maybe it would be interesting to allow Volke to always open chests for 50G a pop.
+			
+			// The thief class actually already has too many skills to fit another in its class data. We'll have to assign these manually
+			// in the chapter unit data.
+		}
+		
 	}
 	
 	private void randomizeGrowthsIfNecessary(String seed) {


### PR DESCRIPTION
Fixed #204 - Added logic to remove KEY0 from Sothe personally and apply it as needed to any playable character that becomes a Thief. KEY50 remains on Volke for a guaranteed unlocker (albeit at 50G for every lock). With this change, every thief should be able to unlock doors and chests for free, but Volke can always unlock doors and chests for 50G, regardless of his class. This change only applies if Thieves are included in Player Character randomization.