### PR TITLE
[Issue #237] Make sure bosses have appropriate attacking weapons

### DIFF
--- a/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9Data.java
+++ b/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9Data.java
@@ -911,6 +911,14 @@ public class FE9Data {
 		public static Set<Item> allThunderMagic = new HashSet<Item>(Arrays.asList(THUNDER, ELTHUNDER, THORON, REXBOLT, BOLTING));
 		public static Set<Item> allLightMagic = new HashSet<Item>(Arrays.asList(LIGHT, SHINE, NOSFERATU, REXAURA, PURGE));
 		
+		public static Set<Item> meleeOnlyWeapons = new HashSet<Item>(Arrays.asList(IRON_SWORD, PRACTICE_SWORD, SLIM_SWORD, STEEL_SWORD, SILVER_SWORD, IRON_BLADE, 
+				SILVER_BLADE, VENIN_EDGE, REGAL_SWORD, BRAVE_SWORD, VAGUE_KATTI, KILLING_EDGE, ARMORSLAYER, LAGUZSLAYER, LONGSWORD, AMITI, STEEL_BLADE,
+				IRON_LANCE, SLIM_LANCE, STEEL_LANCE, SILVER_LANCE, VENIN_LANCE, BRAVE_LANCE, 
+				KILLER_LANCE, KNIGHT_KILLER, LAGUZ_LANCE, HEAVY_SPEAR, IRON_AXE, PRACTICE_AXE, STEEL_AXE, SILVER_AXE, VENIN_AXE, BRAVE_AXE, KILLER_AXE, 
+				POLEAX, HAMMER, DEVIL_AXE, LAGUZ_AXE, URVAN, KNIFE, DAGGER, STILETTO));
+		public static Set<Item> rangedOnlyWeapons = new HashSet<Item>(Arrays.asList(DOUBLE_BOW, IRON_BOW, STEEL_BOW, SILVER_BOW, VENIN_BOW, KILLER_BOW, BRAVE_BOW, 
+				LAGUZ_BOW, LONGBOW, ROLF_BOW, BRIGHT_BOW, METEOR, BLIZZARD, BOLTING, PURGE));
+		
 		public static Set<Item> allKnives = new HashSet<Item>(Arrays.asList(KNIFE, DAGGER, STILETTO));
 		public static Set<Item> allStaves = new HashSet<Item>(Arrays.asList(ASHERA_STAFF, HEAL, MEND, RECOVER, PHYSIC, FORTIFY, RESTORE, SILENCE, SLEEP, 
 				WARP, RESCUE, TORCH_STAFF, HAMMERNE, WARD));
@@ -951,6 +959,8 @@ public class FE9Data {
 				REXAURA, ASHERA_STAFF));
 		
 		public static Set<Item> blacklistedWeapons = new HashSet<Item>(Arrays.asList(PRACTICE_AXE, PRACTICE_SWORD, DEVIL_AXE));
+		
+		public static Set<Item> siegeTomes = new HashSet<Item>(Arrays.asList(PURGE, METEOR, BLIZZARD, BOLTING));
 		
 		public static Set<Item> allDroppableWeapons() {
 			Set<Item> result = new HashSet<Item>();
@@ -995,6 +1005,10 @@ public class FE9Data {
 		public boolean isSkillScroll() { return allSkillScrolls.contains(this); }
 		
 		public boolean isBlacklisted() { return blacklistedWeapons.contains(this); }
+		public boolean isSiegeTome() { return siegeTomes.contains(this); }
+		
+		public boolean isMeleeLocked() { return meleeOnlyWeapons.contains(this); }
+		public boolean isRangeLocked() { return rangedOnlyWeapons.contains(this); }
 		
 		public static Set<Item> specialWeaponsForClass(FE9Data.CharacterClass charClass) {
 			switch (charClass) {

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
@@ -332,6 +332,24 @@ public class FE9ItemDataLoader {
 		}
 	}
 	
+	public boolean isSiegeTome(FE9Item item) {
+		FE9Data.Item fe9Item = FE9Data.Item.withIID(iidOfItem(item));
+		if (fe9Item != null) { return fe9Item.isSiegeTome(); }
+		return false;
+	}
+	
+	public boolean isRanged(FE9Item item) {
+		FE9Data.Item fe9Item = FE9Data.Item.withIID(iidOfItem(item));
+		if (fe9Item != null) { return !fe9Item.isMeleeLocked(); }	
+		return false;
+	}
+	
+	public boolean isMelee(FE9Item item) {
+		FE9Data.Item fe9Item = FE9Data.Item.withIID(iidOfItem(item));
+		if (fe9Item != null) { return !fe9Item.isRangeLocked(); }
+		return false;
+	}
+	
 	public List<FE9Item> specialWeaponsForJID(String jid) {
 		if (jid == null) { return null; }
 		FE9Data.CharacterClass charClass = FE9Data.CharacterClass.withJID(jid);

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -768,10 +768,22 @@ public class FE9ClassRandomizer {
 									weaponLevelsMap.put(WeaponType.KNIFE, itemData.highestRankInString(finalWeaponLevelString));
 								}
 								
+								// Don't give out staves to bosses.
+								if (types.contains(WeaponType.STAFF) && types.size() > 1) {
+									types.remove(WeaponType.STAFF);
+								}
+								
 								DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, weaponCount + " weapons to assign.");
 								for (WeaponType type : types) {
 									DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Type: " + type.toString() + " (" + weaponLevelsMap.get(type) + ")");
 								}
+								
+								boolean hasNonSiegeTome = false;
+								boolean hasSiegeTome = false;
+								
+								boolean hasRangedOption = false;
+								boolean hasMeleeOption = false;
+								
 								for (int i = 0; i < weaponCount; i++) {
 									WeaponType randomUsableType = types.get(rng.nextInt(types.size()));
 									DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Selected type: " + randomUsableType.toString());
@@ -796,6 +808,83 @@ public class FE9ClassRandomizer {
 										FE9Item weapon = replacements.get(rng.nextInt(replacements.size()));
 										DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Selected: " + itemData.iidOfItem(weapon));
 										weapons.add(weapon);
+										if (itemData.isSiegeTome(weapon)) { hasSiegeTome = true; }
+										else { hasNonSiegeTome = true; }
+										
+										if (itemData.isRanged(weapon)) { hasRangedOption = true; }
+										if (itemData.isMelee(weapon)) { hasMeleeOption = true; }
+									}
+								}
+								
+								if (hasSiegeTome && !hasNonSiegeTome) {
+									// Give this character an additional non-siege tome.
+									while (types.size() > 0) {
+										WeaponType usableType = types.get(rng.nextInt(types.size()));
+										WeaponRank usableRank = weaponLevelsMap.get(usableType);
+										List<FE9Item> replacements = itemData.weaponsOfRankAndType(usableRank, usableType);
+										replacements.removeIf(weapon -> { return itemData.isSiegeTome(weapon); });
+										while (replacements.isEmpty()) {
+											usableRank = usableRank.lowerRank();
+											if (usableRank == WeaponRank.NONE) { break; }
+											replacements = itemData.weaponsOfRankAndType(usableRank.lowerRank(), usableType);
+											replacements.removeIf(weapon -> { return itemData.isSiegeTome(weapon); });
+										}
+										if (!replacements.isEmpty()) {
+											FE9Item additionalWeapon = replacements.get(rng.nextInt(replacements.size()));
+											DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Additional Weapon: " + itemData.iidOfItem(additionalWeapon));
+											weapons.add(additionalWeapon);
+											break;
+										} else {
+											types.remove(usableType);
+										}
+									}
+								}
+								
+								if (hasRangedOption && !hasMeleeOption) {
+									// Give this character a melee option if possible.
+									while (types.size() > 0) {
+										WeaponType usableType = types.get(rng.nextInt(types.size()));
+										WeaponRank usableRank = weaponLevelsMap.get(usableType);
+										List<FE9Item> replacements = itemData.weaponsOfRankAndType(usableRank, usableType);
+										replacements.removeIf(weapon -> { return !itemData.isMelee(weapon); });
+										while (replacements.isEmpty()) {
+											usableRank = usableRank.lowerRank();
+											if (usableRank == WeaponRank.NONE) { break; }
+											replacements = itemData.weaponsOfRankAndType(usableRank, usableType);
+											replacements.removeIf(weapon -> {return !itemData.isMelee(weapon); });
+										}
+										if (!replacements.isEmpty()) {
+											FE9Item additionalWeapon = replacements.get(rng.nextInt(replacements.size()));
+											DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Additional Weapon: " + itemData.iidOfItem(additionalWeapon));
+											weapons.add(additionalWeapon);
+											break;
+										} else {
+											types.remove(usableType);
+										}
+									}
+								}
+								
+								if (hasMeleeOption && !hasRangedOption) {
+									// Give this character a ranged option if possible.
+									while (types.size() > 0) {
+										WeaponType usableType = types.get(rng.nextInt(types.size()));
+										WeaponRank usableRank = weaponLevelsMap.get(usableType);
+										List<FE9Item> replacements = itemData.weaponsOfRankAndType(usableRank, usableType);
+										replacements.removeIf(weapon -> { return !itemData.isRanged(weapon); });
+										while (replacements.isEmpty()) {
+											usableRank = usableRank.lowerRank();
+											if (usableRank == WeaponRank.NONE) { break; }
+											replacements = itemData.weaponsOfRankAndType(usableRank, usableType);
+											replacements.removeIf(weapon -> {return !itemData.isRanged(weapon); });
+										}
+										if (!replacements.isEmpty()) {
+											FE9Item additionalWeapon = replacements.get(rng.nextInt(replacements.size()));
+											DebugPrinter.log(DebugPrinter.Key.FE9_RANDOM_CLASSES, "Additional Weapon: " + itemData.iidOfItem(additionalWeapon));
+											weapons.add(additionalWeapon);
+											break;
+										} else {
+											types.remove(usableType);
+										}
 									}
 								}
 							}


### PR DESCRIPTION
Fixed #237 - Added logic to make sure bosses can attack from both melee and range (when possible) and that they are not left with staves or only siege tomes.