### PR TITLE
[Issue #234] Fixed minion randomization between Ch. 13 and Ch. 17

### DIFF
--- a/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9ChapterUnit.java
+++ b/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9ChapterUnit.java
@@ -311,9 +311,97 @@ public class FE9ChapterUnit implements FEModifiableData {
 		return data[0x60];
 	}
 	
-	public byte[] getSuffixData() {
-		// 0x61 ~ 0x6C
-		return Arrays.copyOfRange(data, 0x61, 0x6C);
+	public byte[] getPreDropData() {
+		// 0x61 ~ 0x63
+		return Arrays.copyOfRange(data, 0x61, 0x64);
+	}
+	
+	public boolean willDropWeapon1() {
+		return data[0x64] != 0x0;
+	}
+	
+	public void setWillDropWeapon1(boolean drop) {
+		if (drop != willDropWeapon1()) { 
+			data[0x64] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropWeapon2() {
+		return data[0x65] != 0x0;
+	}
+	
+	public void setWillDropWeapon2(boolean drop) {
+		if (drop != willDropWeapon2()) {
+			data[0x65] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropWeapon3() {
+		return data[0x66] != 0x0;
+	}
+	
+	public void setWillDropWeapon3(boolean drop) {
+		if (drop != willDropWeapon3()) {
+			data[0x66] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropWeapon4() {
+		return data[0x67] != 0x0;
+	}
+	
+	public void setWillDropWeapon4(boolean drop) {
+		if (drop != willDropWeapon4()) {
+			data[0x67] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropItem1() {
+		return data[0x68] != 0x0;
+	}
+	
+	public void setWillDropItem1(boolean drop) {
+		if (drop != willDropItem1()) {
+			data[0x68] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropItem2() {
+		return data[0x69] != 0x0;
+	}
+	
+	public void setWillDropItem2(boolean drop) {
+		if (drop != willDropItem2()) {
+			data[0x69] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropItem3() {
+		return data[0x6A] != 0x0;
+	}
+	
+	public void setWillDropItem3(boolean drop) {
+		if (drop != willDropItem3()) {
+			data[0x6A] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
+	}
+	
+	public boolean willDropItem4() {
+		return data[0x6B] != 0x0;
+	}
+	
+	public void setWillDropItem4(boolean drop) {
+		if (drop != willDropItem4()) {
+			data[0x6B] = (byte)(drop ? 0x1 : 0x0);
+			wasModified = true;
+		}
 	}
 	
 	public void setStartingLevel(int level) {

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ChapterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ChapterDataLoader.java
@@ -127,14 +127,14 @@ public class FE9ChapterDataLoader {
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "--- Starting Character " + unitID + " ---");
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "PID: " + army.getPIDForUnit(unit));
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "JID: " + army.getJIDForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 1: " + army.getWeapon1ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 2: " + army.getWeapon2ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 3: " + army.getWeapon3ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 4: " + army.getWeapon4ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 1: " + army.getItem1ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 2: " + army.getItem2ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 3: " + army.getItem3ForUnit(unit));
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 4: " + army.getItem4ForUnit(unit));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 1: " + army.getWeapon1ForUnit(unit) + (unit.willDropWeapon1() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 2: " + army.getWeapon2ForUnit(unit) + (unit.willDropWeapon2() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 3: " + army.getWeapon3ForUnit(unit) + (unit.willDropWeapon3() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Weapon 4: " + army.getWeapon4ForUnit(unit) + (unit.willDropWeapon4() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 1: " + army.getItem1ForUnit(unit) + (unit.willDropItem1() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 2: " + army.getItem2ForUnit(unit) + (unit.willDropItem2() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 3: " + army.getItem3ForUnit(unit) + (unit.willDropItem3() ? " (Drop)" : ""));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Item 4: " + army.getItem4ForUnit(unit) + (unit.willDropItem4() ? " (Drop)" : ""));
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Skill 1: " + army.getSkill1ForUnit(unit));
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Skill 2: " + army.getSkill2ForUnit(unit));
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Skill 3: " + army.getSkill3ForUnit(unit));
@@ -150,7 +150,7 @@ public class FE9ChapterDataLoader {
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Unknown Data (0x4B ~ 0x5B): " + WhyDoesJavaNotHaveThese.displayStringForBytes(unit.getPostAdjustmentData()));
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Starting Coordinates: (" + army.getStartingXForUnit(unit) + ", " + army.getStartingYForUnit(unit) + ")");
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Ending Coordinates: (" + army.getEndingXForUnit(unit) + ", " + army.getEndingYForUnit(unit) + ")");
-				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Unknown Data (0x61 ~ 0x6C): " + WhyDoesJavaNotHaveThese.displayStringForBytes(unit.getSuffixData()));
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "Unknown Data (0x61 ~ 0x63): " + WhyDoesJavaNotHaveThese.displayStringForBytes(unit.getPreDropData()));
 				DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "--- Ending Character " + unitID + " ---");
 			}
 			DebugPrinter.log(DebugPrinter.Key.FE9_CHAPTER_LOADER, "===== End Chapter Army: " + army.getID() + " =====");

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9CharacterDataLoader.java
@@ -2,6 +2,7 @@ package random.gcnwii.fe9.loader;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,7 @@ public class FE9CharacterDataLoader {
 	List<FE9Character> minionCharacters;
 	
 	Map<String, List<FE9Character>> daeinMinionsByJID;
+	Map<String, List<FE9Character>> pid14MinionsByJID;
 	
 	Map<String, Long> knownAddresses;
 	Map<Long, String> knownPointers;
@@ -51,6 +53,7 @@ public class FE9CharacterDataLoader {
 	Map<String, FE9Character> idLookup;
 	
 	GCNDataFileHandler fe8databin;
+	FE9CommonTextLoader textData;
 	
 	public FE9CharacterDataLoader(GCNISOHandler isoHandler, FE9CommonTextLoader commonTextLoader) throws GCNISOException {
 		allCharacters = new ArrayList<FE9Character>();
@@ -63,6 +66,7 @@ public class FE9CharacterDataLoader {
 		knownPointers = new HashMap<Long, String>();
 		
 		daeinMinionsByJID = new HashMap<String, List<FE9Character>>();
+		pid14MinionsByJID = new HashMap<String, List<FE9Character>>();
 		
 		idLookup = new HashMap<String, FE9Character>();
 		
@@ -71,6 +75,8 @@ public class FE9CharacterDataLoader {
 		if (handler instanceof GCNDataFileHandler) {
 			fe8databin = (GCNDataFileHandler)handler;
 		}
+		
+		textData = commonTextLoader;
 		
 		long offset = FE9Data.CharacterDataStartOffset;
 		for (int i = 0; i < FE9Data.CharacterCount; i++) {
@@ -126,7 +132,7 @@ public class FE9CharacterDataLoader {
 				bossCharacters.add(character);
 			}
 			
-			if ((pid.contains("_DAYNE") || pid.contains("_ZAKO") || pid.contains("_BANDIT")) && !pid.contains("_EV")) {
+			if (isMinionCharacter(character)) {
 				minionCharacters.add(character);
 				if (pid.contains("_DAYNE")) {
 					// Daein soldiers have classes built into them, so we need to explicitly change PIDs when randomizing minions later.
@@ -139,6 +145,14 @@ public class FE9CharacterDataLoader {
 						daeinMinionsByJID.put(jid, daeinCharacters);
 					}
 					daeinCharacters.add(character);
+				} else if (pid.startsWith("PID_14_")) {
+					// Chapter 13 units also do the same thing as the Daein soldiers, where their classes are baked in to the PID.
+					List<FE9Character> pid14Characters = pid14MinionsByJID.get(jid);
+					if (pid14Characters == null) {
+						pid14Characters = new ArrayList<FE9Character>();
+						pid14MinionsByJID.put(jid, pid14Characters);
+					}
+					pid14Characters.add(character);
 				}
 			}
 		}
@@ -161,7 +175,12 @@ public class FE9CharacterDataLoader {
 	public boolean isMinionCharacter(FE9Character character) {
 		if (character == null) { return false; }
 		String pid = fe8databin.stringForPointer(character.getCharacterIDPointer());
-		return ((pid.contains("_DAYNE") || pid.contains("_ZAKO") || pid.contains("_BANDIT")) && !pid.contains("_EV"));
+		return (pid.contains("_DAYNE") || pid.contains("_ZAKO") || pid.contains("_BANDIT") ||
+				pid.startsWith("PID_14_") || // Chapter 13, also has classes baked in.
+				pid.startsWith("PID_15_PEDDLING") || // Chapter 14 minions all use the same PID, with an optional suffix for the two Feral Ones.
+				pid.equals("PID_16_LIBERATION") || // Chapter 15 laguz units all use the same PID.
+				pid.equals("PID_178_TANAS") // Chapter 16 and 17 are all the same.
+				) && !pid.contains("_EV");
 	}
 	
 	public boolean isRestrictedMinionCharacterPID(String pid) {
@@ -186,6 +205,10 @@ public class FE9CharacterDataLoader {
 		FE9Data.Character fe9Char = FE9Data.Character.withPID(getPIDForCharacter(character));
 		if (fe9Char == null) { return false; }
 		return fe9Char.isModifiable() && !fe9Char.isBugged();
+	}
+	
+	public List<FE9Character> allCharacters() {
+		return allCharacters;
 	}
 	
 	public FE9Character[] allPlayableCharacters() {
@@ -224,8 +247,44 @@ public class FE9CharacterDataLoader {
 		return pid.contains("_DAYNE");
 	}
 	
+	public List<String> availableJIDsForDaeinMinions() {
+		List<String> jids = new ArrayList<String>(daeinMinionsByJID.keySet());
+		jids.sort(new Comparator<String>() {
+			@Override
+			public int compare(String o1, String o2) {
+				return o1.compareTo(o2);
+			}
+		});
+		return jids;
+	}
+	
+	public List<String> availableJIDsForPID14Minions() {
+		List<String> jids = new ArrayList<String>(pid14MinionsByJID.keySet());
+		jids.sort(new Comparator<String>() {
+			@Override
+			public int compare(String o1, String o2) {
+				return o1.compareTo(o2);
+			}
+		});
+		return jids;
+	}
+	
+	public boolean isPID14Character(FE9Character character) {
+		String pid = getPIDForCharacter(character);
+		if (pid == null) { return false; }
+		return pid.startsWith("PID_14");
+	}
+	
 	public List<FE9Character> getDaeinCharactersForJID(String jid) {
 		return daeinMinionsByJID.get(jid);
+	}
+	
+	public List<FE9Character> getPID14CharactersForJID(String jid) {
+		return pid14MinionsByJID.get(jid);
+	}
+	
+	public String getDisplayName(FE9Character character) {
+		return textData.textStringForIdentifier(getMPIDForCharacter(character));
 	}
 	
 	public String getPIDForCharacter(FE9Character character) {
@@ -243,6 +302,13 @@ public class FE9CharacterDataLoader {
 		if (character.getCharacterNamePointer() == 0) { return null; }
 		
 		return fe8databin.stringForPointer(character.getCharacterNamePointer());
+	}
+	
+	public String getFIDForCharacter(FE9Character character) {
+		if (character == null) { return null; }
+		if (character.getPortraitPointer() == 0) { return null; }
+		
+		return fe8databin.stringForPointer(character.getPortraitPointer());
 	}
 	
 	public String getJIDForCharacter(FE9Character character) {
@@ -463,6 +529,18 @@ public class FE9CharacterDataLoader {
 		}
 	}
 	
+	public int getLevelForCharacter(FE9Character character) {
+		return character.getLevel();
+	}
+	
+	public int getBuildForCharacter(FE9Character character) {
+		return character.getBuild();
+	}
+	
+	public int getWeightForCharacter(FE9Character character) {
+		return character.getWeight();
+	}
+	
 	public FE9Data.Affinity getAffinityForCharacter(FE9Character character) {
 		String affinityID = fe8databin.stringForPointer(character.getAffinityPointer());
 		return FE9Data.Affinity.withID(affinityID);
@@ -484,9 +562,11 @@ public class FE9CharacterDataLoader {
 		try {
 			GCNFileHandler handler = isoHandler.handlerForFileWithName(FE9Data.CharacterDataFilename);
 			for (FE9Character character : allCharacters) {
+				DebugPrinter.log(DebugPrinter.Key.FE9_CHARACTER_LOADER, "Writing character: " + getDisplayName(character));
 				character.commitChanges();
 				if (character.hasCommittedChanges()) {
 					Diff charDiff = new Diff(character.getAddressOffset(), character.getData().length, character.getData(), null);
+					DebugPrinter.log(DebugPrinter.Key.FE9_CHARACTER_LOADER, "Adding change for " + getDisplayName(character) + " at address 0x" + Long.toHexString(character.getAddressOffset()));
 					handler.addChange(charDiff);
 				}
 			}

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -323,6 +323,9 @@ public class FE9Randomizer extends Randomizer {
 		sb.append((char)0xA);
 		sb.append("Celerity when you're at a base.");
 		textData.setStringForIdentifier("MH_I_SWIFT", sb.toString());
+		
+		// Daunt scroll also doesn't have the correct name.
+		textData.setStringForIdentifier("MIID_HORROR", "Daunt");
 	}
 	
 	private void makePostRandomizationAdjustments(String seed) {
@@ -632,6 +635,10 @@ public class FE9Randomizer extends Randomizer {
 					FE9RewardsRandomizer.randomizeRewards(itemData, chapterData, rng);
 					break;
 				}
+			}
+			if (miscOptions.enemyDropChance > 0) {
+				Random rng = new Random(SeedGenerator.generateSeedValue(seed, FE9RewardsRandomizer.rngSalt));
+				FE9RewardsRandomizer.addEnemyDrops(charData, itemData, chapterData, miscOptions.enemyDropChance, rng);
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9RewardsRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9RewardsRandomizer.java
@@ -3,10 +3,14 @@ package random.gcnwii.fe9.randomizer;
 import java.util.List;
 import java.util.Random;
 
+import fedata.gcnwii.fe9.FE9ChapterArmy;
 import fedata.gcnwii.fe9.FE9ChapterRewards;
 import fedata.gcnwii.fe9.FE9ChapterRewardsProcessor;
+import fedata.gcnwii.fe9.FE9ChapterUnit;
+import fedata.gcnwii.fe9.FE9Data;
 import fedata.gcnwii.fe9.FE9Item;
 import random.gcnwii.fe9.loader.FE9ChapterDataLoader;
+import random.gcnwii.fe9.loader.FE9CharacterDataLoader;
 import random.gcnwii.fe9.loader.FE9ItemDataLoader;
 import util.DebugPrinter;
 
@@ -41,6 +45,62 @@ public class FE9RewardsRandomizer {
 			});
 			
 			rewards.commitChanges();
+		}
+	}
+	
+	public static void addEnemyDrops(FE9CharacterDataLoader charData, FE9ItemDataLoader itemData, FE9ChapterDataLoader chapterData, int dropChance, Random rng) {
+		List<FE9Item> potentialItemRewards = itemData.getPossibleRewards();
+		potentialItemRewards.removeIf(item -> { return itemData.isWeapon(item); });
+		
+		for (FE9Data.Chapter chapter : FE9Data.Chapter.allChapters()) {
+			List<FE9ChapterArmy> armies = chapterData.armiesForChapter(chapter);
+			for (FE9ChapterArmy army : armies) {
+				for (String unitID : army.getAllUnitIDs()) {
+					FE9ChapterUnit unit = army.getUnitForUnitID(unitID);
+					String pid = army.getPIDForUnit(unit);
+					if (charData.isMinionCharacter(charData.characterWithID(pid))) {
+						if (rng.nextInt(100) < dropChance) {
+							// We want to drop. 50% of these should be weapons, and 50% should be items.
+							if (rng.nextInt(2) == 0 && army.getWeapon1ForUnit(unit) != null) {
+								// Drop the weapon.
+								unit.setWillDropWeapon1(true);
+							} else {
+								if (potentialItemRewards.isEmpty()) { continue; }
+								FE9Item droppedItem = potentialItemRewards.get(rng.nextInt(potentialItemRewards.size()));
+								// Drop an item.
+								if (unit.willDropItem1()) {
+									if (army.getItem1ForUnit(unit).equals(FE9Data.Item.CHEST_KEY.getIID())) { continue; } // Do not replace chest keys.
+									army.setItem1ForUnit(unit, itemData.iidOfItem(droppedItem));
+								} else if (unit.willDropItem2()) {
+									if (army.getItem2ForUnit(unit).equals(FE9Data.Item.CHEST_KEY.getIID())) { continue; }
+									army.setItem2ForUnit(unit, itemData.iidOfItem(droppedItem));
+								} else if (unit.willDropItem3()) {
+									if (army.getItem3ForUnit(unit).equals(FE9Data.Item.CHEST_KEY.getIID())) { continue; }
+									army.setItem3ForUnit(unit, itemData.iidOfItem(droppedItem));
+								} else if (unit.willDropItem4()) {
+									if (army.getItem4ForUnit(unit).equals(FE9Data.Item.CHEST_KEY.getIID())) { continue; }
+									army.setItem4ForUnit(unit, itemData.iidOfItem(droppedItem));
+								} else {
+									if (army.getItem1ForUnit(unit) == null) {
+										army.setItem1ForUnit(unit, itemData.iidOfItem(droppedItem));
+										unit.setWillDropItem1(true);
+									} else if (army.getItem2ForUnit(unit) == null) {
+										army.setItem2ForUnit(unit, itemData.iidOfItem(droppedItem));
+										unit.setWillDropItem2(true);
+									} else if (army.getItem3ForUnit(unit) == null) {
+										army.setItem3ForUnit(unit, itemData.iidOfItem(droppedItem));
+										unit.setWillDropItem3(true);
+									} else if (army.getItem4ForUnit(unit) == null) {
+										army.setItem4ForUnit(unit, itemData.iidOfItem(droppedItem));
+										unit.setWillDropItem4(true);
+									}
+								}
+							}
+						}
+					}
+				}
+				army.commitChanges();
+			}
 		}
 	}
 

--- a/Universal FE Randomizer/src/ui/MiscellaneousView.java
+++ b/Universal FE Randomizer/src/ui/MiscellaneousView.java
@@ -7,9 +7,13 @@ import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Spinner;
+import org.eclipse.swt.widgets.Widget;
 
 import fedata.general.FEBase.GameType;
 import ui.model.MiscellaneousOptions;
@@ -30,6 +34,10 @@ public class MiscellaneousView extends Composite {
 	private Composite rewardModeContainer;
 	private Button similarRewardsButton;
 	private Button randomRewardsButton;
+	
+	private Button enemyDropsButton;
+	private Label enemyDropChanceLabel;
+	private Spinner enemyDropChanceSpinner;
 	
 	public MiscellaneousView(Composite parent, int style, GameType gameType) {
 		super(parent, style);
@@ -84,6 +92,8 @@ public class MiscellaneousView extends Composite {
 		}
 		randomizeChestVillageRewards.setLayoutData(chestVillageData);
 		
+		Control previousControl = randomizeChestVillageRewards;
+		
 		if (gameType == GameType.FE9) {
 			rewardModeContainer = new Composite(container, SWT.NONE);
 			rewardModeContainer.setLayout(new FormLayout());
@@ -133,6 +143,49 @@ public class MiscellaneousView extends Composite {
 					randomRewardsButton.setEnabled(randomizeChestVillageRewards.getSelection());
 				}
 			});
+			
+			previousControl = rewardModeContainer;
+		}
+		
+		// Random enemy drops
+		if (gameType == GameType.FE9) {
+			enemyDropsButton = new Button(container, SWT.CHECK);
+			enemyDropsButton.setText("Add Random Enemy Drops");
+			enemyDropsButton.setToolTipText("Gives a chance for random minions to drop weapons or a random item.");
+			enemyDropsButton.setSelection(false);
+			
+			FormData dropData = new FormData();
+			dropData.left = new FormAttachment(0, 5);
+			dropData.top = new FormAttachment(previousControl, 10);
+			enemyDropsButton.setLayoutData(dropData);
+			
+			enemyDropChanceSpinner = new Spinner(container, SWT.NONE);
+			enemyDropChanceSpinner.setValues(10, 1, 100, 0, 1, 5);
+			enemyDropChanceSpinner.setEnabled(false);
+			
+			FormData spinnerData = new FormData();
+			spinnerData.right = new FormAttachment(100, -5);
+			spinnerData.top = new FormAttachment(enemyDropsButton, 5);
+			enemyDropChanceSpinner.setLayoutData(spinnerData);
+			
+			enemyDropChanceLabel = new Label(container, SWT.RIGHT);
+			enemyDropChanceLabel.setText("Chance: ");
+			enemyDropChanceLabel.setEnabled(false);
+			
+			FormData labelData = new FormData();
+			labelData.right = new FormAttachment(enemyDropChanceSpinner, -5);
+			labelData.top = new FormAttachment(enemyDropChanceSpinner, 0, SWT.CENTER);
+			enemyDropChanceLabel.setLayoutData(labelData);
+			
+			enemyDropsButton.addListener(SWT.Selection, new Listener() {
+				@Override
+				public void handleEvent(Event event) {
+					enemyDropChanceSpinner.setEnabled(enemyDropsButton.getSelection());
+					enemyDropChanceLabel.setEnabled(enemyDropsButton.getSelection());
+				}
+			});
+			
+			previousControl = enemyDropChanceSpinner;
 		}
 	}
 	
@@ -164,7 +217,7 @@ public class MiscellaneousView extends Composite {
 				return new MiscellaneousOptions(false, false);
 			}
 		} else if (type.isGCN()) {
-			return new MiscellaneousOptions(false, randomizeChestVillageRewards.getSelection(), rewardMode);
+			return new MiscellaneousOptions(false, randomizeChestVillageRewards.getSelection(), rewardMode, enemyDropsButton.getSelection() ? enemyDropChanceSpinner.getSelection() : 0);
 		}
 		
 		return new MiscellaneousOptions(false, false);
@@ -188,6 +241,14 @@ public class MiscellaneousView extends Composite {
 			if (randomRewardsButton != null) {
 				randomRewardsButton.setSelection(options.rewardMode == RewardMode.RANDOM);
 				randomRewardsButton.setEnabled(options.randomizeRewards);
+			}
+			if (enemyDropsButton != null && enemyDropChanceSpinner != null) {
+				enemyDropsButton.setSelection(options.enemyDropChance > 0);
+				enemyDropChanceSpinner.setEnabled(options.enemyDropChance > 0);
+				enemyDropChanceLabel.setEnabled(options.enemyDropChance > 0);
+				if (options.enemyDropChance > 0) {
+					enemyDropChanceSpinner.setSelection(options.enemyDropChance);
+				}
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/ui/fe9/FE9ClassesView.java
+++ b/Universal FE Randomizer/src/ui/fe9/FE9ClassesView.java
@@ -178,24 +178,13 @@ public class FE9ClassesView extends Composite {
 		minionData.top = new FormAttachment(mixBossRaces, 10);
 		randomizeMinions.setLayoutData(minionData);
 		
-		mixMinionRaces = new Button(container, SWT.CHECK);
-		mixMinionRaces.setText("Allow Cross-race Assignments");
-		mixMinionRaces.setToolTipText("Allows beorc minions to be assigned laguz classes and vice versa.");
-		mixMinionRaces.setEnabled(false);
-		mixMinionRaces.setSelection(false);
-		
-		FormData minionRaceData = new FormData();
-		minionRaceData.left = new FormAttachment(randomizeMinions, 5, SWT.LEFT);
-		minionRaceData.top = new FormAttachment(randomizeMinions, 5);
-		mixMinionRaces.setLayoutData(minionRaceData);
-		
 		minionChanceSpinner = new Spinner(container, SWT.NONE);
 		minionChanceSpinner.setValues(50, 1, 100, 0, 1, 5);
 		minionChanceSpinner.setEnabled(false);
 		
 		FormData spinnerData = new FormData();
 		spinnerData.right = new FormAttachment(100, -5);
-		spinnerData.top = new FormAttachment(mixMinionRaces, 5);
+		spinnerData.top = new FormAttachment(randomizeMinions, 5);
 		minionChanceSpinner.setLayoutData(spinnerData);
 		
 		minionChanceLabel = new Label(container, SWT.NONE);
@@ -207,6 +196,17 @@ public class FE9ClassesView extends Composite {
 		labelData.top = new FormAttachment(minionChanceSpinner, 0, SWT.CENTER);
 		minionChanceLabel.setLayoutData(labelData);
 		
+		mixMinionRaces = new Button(container, SWT.CHECK);
+		mixMinionRaces.setText("Allow Cross-race Assignments");
+		mixMinionRaces.setToolTipText("Allows beorc minions to be assigned laguz classes and vice versa.");
+		mixMinionRaces.setEnabled(false);
+		mixMinionRaces.setSelection(false);
+		
+		FormData minionRaceData = new FormData();
+		minionRaceData.left = new FormAttachment(randomizeMinions, 5, SWT.LEFT);
+		minionRaceData.top = new FormAttachment(minionChanceSpinner, 5);
+		mixMinionRaces.setLayoutData(minionRaceData);
+		
 		forceDifferent = new Button(container, SWT.CHECK);
 		forceDifferent.setText("Force Class Change");
 		forceDifferent.setToolTipText("Ensures that no character will remain the same class if randomized.");
@@ -215,7 +215,7 @@ public class FE9ClassesView extends Composite {
 		
 		FormData differentData = new FormData();
 		differentData.left = new FormAttachment(0, 5);
-		differentData.top = new FormAttachment(minionChanceLabel, 10);
+		differentData.top = new FormAttachment(mixMinionRaces, 20);
 		forceDifferent.setLayoutData(differentData);
 	}
 	

--- a/Universal FE Randomizer/src/ui/model/MiscellaneousOptions.java
+++ b/Universal FE Randomizer/src/ui/model/MiscellaneousOptions.java
@@ -9,6 +9,7 @@ public class MiscellaneousOptions {
 	public final Boolean applyEnglishPatch;
 	
 	public final Boolean randomizeRewards;
+	public final Integer enemyDropChance;
 	
 	public final RewardMode rewardMode;
 	
@@ -17,6 +18,7 @@ public class MiscellaneousOptions {
 		this.applyEnglishPatch = false;
 		rewardMode = RewardMode.RANDOM;
 		this.randomizeRewards = randomRewards;
+		enemyDropChance = 0;
 	}
 
 	public MiscellaneousOptions(Boolean applyEnglishPatch, Boolean randomRewards) {
@@ -24,12 +26,14 @@ public class MiscellaneousOptions {
 		this.applyEnglishPatch = applyEnglishPatch;
 		rewardMode = RewardMode.RANDOM;
 		this.randomizeRewards = randomRewards;
+		enemyDropChance = 0;
 	}
 	
-	public MiscellaneousOptions(Boolean applyEnglishPatch, Boolean randomRewards, RewardMode rewardMode) {
+	public MiscellaneousOptions(Boolean applyEnglishPatch, Boolean randomRewards, RewardMode rewardMode, Integer enemyDropChance) {
 		super();
 		this.applyEnglishPatch = applyEnglishPatch;
 		this.rewardMode = rewardMode;
 		this.randomizeRewards = randomRewards;
+		this.enemyDropChance = enemyDropChance;
 	}
 }

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -28,7 +28,7 @@ public class OptionRecorder {
 	
 	private static final Integer FE4OptionBundleVersion = 2;
 	private static final Integer GBAOptionBundleVersion = 2;
-	private static final Integer FE9OptionBundleVersion = 1;
+	private static final Integer FE9OptionBundleVersion = 2;
 	
 	public static class AllOptions {
 		public FE4OptionBundle fe4;


### PR DESCRIPTION
Fixed #234 - Fixed an issue where minions between Chapters 13 and 17 were using special PIDs.

Also:

* Updated logic to make sure enemies with class-specific PIDs can only change to classes that have another corresponding PID.
* Added a new option to add random drops for enemies.
* Added a display string for the Daunt scroll.