### PR TITLE
[Issue #233] Updated script for Shinon and Gatrie's rejoining chapters

### DIFF
--- a/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9ChapterArmy.java
+++ b/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9ChapterArmy.java
@@ -312,4 +312,25 @@ public class FE9ChapterArmy {
 			e.printStackTrace();
 		}
 	}
+	
+	public boolean unitHasItem(FE9ChapterUnit unit, String iid) {
+		String weapon1IID = getWeapon1ForUnit(unit);
+		String weapon2IID = getWeapon2ForUnit(unit);
+		String weapon3IID = getWeapon3ForUnit(unit);
+		String weapon4IID = getWeapon4ForUnit(unit);
+		
+		String item1IID = getItem1ForUnit(unit);
+		String item2IID = getItem2ForUnit(unit);
+		String item3IID = getItem3ForUnit(unit);
+		String item4IID = getItem4ForUnit(unit);
+		
+		return ((weapon1IID != null && weapon1IID.equals(iid)) ||
+				(weapon2IID != null && weapon2IID.equals(iid)) ||
+				(weapon3IID != null && weapon3IID.equals(iid)) ||
+				(weapon4IID != null && weapon4IID.equals(iid)) ||
+				(item1IID != null && item1IID.equals(iid)) ||
+				(item2IID != null && item2IID.equals(iid)) ||
+				(item3IID != null && item3IID.equals(iid)) ||
+				(item4IID != null && item4IID.equals(iid)));
+	}
 }

--- a/Universal FE Randomizer/src/io/gcn/GCNISOHandler.java
+++ b/Universal FE Randomizer/src/io/gcn/GCNISOHandler.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.FileHandler;
 import io.FileWriter;
@@ -296,6 +297,8 @@ public class GCNISOHandler {
 			recalculateFileOffsets(rootEntry, -1, fileDataOrder, delegate);
 		} catch (GCNISOException e1) {
 			assert false : "Failed to recalculate File Offsets.";
+			if (delegate != null) { delegate.onError("Encountered error while recalculating file offsets.\n\n" + e1.getMessage()); }
+			return;
 		}
 		
 		// Start writing. Our header shouldn't have changed because our FST hasn't moved.
@@ -367,11 +370,14 @@ public class GCNISOHandler {
 		} catch (FileNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
+			if (delegate != null) { delegate.onError("Unable to open file.\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); }
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
+			if (delegate != null) { delegate.onError("Error writing file.\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); }
 			e.printStackTrace();
 		} catch (GCNISOException e) {
 			// TODO Auto-generated catch block
+			if (delegate != null) { delegate.onError("Error processing ISO file.\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); }
 			e.printStackTrace();
 		}
 	}

--- a/Universal FE Randomizer/src/io/gcn/GCNISOHandlerRecompilationDelegate.java
+++ b/Universal FE Randomizer/src/io/gcn/GCNISOHandlerRecompilationDelegate.java
@@ -2,6 +2,7 @@ package io.gcn;
 
 public interface GCNISOHandlerRecompilationDelegate {
 	
+	public void onError(String errorMessage);
 	public void onProgressUpdate(double progress);
 	public void onStatusUpdate(String status);
 }

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
@@ -338,25 +338,25 @@ public class FE9ItemDataLoader {
 		return fe9ItemListFromSet(FE9Data.Item.specialWeaponsForClass(charClass));
 	}
 	
-	public List<FE9Item> weaponsSetForJID(String jid) {
+	public FE9Item laguzWeaponForJID(String jid) {
 		if (jid == null) { return null; }
 		FE9Data.CharacterClass charClass = FE9Data.CharacterClass.withJID(jid);
-		List<FE9Item> weapons = new ArrayList<FE9Item>();
 		if (charClass.isLaguz()) {
 			switch (charClass) {
-			case LION: case FERAL_LION: weapons.add(itemWithIID(FE9Data.Item.LION_CLAW.getIID())); break;
-			case TIGER: case FERAL_TIGER: weapons.add(itemWithIID(FE9Data.Item.TIGER_CLAW.getIID())); break;
-			case CAT: case FERAL_CAT: case CAT_F: case FERAL_CAT_F: weapons.add(itemWithIID(FE9Data.Item.CAT_CLAW.getIID())); break;
-			case WHITE_DRAGON: case FERAL_WHITE_DRAGON: weapons.add(itemWithIID(FE9Data.Item.WHITE_BREATH.getIID())); break;
-			case RED_DRAGON: case FERAL_RED_DRAGON: case RED_DRAGON_F: case FERAL_RED_DRAGON_F: weapons.add(itemWithIID(FE9Data.Item.RED_BREATH.getIID())); break;
-			case HAWK: case FERAL_HAWK: weapons.add(itemWithIID(FE9Data.Item.HAWK_BEAK.getIID())); break;
-			case CROW: case FERAL_CROW: weapons.add(itemWithIID(FE9Data.Item.CROW_BEAK.getIID())); break;
-			case TIBARN_HAWK: weapons.add(itemWithIID(FE9Data.Item.HAWK_KING_BEAK.getIID())); break;
-			case NAESALA_CROW: weapons.add(itemWithIID(FE9Data.Item.CROW_KING_BEAK.getIID())); break;
-			default: break;
+			case LION: case FERAL_LION: return itemWithIID(FE9Data.Item.LION_CLAW.getIID());
+			case TIGER: case FERAL_TIGER: return itemWithIID(FE9Data.Item.TIGER_CLAW.getIID());
+			case CAT: case FERAL_CAT: case CAT_F: case FERAL_CAT_F: return itemWithIID(FE9Data.Item.CAT_CLAW.getIID());
+			case WHITE_DRAGON: case FERAL_WHITE_DRAGON: return itemWithIID(FE9Data.Item.WHITE_BREATH.getIID());
+			case RED_DRAGON: case FERAL_RED_DRAGON: case RED_DRAGON_F: case FERAL_RED_DRAGON_F: return itemWithIID(FE9Data.Item.RED_BREATH.getIID());
+			case HAWK: case FERAL_HAWK: return itemWithIID(FE9Data.Item.HAWK_BEAK.getIID());
+			case CROW: case FERAL_CROW: return itemWithIID(FE9Data.Item.CROW_BEAK.getIID());
+			case TIBARN_HAWK: return itemWithIID(FE9Data.Item.HAWK_KING_BEAK.getIID());
+			case NAESALA_CROW: return itemWithIID(FE9Data.Item.CROW_KING_BEAK.getIID());
+			default: return null;
 			}
 		}
-		return weapons;
+		
+		return null;
 	}
 	
 	public List<FE9Item> formerThiefKit() {

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -311,8 +311,8 @@ public class FE9ClassRandomizer {
 							army.setJIDForUnit(unit, targetJID);
 							
 							List<FE9Item> weapons = new ArrayList<FE9Item>();
-							if (!itemData.weaponsSetForJID(targetJID).isEmpty()) {
-								weapons.addAll(itemData.weaponsSetForJID(targetJID));
+							if (itemData.laguzWeaponForJID(targetJID) != null) {
+								weapons.add(itemData.laguzWeaponForJID(targetJID));
 							} else {
 								int weaponCount = 0;
 								String iid1 = army.getWeapon1ForUnit(unit);
@@ -733,8 +733,8 @@ public class FE9ClassRandomizer {
 							army.setJIDForUnit(unit, targetJID);
 							
 							List<FE9Item> weapons = new ArrayList<FE9Item>();
-							if (!itemData.weaponsSetForJID(targetJID).isEmpty()) {
-								weapons.addAll(itemData.weaponsSetForJID(targetJID));
+							if (itemData.laguzWeaponForJID(targetJID) != null) {
+								weapons.add(itemData.laguzWeaponForJID(targetJID));
 							} else {
 								int weaponCount = 0;
 								String iid1 = army.getWeapon1ForUnit(unit);
@@ -978,8 +978,8 @@ public class FE9ClassRandomizer {
 					}
 					
 					List<FE9Item> weapons = new ArrayList<FE9Item>();
-					if (!itemData.weaponsSetForJID(targetJID).isEmpty()) {
-						weapons.addAll(itemData.weaponsSetForJID(targetJID));
+					if (itemData.laguzWeaponForJID(targetJID) != null) {
+						weapons.add(itemData.laguzWeaponForJID(targetJID));
 					} else {
 						int weaponCount = 0;
 						String iid1 = army.getWeapon1ForUnit(unit);


### PR DESCRIPTION
Fixed #233 - Updated the Chapter 13 and 18 scripts to make sure Gatrie and Shinon's weapons upon rejoining match their new class (assuming their classes cannot Steel Lance and Brave Bow, respectively).