### PR TITLE
Added newlines to FE9 Changelog to fix overflow display issues.

### DIFF
--- a/Universal FE Randomizer/src/util/recordkeeper/ChangelogSection.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/ChangelogSection.java
@@ -43,7 +43,7 @@ public class ChangelogSection implements ChangelogElement {
 		}
 		sb.append("\"></a>");
 		for (ChangelogElement element : childElements) {
-			sb.append(element.build());
+			sb.append(element.build() + System.lineSeparator());
 		}
 		sb.append("</div>");
 		return sb.toString();

--- a/Universal FE Randomizer/src/util/recordkeeper/ChangelogText.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/ChangelogText.java
@@ -47,7 +47,7 @@ public class ChangelogText implements ChangelogElement {
 		case BOLD: sb.append(" style=\"font-weight:bold;\""); break;
 		case ITALICS: sb.append(" style=\"font-style:italic;\""); break;
 		}
-		sb.append(">" + content + "</p>");
+		sb.append(">" + content + "</p>\n");
 		
 		return sb.toString();
 	}

--- a/Universal FE Randomizer/src/util/recordkeeper/ChangelogText.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/ChangelogText.java
@@ -47,7 +47,7 @@ public class ChangelogText implements ChangelogElement {
 		case BOLD: sb.append(" style=\"font-weight:bold;\""); break;
 		case ITALICS: sb.append(" style=\"font-style:italic;\""); break;
 		}
-		sb.append(">" + content + "</p>\n");
+		sb.append(">" + content + "</p>" + System.lineSeparator());
 		
 		return sb.toString();
 	}


### PR DESCRIPTION
Fixed #276 - Added a newline in the ChangelogSection after each internal element for FE9 changelogs. This should resolve the issue where the changelog overflows and starts rendering tables on top of each other.