### PR TITLE
Added option to disable cross-gender assignments for class randomization.

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -518,7 +518,7 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			return classList;
 		}
 		
-		public static Set<CharacterClass> targetClassesForRandomization(CharacterClass sourceClass, boolean isForEnemy, Boolean excludeSource, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean requireAttack, Boolean requiresRange, Boolean applyRestrictions) {
+		public static Set<CharacterClass> targetClassesForRandomization(CharacterClass sourceClass, boolean isForEnemy, Boolean excludeSource, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean requireAttack, Boolean requiresRange, Boolean applyRestrictions, Boolean restrictGender) {
 			Set<CharacterClass> limited = limitedClassesForRandomization(sourceClass);
 			if (limited != null && applyRestrictions) {
 				return limited;
@@ -563,6 +563,14 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			
 			if (isForEnemy) {
 				classList.removeAll(allPlayerOnlyClasses);
+			}
+			
+			if (restrictGender) {
+				if (sourceClass.isFemale()) {
+					classList.retainAll(allFemaleClasses);
+				} else {
+					classList.retainAll(allMaleClasses);
+				}
 			}
 			
 			classList.retainAll(allValidClasses);
@@ -2077,9 +2085,11 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		if (applyRestrictions == null) { applyRestrictions = false; }
 		Boolean excludeSpecial = options.get(GBAFEClassProvider.optionKeyExcludeSpecial);
 		if (excludeSpecial == null) { excludeSpecial = false; }
+		Boolean restrictGender = options.get(GBAFEClassProvider.optionKeyRestrictGender);
+		if (restrictGender == null) { restrictGender = false; }
 		
 		return new HashSet<GBAFEClass>(CharacterClass.targetClassesForRandomization(CharacterClass.valueOf(sourceClass.getID()), isForEnemy,
-				excludeSource, excludeLords, excludeThieves, excludeSpecial, requireAttack, requiresRange, applyRestrictions));
+				excludeSource, excludeLords, excludeThieves, excludeSpecial, requireAttack, requiresRange, applyRestrictions, restrictGender));
 	}
 	
 	public GBAFEClass correspondingMaleClass(GBAFEClass charClass) {

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -632,7 +632,7 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			return classList;
 		}
 		
-		public static Set<CharacterClass> targetClassesForRandomization(CharacterClass sourceClass, boolean isForEnemy, Boolean excludeSource, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean requireAttack, Boolean requiresRange, Boolean applyRestrictions) {
+		public static Set<CharacterClass> targetClassesForRandomization(CharacterClass sourceClass, boolean isForEnemy, Boolean excludeSource, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean requireAttack, Boolean requiresRange, Boolean applyRestrictions, Boolean restrictGender) {
 			Set<CharacterClass> limited = limitedClassesForRandomization(sourceClass);
 			if (limited != null && applyRestrictions) {
 				return limited;
@@ -673,6 +673,14 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			if (requiresRange) {
 				classList.removeAll(allPacifistClasses);
 				classList.removeAll(allMeleeLockedClasses);
+			}
+			
+			if (restrictGender) {
+				if (sourceClass.isFemale()) {
+					classList.retainAll(allFemaleClasses);
+				} else {
+					classList.retainAll(allMaleClasses);
+				}
 			}
 			
 			classList.retainAll(allValidClasses);
@@ -2618,9 +2626,11 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		if (applyRestrictions == null) { applyRestrictions = false; }
 		Boolean excludeSpecial = options.get(GBAFEClassProvider.optionKeyExcludeSpecial);
 		if (excludeSpecial == null) { excludeSpecial = false; }
+		Boolean restrictGender = options.get(GBAFEClassProvider.optionKeyRestrictGender);
+		if (restrictGender == null) { restrictGender = false; }
 		
 		return new HashSet<GBAFEClass>(CharacterClass.targetClassesForRandomization(CharacterClass.valueOf(sourceClass.getID()), isForEnemy,
-				excludeSource, excludeLords, excludeThieves, excludeSpecial, requireAttack, requiresRange, applyRestrictions));
+				excludeSource, excludeLords, excludeThieves, excludeSpecial, requireAttack, requiresRange, applyRestrictions, restrictGender));
 	}
 	
 	public GBAFEClass correspondingMaleClass(GBAFEClass charClass) {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import javax.swing.plaf.metal.OceanTheme;
-
 import fedata.gba.GBAFECharacterData;
 import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
@@ -616,7 +614,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			return classList;
 		}
 		
-		public static Set<CharacterClass> targetClassesForRandomization(CharacterClass sourceClass, boolean isForEnemy, Boolean excludeSource, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean separateMonsterClasses, Boolean requireAttack, Boolean requiresRange, Boolean requiresMelee, Boolean applyRestrictions) {
+		public static Set<CharacterClass> targetClassesForRandomization(CharacterClass sourceClass, boolean isForEnemy, Boolean excludeSource, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean separateMonsterClasses, Boolean requireAttack, Boolean requiresRange, Boolean requiresMelee, Boolean applyRestrictions, Boolean restrictGender) {
 			Set<CharacterClass> limited = limitedClassesForRandomization(sourceClass, separateMonsterClasses, requiresRange, requiresMelee);
 			if (limited != null && applyRestrictions) {
 				return limited;
@@ -672,6 +670,14 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			if (requiresMelee) {
 				classList.removeAll(allPacifistClasses);
 				classList.removeAll(allRangeLockedClasses);
+			}
+			
+			if (restrictGender) {
+				if (sourceClass.isFemale()) {
+					classList.retainAll(allFemaleClasses);
+				} else {
+					classList.retainAll(allMaleClasses);
+				}
 			}
 			
 			classList.retainAll(allValidClasses);
@@ -2794,9 +2800,11 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		if (separateMonsters == null) { separateMonsters = false; }
 		Boolean excludeSpecial = options.get(GBAFEClassProvider.optionKeyExcludeSpecial);
 		if (excludeSpecial == null) { excludeSpecial = false; }
+		Boolean restrictGender = options.get(GBAFEClassProvider.optionKeyRestrictGender);
+		if (restrictGender == null) { restrictGender = false; }
 		
 		return new HashSet<GBAFEClass>(CharacterClass.targetClassesForRandomization(CharacterClass.valueOf(sourceClass.getID()), isForEnemy,
-				excludeSource, excludeLords, excludeThieves, excludeSpecial, separateMonsters, requireAttack, requiresRange, requiresMelee, applyRestrictions));
+				excludeSource, excludeLords, excludeThieves, excludeSpecial, separateMonsters, requireAttack, requiresRange, requiresMelee, applyRestrictions, restrictGender));
 	}
 	
 	public GBAFEClass correspondingMaleClass(GBAFEClass charClass) {

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEClassProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEClassProvider.java
@@ -15,6 +15,7 @@ public interface GBAFEClassProvider {
 	public static final String optionKeyRequireRange = "requireRange";
 	public static final String optionKeyRequireMelee = "requireMelee";
 	public static final String optionKeyApplyRestrictions = "applyRestrictions";
+	public static final String optionKeyRestrictGender = "restrictGender";
 	
 	public long classDataTablePointer();
 	public int numberOfClasses();

--- a/Universal FE Randomizer/src/random/gba/loader/ClassDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ClassDataLoader.java
@@ -211,11 +211,11 @@ public class ClassDataLoader {
 		return classForID(correspondingClass.getID());
 	}
 	
-	public GBAFEClassData[] potentialClasses(GBAFEClassData sourceClass, Boolean isForEnemy, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean excludeSource, Boolean requireAttack, Boolean requireRange, Boolean requireMelee, Boolean applyRestrictions, GBAFEClassData mustLoseToClass) {
-		return potentialClasses(sourceClass, isForEnemy, excludeLords, excludeThieves, excludeSpecial, false, excludeSource, requireAttack, requireRange, requireMelee, applyRestrictions, mustLoseToClass);
+	public GBAFEClassData[] potentialClasses(GBAFEClassData sourceClass, Boolean isForEnemy, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean excludeSource, Boolean requireAttack, Boolean requireRange, Boolean requireMelee, Boolean applyRestrictions, Boolean restrictGender, GBAFEClassData mustLoseToClass) {
+		return potentialClasses(sourceClass, isForEnemy, excludeLords, excludeThieves, excludeSpecial, false, excludeSource, requireAttack, requireRange, requireMelee, applyRestrictions, restrictGender, mustLoseToClass);
 	}
 	
-	public GBAFEClassData[] potentialClasses(GBAFEClassData sourceClass, Boolean isForEnemy, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean separateMonsters, Boolean excludeSource, Boolean requireAttack, Boolean requireRange, Boolean requireMelee, Boolean applyRestrictions, GBAFEClassData mustLoseToClass) {
+	public GBAFEClassData[] potentialClasses(GBAFEClassData sourceClass, Boolean isForEnemy, Boolean excludeLords, Boolean excludeThieves, Boolean excludeSpecial, Boolean separateMonsters, Boolean excludeSource, Boolean requireAttack, Boolean requireRange, Boolean requireMelee, Boolean applyRestrictions, Boolean restrictGender, GBAFEClassData mustLoseToClass) {
 		GBAFEClass sourceCharClass = provider.classWithID(sourceClass.getID());
 		Set<GBAFEClass> targetClasses = null;
 		
@@ -229,6 +229,7 @@ public class ClassDataLoader {
 		options.put(GBAFEClassProvider.optionKeyRequireRange, requireRange);
 		options.put(GBAFEClassProvider.optionKeyRequireMelee, requireMelee);
 		options.put(GBAFEClassProvider.optionKeyApplyRestrictions, applyRestrictions);
+		options.put(GBAFEClassProvider.optionKeyRestrictGender, restrictGender);
 		
 		if (mustLoseToClass != null) {
 			targetClasses = provider.classesThatLoseToClass(provider.classWithID(sourceClass.getID()), provider.classWithID(mustLoseToClass.getID()), options);

--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -61,6 +61,7 @@ public class ClassRandomizer {
 		Boolean separateMonsters = false;
 		
 		Boolean forceChange = options.forceChange;
+		Boolean restrictGender = options.restrictGender;
 		
 		if (type == GameType.FE8) {
 			hasMonsters = true;
@@ -97,8 +98,8 @@ public class ClassRandomizer {
 			if (determinedClasses.containsKey(character.getID())) {
 				continue;
 			} else {
-				GBAFEClassData[] possibleClasses = hasMonsters ? classData.potentialClasses(originalClass, charactersData.isEnemyAtAnyPoint(character.getID()), !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, isLordCharacter, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), null) :
-					classData.potentialClasses(originalClass, charactersData.isEnemyAtAnyPoint(character.getID()), !includeLords, !includeThieves, !includeSpecial, forceChange, isLordCharacter, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), null);
+				GBAFEClassData[] possibleClasses = hasMonsters ? classData.potentialClasses(originalClass, charactersData.isEnemyAtAnyPoint(character.getID()), !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, isLordCharacter, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), restrictGender, null) :
+					classData.potentialClasses(originalClass, charactersData.isEnemyAtAnyPoint(character.getID()), !includeLords, !includeThieves, !includeSpecial, forceChange, isLordCharacter, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), restrictGender, null);
 				if (possibleClasses.length == 0) {
 					continue;
 				}
@@ -153,6 +154,7 @@ public class ClassRandomizer {
 		Boolean hasMonsters = false;
 		Boolean separateMonsters = false;
 		Boolean forceChange = options.forceChange;
+		Boolean restrictGender = options.restrictGender;
 		if (type == GameType.FE8) {
 			hasMonsters = true;
 			separateMonsters = options.separateMonsters;
@@ -194,8 +196,8 @@ public class ClassRandomizer {
 				}
 				
 				GBAFEClassData[] possibleClasses = hasMonsters ? 
-						classData.potentialClasses(originalClass, true, !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, true, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), mustLoseToClass) :
-					classData.potentialClasses(originalClass, true, !includeLords, !includeThieves, !includeSpecial, forceChange, true, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), mustLoseToClass);
+						classData.potentialClasses(originalClass, true, !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, true, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), restrictGender, mustLoseToClass) :
+					classData.potentialClasses(originalClass, true, !includeLords, !includeThieves, !includeSpecial, forceChange, true, characterRequiresRange, characterRequiresMelee, character.isClassRestricted(), restrictGender, mustLoseToClass);
 				if (possibleClasses.length == 0) {
 					continue;
 				}
@@ -234,6 +236,7 @@ public class ClassRandomizer {
 		Boolean hasMonsters = false;
 		Boolean separateMonsters = false;
 		Boolean forceChange = options.forceChange;
+		Boolean restrictGender = options.restrictGender;
 		if (type == GameType.FE8) {
 			hasMonsters = true;
 			separateMonsters = options.separateMonsters;
@@ -315,8 +318,8 @@ public class ClassRandomizer {
 						Boolean shouldMakeEasy = chapter.shouldBeSimplified();
 						GBAFEClassData loseToClass = shouldMakeEasy ? lordClass : null;
 						GBAFEClassData[] possibleClasses = hasMonsters ? 
-								classData.potentialClasses(originalClass, true, !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, true, false, false, shouldRestrictToSafeClasses, loseToClass) :
-							classData.potentialClasses(originalClass, true, false, false, false, forceChange, true, false, false, shouldRestrictToSafeClasses, loseToClass);
+								classData.potentialClasses(originalClass, true, !includeLords, !includeThieves, !includeSpecial, separateMonsters, forceChange, true, false, false, shouldRestrictToSafeClasses, restrictGender, loseToClass) :
+							classData.potentialClasses(originalClass, true, false, false, false, forceChange, true, false, false, shouldRestrictToSafeClasses, restrictGender, loseToClass);
 						if (possibleClasses.length == 0) {
 							continue;
 						}

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -2175,6 +2175,11 @@ public class GBARandomizer extends Randomizer {
 		} else {
 			rk.addHeaderItem("Force Class Change", "NO");
 		}
+		if (classes.restrictGender) {
+			rk.addHeaderItem("Restrict Gender", "YES");
+		} else {
+			rk.addHeaderItem("Restrict Gender", "NO");
+		}
 		if (gameType == GameType.FE8) {
 			if (classes.separateMonsters) {
 				rk.addHeaderItem("Mix Monster and Human Classes", "NO");

--- a/Universal FE Randomizer/src/ui/ClassesView.java
+++ b/Universal FE Randomizer/src/ui/ClassesView.java
@@ -32,6 +32,7 @@ public class ClassesView extends Composite {
 	private Button randomizeBossesButton;
 	
 	private Button forceChangeButton;
+	private Button disableCrossGenderButton;
 	private Boolean hasMonsterOption;
 	private Button mixMonsterClasses;
 	
@@ -74,6 +75,7 @@ public class ClassesView extends Composite {
 				basesAdjustClassButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection());
 				
 				forceChangeButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
+				disableCrossGenderButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
 				
 				if (hasMonsterOption) {
 					mixMonsterClasses.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
@@ -184,6 +186,7 @@ public class ClassesView extends Composite {
 			@Override
 			public void handleEvent(Event event) {
 				forceChangeButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
+				disableCrossGenderButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
 				if (hasMonsterOption) {
 					mixMonsterClasses.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
 				}
@@ -208,6 +211,7 @@ public class ClassesView extends Composite {
 				basesAdjustClassButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection());
 				
 				forceChangeButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
+				disableCrossGenderButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
 				if (hasMonsterOption) {
 					mixMonsterClasses.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
 				}
@@ -281,14 +285,25 @@ public class ClassesView extends Composite {
 		optionData.top = new FormAttachment(baseTransferGroup, 10);
 		forceChangeButton.setLayoutData(optionData);
 		
+		disableCrossGenderButton = new Button(container, SWT.CHECK);
+		disableCrossGenderButton.setText("Disable Cross-Gender Assignments");
+		disableCrossGenderButton.setToolTipText("Restricts class assignments to those that match the original class's gender.");
+		disableCrossGenderButton.setEnabled(false);
+		disableCrossGenderButton.setSelection(false);
+		
+		optionData = new FormData();
+		optionData.left = new FormAttachment(forceChangeButton, 0, SWT.LEFT);
+		optionData.top = new FormAttachment(forceChangeButton, 5);
+		disableCrossGenderButton.setLayoutData(optionData);
+		
 		if (type == GameType.FE8) {
 			mixMonsterClasses = new Button(container, SWT.CHECK);
 			mixMonsterClasses.setText("Mix Monster Classes");
 			mixMonsterClasses.setToolTipText("If enabled, allows cross-assignment of classes between humans and monsters.\nIf disabled, ensures that units that were monsters remain monsters and units that were human remain humans when randomizing classes.\nHas no effect unless another class randomization option is enabled.");
 			
 			FormData monsterData = new FormData();
-			monsterData.left = new FormAttachment(forceChangeButton, 0, SWT.LEFT);
-			monsterData.top = new FormAttachment(forceChangeButton, 5);
+			monsterData.left = new FormAttachment(disableCrossGenderButton, 0, SWT.LEFT);
+			monsterData.top = new FormAttachment(disableCrossGenderButton, 5);
 			mixMonsterClasses.setLayoutData(monsterData);
 			
 			hasMonsterOption = true;
@@ -322,9 +337,9 @@ public class ClassesView extends Composite {
 		else if (basesAdjustClassButton.getSelection()) { baseOption = BaseTransferOption.ADJUST_TO_CLASS; }
 		
 		if (hasMonsterOption) {
-			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, !mixMonsterClasses.getSelection(), forceChangeButton.getSelection(), evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption);
+			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, !mixMonsterClasses.getSelection(), forceChangeButton.getSelection(), disableCrossGenderButton.getSelection(), evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption);
 		} else {
-			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, forceChangeButton.getSelection(), evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption);
+			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, forceChangeButton.getSelection(), disableCrossGenderButton.getSelection(), evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption);
 		}
 	}
 	
@@ -376,6 +391,8 @@ public class ClassesView extends Composite {
 			if (options.randomizePCs || options.randomizeEnemies || options.randomizeEnemies) {
 				forceChangeButton.setEnabled(true);
 				forceChangeButton.setSelection(options.forceChange);
+				disableCrossGenderButton.setEnabled(true);
+				disableCrossGenderButton.setSelection(options.restrictGender);
 				
 				if (hasMonsterOption) {
 					mixMonsterClasses.setEnabled(true);
@@ -383,6 +400,7 @@ public class ClassesView extends Composite {
 				}
 			} else {
 				forceChangeButton.setEnabled(false);
+				disableCrossGenderButton.setEnabled(false);
 				if (hasMonsterOption) {
 					mixMonsterClasses.setEnabled(false);
 				}

--- a/Universal FE Randomizer/src/ui/model/ClassOptions.java
+++ b/Universal FE Randomizer/src/ui/model/ClassOptions.java
@@ -15,6 +15,7 @@ public class ClassOptions {
 	public final boolean assignEvenly;
 	
 	public final boolean forceChange;
+	public final boolean restrictGender;
 	
 	public final Boolean separateMonsters; // FE8 only.
 	
@@ -23,7 +24,7 @@ public class ClassOptions {
 	
 	public final BaseTransferOption basesTransfer;
 	
-	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, boolean forceChange, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer) {
+	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, boolean forceChange, boolean restrictGender, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer) {
 		super();
 		randomizePCs = pcs;
 		createPrfs = newPrfs;
@@ -41,9 +42,10 @@ public class ClassOptions {
 		this.basesTransfer = basesTransfer;
 		
 		this.forceChange = forceChange;
+		this.restrictGender = restrictGender;
 	}
 	
-	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, Boolean separateMonsters, boolean forceChange, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer) {
+	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, Boolean separateMonsters, boolean forceChange, boolean restrictGender, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer) {
 		super();
 		randomizePCs = pcs;
 		createPrfs = newPrfs;
@@ -61,6 +63,7 @@ public class ClassOptions {
 		this.basesTransfer = basesTransfer;
 		
 		this.forceChange = forceChange;
+		this.restrictGender = restrictGender;
 	}
 
 }

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -26,7 +26,7 @@ import ui.model.WeaponOptions;
 
 public class OptionRecorder {
 	private static final Integer FE4OptionBundleVersion = 3;
-	private static final Integer GBAOptionBundleVersion = 10;
+	private static final Integer GBAOptionBundleVersion = 11;
 	private static final Integer FE9OptionBundleVersion = 10;
 	
 	public static class AllOptions {


### PR DESCRIPTION
Fixed #188 - Added an option when randomizing classes to disable cross-gender assignments. This takes precedence over force class change if necessary. The option also applies to all enemies and bosses if those are enabled.