### PR TITLE
Added checksum override option

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -317,7 +317,7 @@ public class GBARandomizer extends Randomizer {
 		
 		updateStatusString("Detecting Free Space...");
 		updateProgress(0.02);
-		freeSpace = new FreeSpaceManager(FEBase.GameType.FE7, FE7Data.InternalFreeRange);
+		freeSpace = new FreeSpaceManager(FEBase.GameType.FE7, FE7Data.InternalFreeRange, handler);
 		updateStatusString("Loading Text...");
 		updateProgress(0.05);
 		textData = new TextLoader(FEBase.GameType.FE7, handler);
@@ -347,7 +347,7 @@ public class GBARandomizer extends Randomizer {
 		
 		updateStatusString("Detecting Free Space...");
 		updateProgress(0.02);
-		freeSpace = new FreeSpaceManager(FEBase.GameType.FE6, FE6Data.InternalFreeRange);
+		freeSpace = new FreeSpaceManager(FEBase.GameType.FE6, FE6Data.InternalFreeRange, handler);
 		updateStatusString("Loading Text...");
 		updateProgress(0.05);
 		textData = new TextLoader(FEBase.GameType.FE6, handler);
@@ -379,7 +379,7 @@ public class GBARandomizer extends Randomizer {
 		
 		updateStatusString("Detecting Free Space...");
 		updateProgress(0.02);
-		freeSpace = new FreeSpaceManager(FEBase.GameType.FE8, FE8Data.InternalFreeRange);
+		freeSpace = new FreeSpaceManager(FEBase.GameType.FE8, FE8Data.InternalFreeRange, handler);
 		updateStatusString("Loading Text...");
 		updateProgress(0.04);
 		textData = new TextLoader(FEBase.GameType.FE8, handler);

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -119,6 +119,7 @@ public class FE9Randomizer extends Randomizer {
 			return;
 		} catch (GCNISOException e) {
 			notifyError("Failed to read Gamecube ISO format.");
+			return;
 		}
 		
 		ChangelogBuilder changelogBuilder = new ChangelogBuilder();

--- a/Universal FE Randomizer/src/ui/MainView.java
+++ b/Universal FE Randomizer/src/ui/MainView.java
@@ -113,6 +113,8 @@ public class MainView implements FileFlowDelegate {
 	private GameType loadedGameType = GameType.UNKNOWN;
 	private Boolean hasLoadedInfo = false;
 	
+	private boolean patchingAvailable = false;
+	
 	private Group romInfoGroup;
 	private Label romName;
 	private Label romCode;
@@ -800,8 +802,10 @@ public class MainView implements FileFlowDelegate {
 			checksum.setText("CRC-32: " + Long.toHexString(handler.getCRC32()).toUpperCase());
 			
 			GameType type = loadedGameType;
+			patchingAvailable = false;
 			if (handler.getCRC32() == FE6Data.CleanCRC32) { 
 				type = GameType.FE6;
+				patchingAvailable = true;
 				friendlyName.setText("Display Name: " + FE6Data.FriendlyName);
 			}
 			else if (handler.getCRC32() == FE7Data.CleanCRC32) { 
@@ -814,6 +818,7 @@ public class MainView implements FileFlowDelegate {
 			}
 			else if (handler.getCRC32() == FE4Data.CleanHeaderedCRC32 || handler.getCRC32() == FE4Data.CleanUnheaderedCRC32) {
 				type = GameType.FE4;
+				patchingAvailable = true;
 				friendlyName.setText("Display Name: " + FE4Data.FriendlyName);
 				romName.setText("ROM Name: " + FE4Data.InternalName);
 				romCode.setText("ROM Code: --");
@@ -844,7 +849,9 @@ public class MainView implements FileFlowDelegate {
 				loadingModal.hide();
 				
 				MessageModal checksumFailure = new MessageModal(mainShell, "Unrecognized Checksum", "Yune was unable to determine the game from the file selected.\n"
-						+ "If you know the game for the file, you may select it below.\n\nNote: Be aware that this file is likely untested and may cause errors.");
+						+ "If you know the game for the file, you may select it below.\n\nNote: Patching cannot be guaranteed, and is therefore, disabled.\n\n"
+						+ "Warning: Be aware that this file is likely untested and may cause errors.\n" 
+						+ "There will be very limited support for issues from randomizing this file.");
 				ModalButtonListener fe4Selection = new ModalButtonListener() {
 					@Override
 					public void onSelected() {
@@ -954,6 +961,7 @@ public class MainView implements FileFlowDelegate {
 
 		
 		miscView.setVisible(true);
+		miscView.setPatchingEnabled(patchingAvailable);
 		
 		randomizeButton.setVisible(true);
 		

--- a/Universal FE Randomizer/src/ui/MiscellaneousView.java
+++ b/Universal FE Randomizer/src/ui/MiscellaneousView.java
@@ -135,6 +135,17 @@ public class MiscellaneousView extends Composite {
 			});
 		}
 	}
+	
+	public void setPatchingEnabled(boolean patchingEnabled) {
+		if (applyEnglishPatch != null) {
+			if (patchingEnabled) {
+				applyEnglishPatch.setEnabled(true);
+			} else {
+				applyEnglishPatch.setEnabled(false);
+				applyEnglishPatch.setSelection(false);
+			}
+		}
+	}
 
 	public MiscellaneousOptions getMiscellaneousOptions() {
 		if (type.isGBA()) {

--- a/Universal FE Randomizer/src/util/FreeSpaceManager.java
+++ b/Universal FE Randomizer/src/util/FreeSpaceManager.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import fedata.general.FEBase;
+import io.FileHandler;
 
 public class FreeSpaceManager {
 	
@@ -20,14 +21,14 @@ public class FreeSpaceManager {
 	List<AddressRange> internalRanges;
 	List<Long> internalFreeAddress;
 	
-	public FreeSpaceManager(FEBase.GameType gameType, List<AddressRange> internalRanges) {
+	public FreeSpaceManager(FEBase.GameType gameType, List<AddressRange> internalRanges, FileHandler handler) {
 		switch (gameType) {
 		case FE6:
-			freeAddress = 0x1000200;
+			freeAddress = Math.max(0x1000200, handler.getFileLength());
 			break;
 		case FE7:
 		case FE8:
-			freeAddress = 0x1000000;
+			freeAddress = Math.max(0x1000000, handler.getFileLength());
 			break;
 		default:
 			freeAddress = -1;


### PR DESCRIPTION
Added the ability to override the checksum check and directly specify the game when the checksum is unrecognized. This may allow some pre-modded games to be randomized, though the result cannot be guaranteed. It should mostly work if the code to load the characters, classes, or items remains unchanged, as the randomizer uses pointers to the tables instead of the raw table itself, but, its idea of what the IDs are will be still of the base game, so the result may not be as expected.

![image](https://user-images.githubusercontent.com/1689159/88493217-c8288780-cf64-11ea-9bae-81773eed4ddd.png)


