### PR TITLE
"Redistribute" bases randomizer systematically assigns units too much Luck

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
@@ -36,7 +36,7 @@ public class BasesRandomizer {
 			int newDEFBase = 0;
 			int newRESBase = 0;
 			
-			int initialLuck = rng.nextInt(Math.max(1, baseTotal / 7)) + 2;
+			int initialLuck = rng.nextInt(4) + rng.nextInt(4);
 			newLCKBase += initialLuck;
 			baseTotal -= initialLuck;
 			if (baseTotal < 0) {
@@ -45,7 +45,7 @@ public class BasesRandomizer {
 			
 			if (baseTotal > 0) {	
 				do {
-					randomNum = rng.nextInt(10);
+					randomNum = rng.nextInt(9);
 					int amount = rng.nextInt(3) + 1;
 					
 					switch (randomNum) {
@@ -76,7 +76,6 @@ public class BasesRandomizer {
 						newSPDBase += amount;
 						break;
 					case 8:
-					case 9:
 						if (!WhyDoesJavaNotHaveThese.isValueBetween(newLCKBase + amount, -1 * charClass.getBaseLCK(), charClass.getMaxLCK() - charClass.getBaseLCK())) {
 							continue;
 						}


### PR DESCRIPTION
Quick summary of how the "redistribute" bases randomizer for GBA works as I understand it: after summing a character's total personal bases (and randomly either adding or subtracting 0-variance points), earmark randomly between 2 and total/7+1 points for Luck. After that, keep picking a stat randomly (at 3 HP:2 Luck:1 anything else odd) and put randomly 1-3 points into that stat, then take it out of the base total.

On average, this procedure allocates a bit over 1/4 of a unit's personal bases (+2) to Luck. For units with personal bases beyond a sweet spot of ~30 total, this pretty dramatically overweights Luck, semi-routinely generating replacements for late prepromotes with 20+ Luck bases just because that's kind of what happens when you throw a 70+ base total in.

Best I can tell, this is basically the result of, since 6c8c8b76007b84bff8303b3616256bf024214487, doubly-compensating for the lack of class Luck bases by *both* earmarking an initial allotment (which helps ensure low-personal-base-total units have normal-looking Luck) *and* double-weighting Luck when assigning randomly (which produced unusually low Luck for low-total units, but reasonable-looking results for high-total units).

Having clarified what I think is the underlying issue (lack of class Luck bases requires setting some points aside to compensate on player units), I think the most sensible way to allocate luck is to start with a random base that *does not depend* on the base total, then add to it with standard weighting. I'm less clear on what would be a good initial value, but [2d4-2](https://anydice.com/program/6b74) seems pretty solid given that most GBA starting squad units come with 2-4 base Luck.