### PR TITLE
[Issue #288] FE9 tweaks

### DIFF
--- a/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9Data.java
+++ b/Universal FE Randomizer/src/fedata/gcnwii/fe9/FE9Data.java
@@ -663,9 +663,9 @@ public class FE9Data {
 		}
 		
 		public static Set<Skill> allValidSkills = new HashSet<Skill>(Arrays.asList(PARAGON, RENEWAL, CELERITY, RESOLVE, TEMPEST, SERENITY, SAVIOR, VANTAGE,
-				NIHIL, WRATH, GUARD, MIRACLE, ADEPT, CORROSION, COUNTER, DAUNT, PROVOKE, SHADE, GAMBLE, PARITY, SMITE, BLOSSOM));
+				NIHIL, WRATH, GUARD, MIRACLE, ADEPT, CORROSION, COUNTER, DAUNT, PROVOKE, SHADE, GAMBLE, PARITY, SMITE, BLOSSOM, INSIGHT, VIGILANCE));
 		public static Set<Skill> playerOnlySkills = new HashSet<Skill>(Arrays.asList(PARAGON, SAVIOR, PROVOKE, SHADE, GAMBLE, SMITE, BLOSSOM));
-		public static Set<Skill> replaceableInvalidSkills = new HashSet<Skill>(Arrays.asList(REINFORCE, INSIGHT, VIGILANCE));
+		public static Set<Skill> replaceableInvalidSkills = new HashSet<Skill>(Arrays.asList(REINFORCE));
 		
 		public static Set<Skill> occultSkills = new HashSet<Skill>(Arrays.asList(SOL, LUNA, ASTRA, LETHALITY, DEADEYE, COLOSSUS, STUN, ROAR, BOON, BLESSING, AETHER, FLARE, CANCEL));
 		public static Map<CharacterClass, Skill> occultSkillsByClass = new HashMap<CharacterClass, Skill>() {
@@ -762,7 +762,7 @@ public class FE9Data {
 		}};
 		
 		public boolean isModifiable() {
-			return allValidSkills.contains(this);
+			return allValidSkills.contains(this) || replaceableInvalidSkills.contains(this);
 		}
 		
 		public boolean isOccult() {
@@ -1118,7 +1118,8 @@ public class FE9Data {
 		public static Set<Item> allSkillScrolls = new HashSet<Item>(Arrays.asList(PARAGON_SCROLL, OCCULT_SCROLL, RESOLVE_SCROLL, SAVIOR_SCROLL, VANTAGE_SCROLL,
 				NIHIL_SCROLL, WRATH_SCROLL, CORROSION_SCROLL, MIRACLE_SCROLL, COUNTER_SCROLL, DAUNT_SCROLL, PROVOKE_SCROLL, SHADE_SCROLL, GAMBLE_SCROLL, 
 				PARITY_SCROLL, SMITE_SCROLL, GUARD_SCROLL, ADEPT_SCROLL, RENEWAL_SCROLL, CELERITY_SCROLL, BLOSSOM_SCROLL));
-		public static Set<Item> allConsumables = new HashSet<Item>(Arrays.asList(LAGUZ_STONE, LAGUZ_STONE_1, MASTER_SEAL, CHEST_KEY, DOOR_KEY, 
+		public static Set<Item> allPromotionItems = new HashSet<Item>(Arrays.asList(MASTER_SEAL));
+		public static Set<Item> allConsumables = new HashSet<Item>(Arrays.asList(LAGUZ_STONE, LAGUZ_STONE_1, CHEST_KEY, DOOR_KEY, 
 				VULNERARY, ELIXIR, PURE_WATER, ANTITOXIN, TORCH, COIN));
 		public static Set<Item> allGems = new HashSet<Item>(Arrays.asList(WHITE_GEM, BLUE_GEM, RED_GEM));
 		
@@ -1192,6 +1193,7 @@ public class FE9Data {
 		}
 		
 		public boolean isConsumable() { return allConsumables.contains(this); }
+		public boolean isPromotionItem() { return allPromotionItems.contains(this); }
 		public boolean isStatBooster() { return allStatBoosters.contains(this); }
 		public boolean isTreasure() { return allGems.contains(this); }
 		public boolean isSkillScroll() { return allSkillScrolls.contains(this); }

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
@@ -394,6 +394,10 @@ public class FE9ItemDataLoader {
 		return FE9Data.Item.withIID(iidOfItem(item)).isConsumable();
 	}
 	
+	public boolean isPromotionItem(FE9Item item) {
+		return FE9Data.Item.withIID(iidOfItem(item)).isPromotionItem();
+	}
+	
 	public boolean isStatBooster(FE9Item item) {
 		return FE9Data.Item.withIID(iidOfItem(item)).isStatBooster();
 	}
@@ -1208,8 +1212,12 @@ public class FE9ItemDataLoader {
 			if (original.isBRank()) { fe9DataItems.addAll(FE9Data.Item.allBRankWeapons); }
 			if (original.isARank()) { fe9DataItems.addAll(FE9Data.Item.allARankWeapons); }
 			if (original.isSRank()) { fe9DataItems.addAll(FE9Data.Item.allSRankWeapons); }
-		} else if (isConsumable(originalItem)) {
+		} else if (isConsumable(originalItem) || isPromotionItem(originalItem)) {
 			fe9DataItems.addAll(FE9Data.Item.allConsumables);
+			// Equally weight these.
+			for (int i = 0; i < FE9Data.Item.allConsumables.size(); i += FE9Data.Item.allPromotionItems.size()) {
+				fe9DataItems.addAll(FE9Data.Item.allPromotionItems);
+			}
 		} else if (isStatBooster(originalItem)) {
 			fe9DataItems.addAll(FE9Data.Item.allStatBoosters);
 		} else if (isTreasure(originalItem)) {
@@ -1231,6 +1239,9 @@ public class FE9ItemDataLoader {
 		fe9DataItems.addAll(FE9Data.Item.allStatBoosters);
 		fe9DataItems.addAll(FE9Data.Item.allSkillScrolls);
 		fe9DataItems.addAll(FE9Data.Item.allConsumables);
+		for (int i = 0; i < FE9Data.Item.allConsumables.size(); i += FE9Data.Item.allPromotionItems.size()) {
+			fe9DataItems.addAll(FE9Data.Item.allPromotionItems);
+		}
 		
 		return fe9ItemListFromSet(fe9DataItems);
 	}

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9SkillDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9SkillDataLoader.java
@@ -175,8 +175,13 @@ public class FE9SkillDataLoader {
 		else if (charClass == CharacterClass.ASSASSIN || 
 				charClass == CharacterClass.THIEF ||
 				charClass == CharacterClass.SAGE_KNIFE || 
-				charClass == CharacterClass.SAGE_KNIFE_F) { skills.add(getSkillWithSID(FE9Data.Skill.EQUIP_KNIFE.getSID())); }
-		
+				charClass == CharacterClass.SAGE_KNIFE_F) { 
+			skills.add(getSkillWithSID(FE9Data.Skill.EQUIP_KNIFE.getSID()));
+			if (charClass == CharacterClass.ASSASSIN || 
+				charClass == CharacterClass.THIEF) {
+				skills.add(getSkillWithSID(FE9Data.Skill.KEY_0.getSID()));
+			}
+		}
 		return skills;
 	}
 

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9ClassRandomizer.java
@@ -132,12 +132,12 @@ public class FE9ClassRandomizer {
 			
 			if (classData.isLaguzClass(originalClass) && !classData.isLaguzClass(newClass)) {
 				// Laguz -> Beorc
-				strBase += (int)Math.floor(classData.getLaguzSTROffset(originalClass) * 1.5);
-				magBase += (int)Math.floor(classData.getLaguzMAGOffset(originalClass) * 1.5);
-				sklBase += (int)Math.floor(classData.getLaguzSKLOffset(originalClass) * 1.5);
-				spdBase += (int)Math.floor(classData.getLaguzSPDOffset(originalClass) * 1.5);
-				defBase += (int)Math.floor(classData.getLaguzDEFOffset(originalClass) * 1.5);
-				resBase += (int)Math.floor(classData.getLaguzRESOffset(originalClass) * 1.5);
+				strBase += (int)Math.floor(classData.getLaguzSTROffset(originalClass) * 0.5);
+				magBase += (int)Math.floor(classData.getLaguzMAGOffset(originalClass) * 0.5);
+				sklBase += (int)Math.floor(classData.getLaguzSKLOffset(originalClass) * 0.5);
+				spdBase += (int)Math.floor(classData.getLaguzSPDOffset(originalClass) * 0.5);
+				defBase += (int)Math.floor(classData.getLaguzDEFOffset(originalClass) * 0.5);
+				resBase += (int)Math.floor(classData.getLaguzRESOffset(originalClass) * 0.5);
 				
 				character.setBaseSKL(sklBase);
 				character.setBaseSPD(spdBase);
@@ -559,12 +559,12 @@ public class FE9ClassRandomizer {
 			
 			if (classData.isLaguzClass(originalClass) && !classData.isLaguzClass(newClass)) {
 				// Laguz -> Beorc
-				strBase += (int)Math.floor(classData.getLaguzSTROffset(originalClass) * 1.5);
-				magBase += (int)Math.floor(classData.getLaguzMAGOffset(originalClass) * 1.5);
-				sklBase += (int)Math.floor(classData.getLaguzSKLOffset(originalClass) * 1.5);
-				spdBase += (int)Math.floor(classData.getLaguzSPDOffset(originalClass) * 1.5);
-				defBase += (int)Math.floor(classData.getLaguzDEFOffset(originalClass) * 1.5);
-				resBase += (int)Math.floor(classData.getLaguzRESOffset(originalClass) * 1.5);
+				strBase += (int)Math.floor(classData.getLaguzSTROffset(originalClass) * 0.5);
+				magBase += (int)Math.floor(classData.getLaguzMAGOffset(originalClass) * 0.5);
+				sklBase += (int)Math.floor(classData.getLaguzSKLOffset(originalClass) * 0.5);
+				spdBase += (int)Math.floor(classData.getLaguzSPDOffset(originalClass) * 0.5);
+				defBase += (int)Math.floor(classData.getLaguzDEFOffset(originalClass) * 0.5);
+				resBase += (int)Math.floor(classData.getLaguzRESOffset(originalClass) * 0.5);
 				
 				character.setBaseSKL(sklBase);
 				character.setBaseSPD(spdBase);


### PR DESCRIPTION
Fixed #288 

* Added Vigilance and Insight to the skill randomization pool.
* Increased the chance of master seals from random rewards.
* Added SID_KEY0 to assassins by default.
* Decreased the Laguz->Beorc adjustment to 0.5x transform bonuses.