### PR TITLE
[Issue #215] Fixed light magic assignment

### DIFF
--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ClassDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ClassDataLoader.java
@@ -305,6 +305,18 @@ public class FE9ClassDataLoader {
 		charClass.setWeaponLevelPointer(fe8databin.pointerForString(weaponLevelString));
 	}
 	
+	public boolean canClassUseLightMagic(FE9Class charClass) {
+		if (charClass == null) { return false; }
+		
+		String sid1 = getSID1ForClass(charClass);
+		String sid2 = getSID2ForClass(charClass);
+		String sid3 = getSID3ForClass(charClass);
+		
+		return (sid1 != null && sid1.equals(FE9Data.Skill.LUMINA.getSID())) ||
+				(sid2 != null && sid2.equals(FE9Data.Skill.LUMINA.getSID())) ||
+				(sid3 != null && sid3.equals(FE9Data.Skill.LUMINA.getSID()));
+	}
+	
 	public StatBias statBiasForClass(FE9Class charClass) {
 		FE9Data.CharacterClass fe9Class = fe9ClassForClass(charClass);
 		if (fe9Class == null) { 

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -325,7 +325,7 @@ public class FE9ClassRandomizer {
 								equippedRanks.removeIf(rank -> (rank == WeaponRank.UNKNOWN || rank == WeaponRank.NONE));
 								
 								Map<WeaponType, WeaponRank> weaponLevelsMap = itemData.weaponLevelsForWeaponString(finalWeaponLevelString);
-								if (!classData.isPromotedClass(newClass)) { // Only promoted units can actually use Light magic.
+								if (!classData.canClassUseLightMagic(newClass)) { // Light magic keys off of staff ranks, but not every staff user uses light magic.
 									weaponLevelsMap.remove(WeaponType.LIGHT);
 								}
 								List<WeaponType> types = weaponLevelsMap.keySet().stream().sorted(WeaponType.getComparator()).collect(Collectors.toList());
@@ -736,7 +736,7 @@ public class FE9ClassRandomizer {
 								equippedRanks.removeIf(rank -> (rank == WeaponRank.UNKNOWN || rank == WeaponRank.NONE));
 								
 								Map<WeaponType, WeaponRank> weaponLevelsMap = itemData.weaponLevelsForWeaponString(finalWeaponLevelString);
-								if (!classData.isPromotedClass(newClass)) { // Only promoted units can actually use Light magic.
+								if (!classData.canClassUseLightMagic(newClass)) { // Light magic keys off of staff ranks, but not every staff user uses light magic.
 									weaponLevelsMap.remove(WeaponType.LIGHT);
 								}
 								List<WeaponType> types = weaponLevelsMap.keySet().stream().sorted(WeaponType.getComparator()).collect(Collectors.toList());
@@ -981,7 +981,7 @@ public class FE9ClassRandomizer {
 						equippedRanks.removeIf(rank -> (rank == WeaponRank.UNKNOWN || rank == WeaponRank.NONE));
 						
 						Map<WeaponType, WeaponRank> weaponLevelsMap = itemData.weaponLevelsForWeaponString(finalWeaponLevelString);
-						if (!classData.isPromotedClass(newClass)) { // Only promoted units can actually use Light magic.
+						if (!classData.canClassUseLightMagic(newClass)) { // Light magic keys off of staff ranks, but not every staff user uses light magic.
 							weaponLevelsMap.remove(WeaponType.LIGHT);
 						}
 						List<WeaponType> types = weaponLevelsMap.keySet().stream().sorted(WeaponType.getComparator()).collect(Collectors.toList());


### PR DESCRIPTION
Fixed #215 - Fixed an issue where staff sages were being assigned light magic based off of their staff rank. Added a proper check to determine light magic usage (i.e. check the class for the Lumina skill, instead of assuming promoted staff users could use Light magic).