### PR TITLE
[Issue #217] Removed S weapon ranks for all classes.

### DIFF
--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9EnemyBuffer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9EnemyBuffer.java
@@ -159,20 +159,6 @@ public class FE9EnemyBuffer {
 		}
 		
 		chapterData.commitChanges();
-		// Before we upgrade all class's base weapon levels to S, we need to explicitly write weapon ranks for all 
-		// playable characters so that they don't inherit the inflated weapon levels.
-		for (FE9Character character : charData.allPlayableCharacters()) {
-			String charWeaponLevel = charData.getWeaponLevelStringForCharacter(character);
-			String classWeaponLevel = classData.getWeaponLevelsForClass(classData.classWithID(charData.getJIDForCharacter(character)));
-			String definedWeaponLevel = explicitlyDefinedWeaponLevelString(charWeaponLevel, classWeaponLevel);
-			charData.setWeaponLevelStringForCharacter(character, definedWeaponLevel);
-		}
-		
-		for (FE9Class charClass : classData.allValidClasses()) {
-			String weaponLevelString = classData.getWeaponLevelsForClass(charClass);
-			classData.setWeaponLevelsForClass(charClass, sRankWeaponLevel(weaponLevelString));
-		}
-		classData.commit();
 	}
 	
 	public static void improveBossWeapons(int chance, FE9CharacterDataLoader charData, FE9ClassDataLoader classData, FE9ItemDataLoader itemData, 


### PR DESCRIPTION
Fixed #217 - Apparently FE9's engine is smart enough to know to give minions the appropriate weapon ranks to accommodate their weapon when they are loaded in, so there's no longer a need to set weapon ranks for classes. Instead, the class weapon ranks seem to force a promoted character to have at least that rank. This should fix the issue where every class always immediately got S ranks in everything.