### PR TITLE
[Issue #217] Basic Occult Skill Support

### DIFF
--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9SkillDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9SkillDataLoader.java
@@ -83,6 +83,7 @@ public class FE9SkillDataLoader {
 	
 	public String getSID(FE9Skill skill) {
 		assert(fe8databin != null);
+		if (skill == null) { return null; }
 		return fe8databin.stringForPointer(skill.getSkillIDPointer());
 	}
 	
@@ -131,7 +132,11 @@ public class FE9SkillDataLoader {
 	}
 	
 	public FE9Skill occultSkillForJID(String jid) {
-		return getSkillWithSID(FE9Data.Skill.occultSkillForClass(FE9Data.CharacterClass.withJID(jid)).getSID());
+		FE9Data.CharacterClass charClass = FE9Data.CharacterClass.withJID(jid);
+		if (charClass == null) { return null; }
+		FE9Data.Skill occultSkill = FE9Data.Skill.occultSkillForClass(charClass);
+		if (occultSkill == null) { return null; }
+		return getSkillWithSID(occultSkill.getSID());
 	}
 	
 	public List<FE9Skill> requiredSkillsForJID(String jid) {

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -290,6 +290,17 @@ public class FE9ClassRandomizer {
 				}
 			}
 			
+			FE9Skill matchingOccultSkill = skillData.occultSkillForJID(targetJID);
+			if (matchingOccultSkill != null) {
+				FE9Skill skill1 = skillData.getSkillWithSID(charData.getSID1ForCharacter(character));
+				FE9Skill skill2 = skillData.getSkillWithSID(charData.getSID2ForCharacter(character));
+				FE9Skill skill3 = skillData.getSkillWithSID(charData.getSID3ForCharacter(character));
+			
+				if (skillData.isOccultSkill(skill1)) { charData.setSID1ForCharacter(character, skillData.getSID(matchingOccultSkill)); }
+				if (skillData.isOccultSkill(skill2)) { charData.setSID2ForCharacter(character, skillData.getSID(matchingOccultSkill)); }
+				if (skillData.isOccultSkill(skill3)) { charData.setSID3ForCharacter(character, skillData.getSID(matchingOccultSkill)); }
+			}
+			
 			// Update chapter data (class, weapons, and equipment)
 			for (FE9Data.Chapter chapter : FE9Data.Chapter.values())  {
 				DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Processing Chapter: " + chapter.toString());
@@ -699,6 +710,17 @@ public class FE9ClassRandomizer {
 						break;
 					}
 				}
+			}
+			
+			FE9Skill matchingOccultSkill = skillData.occultSkillForJID(targetJID);
+			if (matchingOccultSkill != null) {
+				FE9Skill skill1 = skillData.getSkillWithSID(charData.getSID1ForCharacter(character));
+				FE9Skill skill2 = skillData.getSkillWithSID(charData.getSID2ForCharacter(character));
+				FE9Skill skill3 = skillData.getSkillWithSID(charData.getSID3ForCharacter(character));
+			
+				if (skillData.isOccultSkill(skill1)) { charData.setSID1ForCharacter(character, skillData.getSID(matchingOccultSkill)); }
+				if (skillData.isOccultSkill(skill2)) { charData.setSID2ForCharacter(character, skillData.getSID(matchingOccultSkill)); }
+				if (skillData.isOccultSkill(skill3)) { charData.setSID3ForCharacter(character, skillData.getSID(matchingOccultSkill)); }
 			}
 			
 			// Update chapter data (class, weapons, and equipment)

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9SkillRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9SkillRandomizer.java
@@ -31,6 +31,9 @@ public class FE9SkillRandomizer {
 			if (skillData.isModifiableSkill(skill1)) {
 				FE9Skill randomSkill = distributor.getRandomItem(rng);
 				charData.setSID1ForCharacter(character, skillData.getSID(randomSkill));
+			} else if (skillData.isOccultSkill(skill1)) {
+				// Occult skills should already be handled by the class randomization if they need to be changed.
+				// We'll add options for this later to randomize occult skills.
 			} else {
 				String sid2 = charData.getSID2ForCharacter(character);
 				if (sid2 == null) { continue; }
@@ -38,6 +41,8 @@ public class FE9SkillRandomizer {
 				if (skillData.isModifiableSkill(skill2)) {
 					FE9Skill randomSkill = distributor.getRandomItem(rng);
 					charData.setSID2ForCharacter(character, skillData.getSID(randomSkill));	
+				} else if (skillData.isOccultSkill(skill2)) {
+					// TODO: Randomize with Occult Skills
 				} else {
 					String sid3 = charData.getSID3ForCharacter(character);
 					if (sid3 == null) { continue; }
@@ -45,6 +50,8 @@ public class FE9SkillRandomizer {
 					if (skillData.isModifiableSkill(skill3)) {
 						FE9Skill randomSkill = distributor.getRandomItem(rng);
 						charData.setSID3ForCharacter(character, skillData.getSID(randomSkill));
+					} else if (skillData.isOccultSkill(skill3)) {
+						// TODO: Randomize with Occult Skills
 					}
 				}
 			}
@@ -66,6 +73,8 @@ public class FE9SkillRandomizer {
 				} else {
 					charData.setSID1ForCharacter(character, null);
 				}
+			} else if (skillData.isOccultSkill(skill1)) {
+				// TODO: Randomize with Occult Skills
 			} else {
 				String sid2 = charData.getSID2ForCharacter(character);
 				FE9Skill skill2 = skillData.getSkillWithSID(sid2);
@@ -81,6 +90,8 @@ public class FE9SkillRandomizer {
 					} else {
 						charData.setSID2ForCharacter(character, null);
 					}
+				} else if (skillData.isOccultSkill(skill2)) {
+					// TODO: Randomize with Occult Skills	
 				} else {
 					String sid3 = charData.getSID3ForCharacter(character);
 					FE9Skill skill3 = skillData.getSkillWithSID(sid3);
@@ -91,6 +102,8 @@ public class FE9SkillRandomizer {
 						} else {
 							charData.setSID3ForCharacter(character, null);
 						}
+					} else if (skillData.isOccultSkill(skill3)) {
+						// TODO: Randomize with Occult Skills
 					}
 				}
 			}


### PR DESCRIPTION
Fixed #217 - Added support to make sure we don't ignore occult skills during skill randomization. Including Occult skills when randomizing skills (or buffing enemies) will come later. This simply makes sure the occult skill switches to match the class.