### PR TITLE
[Issue #258] Added restrictions to prevent sprite cache overload in Ch. 20

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFEChapterData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEChapterData.java
@@ -23,4 +23,6 @@ public interface GBAFEChapterData {
 	public void applyNudges();
 	
 	public GBAFEChapterItemData chapterItemGivenToCharacter(int characterID);
+	
+	public int getMaxEnemyClassLimit();
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Chapter.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Chapter.java
@@ -45,6 +45,8 @@ public class FE6Chapter implements GBAFEChapterData {
 	
 	private CharacterNudge[] nudges;
 	
+	private int maxEnemyClassLimit = 0;
+	
 	public FE6Chapter(FileHandler handler, long pointer, Boolean isClassSafe, Boolean removeFightScenes, int[] blacklistedClassIDs, String friendlyName, Boolean simple, CharacterNudge[] nudgesRequired) {
 		this.friendlyName = friendlyName;
 		this.blacklistedClassIDs = new HashSet<Integer>();
@@ -474,4 +476,12 @@ public class FE6Chapter implements GBAFEChapterData {
 	}
 
 	public GBAFEChapterItemData chapterItemGivenToCharacter(int characterID) { return null; }
+	
+	public void setMaxEnemyClassLimit(int limit) {
+		maxEnemyClassLimit = limit;
+	}
+	
+	public int getMaxEnemyClassLimit() {
+		return maxEnemyClassLimit;
+	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Chapter.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Chapter.java
@@ -57,6 +57,7 @@ public class FE7Chapter implements GBAFEChapterData {
 	private int probableLordID = 0;
 	private int probableBossID = 0;
 	
+	private int maxEnemyClassLimit = 0;
 
 	public FE7Chapter(FileHandler handler, long pointer, Boolean isClassSafe, Boolean removeFightScenes, int[] blacklistedClassIDs, String friendlyName, Boolean simple) {
 		
@@ -667,4 +668,12 @@ public class FE7Chapter implements GBAFEChapterData {
 	}
 	
 	public GBAFEChapterItemData chapterItemGivenToCharacter(int characterID) { return null; }
+	
+	public void setMaxEnemyClassLimit(int limit) {
+		maxEnemyClassLimit = limit;
+	}
+	
+	public int getMaxEnemyClassLimit() {
+		return maxEnemyClassLimit;
+	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Chapter.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Chapter.java
@@ -58,6 +58,8 @@ public class FE8Chapter implements GBAFEChapterData {
 	
 	private CharacterNudge[] nudges;
 	
+	private int maxEnemyClassLimit = 0;
+	
 	public FE8Chapter(FileHandler handler, long pointer, Boolean isClassSafe, Boolean removeFightScenes, int[] blacklistedClassIDs, String friendlyName, Boolean simple, int[] targetedRewardRecipientsToTrack, int[] unarmedCharacters, long[] additionalUnitOffsets, CharacterNudge[] nudgesRequired) {
 		this.friendlyName = friendlyName;
 		this.blacklistedClassIDs = new HashSet<Integer>();
@@ -576,5 +578,13 @@ public class FE8Chapter implements GBAFEChapterData {
 	
 	public GBAFEChapterItemData chapterItemGivenToCharacter(int characterID) {
 		return targetedChapterRewards.get(characterID);
+	}
+	
+	public void setMaxEnemyClassLimit(int limit) {
+		maxEnemyClassLimit = limit;
+	}
+	
+	public int getMaxEnemyClassLimit() {
+		return maxEnemyClassLimit;
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -1765,6 +1765,16 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 				return null;
 			}
 		}
+		
+		public int enemyClassLimit() {
+			switch (this) {
+			case CHAPTER_20_EIRIKA:
+			case CHAPTER_20_EPHRAIM:
+				return 9;
+			default:
+				return 0;
+			}
+		}
 	}
 	
 	public enum PromotionItem implements GBAFEPromotionItem {

--- a/Universal FE Randomizer/src/random/gba/loader/ChapterLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ChapterLoader.java
@@ -128,7 +128,8 @@ public class ChapterLoader {
 					CharacterNudge[] nudges = chapter.nudgesRequired();
 					long chapterOffset = baseAddress + (4 * chapter.chapterID);
 					DebugPrinter.log(DebugPrinter.Key.CHAPTER_LOADER, "Loading " + chapter.toString());
-					FE8Chapter fe8Chapter = new FE8Chapter(handler, chapterOffset, chapter.isClassSafe(), chapter.shouldRemoveFightScenes(), classBlacklist, chapter.toString(), chapter.shouldBeEasy(), trackedRewardRecipients, unarmedCharacterIDs, chapter.additionalUnitOffsets(), nudges); 
+					FE8Chapter fe8Chapter = new FE8Chapter(handler, chapterOffset, chapter.isClassSafe(), chapter.shouldRemoveFightScenes(), classBlacklist, chapter.toString(), chapter.shouldBeEasy(), trackedRewardRecipients, unarmedCharacterIDs, chapter.additionalUnitOffsets(), nudges);
+					fe8Chapter.setMaxEnemyClassLimit(chapter.enemyClassLimit());
 					chapters[i++] = fe8Chapter;
 					mappedChapters.put(chapterID, fe8Chapter);
 					DebugPrinter.log(DebugPrinter.Key.CHAPTER_LOADER, "Chapter " + chapter.toString() + " loaded " + fe8Chapter.allUnits().length + " characters and " + fe8Chapter.allRewards().length + " rewards");


### PR DESCRIPTION
Fixed #258 - Added logic to try and prevent overloading the sprite cache when randomizing minions in enemy-abundant chapters. (So far, only FE8's Ch. 20 is affected)

As the logic is fairly restrictive in the class selection, I've only applied this to one chapter in all of the GBAFE games, as it's the only chapter that exhibits this issue (at least the only one reported to have this issue). The theory is that, due to the large number enemies on the screen, randomizing minion classes randomly will likely increase the types of sprites on the map. This will overload the sprite cache and cause some graphics to become corrupted randomly. It's mostly an aesthetic issue, as the underlying data is should be fine. As far as I know, only FE8 exhibits this issue, and only if there are an abundance of unique sprites needed for a chapter. The logic simply locks the number of different classes the normal enemies can be assigned if the option is enabled. The vanilla game has 9 different regular enemy types, so that's where the limit came from.