### PR TITLE
Added options to enable/disable specific stats for enemy buffing

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/EnemyBuffer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/EnemyBuffer.java
@@ -17,6 +17,7 @@ import random.gba.loader.ChapterLoader;
 import random.gba.loader.CharacterDataLoader;
 import random.gba.loader.ClassDataLoader;
 import random.gba.loader.ItemDataLoader;
+import ui.model.EnemyOptions;
 
 public class EnemyBuffer {
 	
@@ -25,61 +26,61 @@ public class EnemyBuffer {
 	// Enemy growths top out at 127. Going above that will underflow back to 0.
 	private static int MaximumGrowthRate = 127;
 
-	public static void buffMinionGrowthRates(int buffAmount, ClassDataLoader classData) {
+	public static void buffMinionGrowthRates(int buffAmount, ClassDataLoader classData, EnemyOptions.BuffStats buffStats) {
 		GBAFEClassData[] allClasses = classData.allClasses();
 		for (GBAFEClassData currentClass : allClasses) {
-			currentClass.setHPGrowth(Math.min(MaximumGrowthRate, currentClass.getHPGrowth() + buffAmount));
-			currentClass.setSTRGrowth(Math.min(MaximumGrowthRate, currentClass.getSTRGrowth() + buffAmount));
-			currentClass.setSKLGrowth(Math.min(MaximumGrowthRate, currentClass.getSKLGrowth() + buffAmount));
-			currentClass.setSPDGrowth(Math.min(MaximumGrowthRate, currentClass.getSPDGrowth() + buffAmount));
-			currentClass.setDEFGrowth(Math.min(MaximumGrowthRate, currentClass.getDEFGrowth() + buffAmount));
-			currentClass.setRESGrowth(Math.min(MaximumGrowthRate, currentClass.getRESGrowth() + buffAmount));
-			currentClass.setLCKGrowth(Math.min(MaximumGrowthRate, currentClass.getLCKGrowth() + buffAmount));
+			if (buffStats.hp) { currentClass.setHPGrowth(Math.min(MaximumGrowthRate, currentClass.getHPGrowth() + buffAmount)); }
+			if (buffStats.str) { currentClass.setSTRGrowth(Math.min(MaximumGrowthRate, currentClass.getSTRGrowth() + buffAmount)); }
+			if (buffStats.skl) { currentClass.setSKLGrowth(Math.min(MaximumGrowthRate, currentClass.getSKLGrowth() + buffAmount)); }
+			if (buffStats.spd) { currentClass.setSPDGrowth(Math.min(MaximumGrowthRate, currentClass.getSPDGrowth() + buffAmount)); }
+			if (buffStats.def) { currentClass.setDEFGrowth(Math.min(MaximumGrowthRate, currentClass.getDEFGrowth() + buffAmount)); }
+			if (buffStats.res) { currentClass.setRESGrowth(Math.min(MaximumGrowthRate, currentClass.getRESGrowth() + buffAmount)); }
+			if (buffStats.lck) { currentClass.setLCKGrowth(Math.min(MaximumGrowthRate, currentClass.getLCKGrowth() + buffAmount)); }
 		}
 	}
 	
-	public static void buffBossStatsLinearly(int maxBuff, CharacterDataLoader charData, ClassDataLoader classData) {
+	public static void buffBossStatsLinearly(int maxBuff, CharacterDataLoader charData, ClassDataLoader classData, EnemyOptions.BuffStats buffStats) {
 		for (GBAFECharacterData boss : charData.bossCharacters()) {
 			double appearanceFactor = (double)charData.appearanceChapter(boss) / (double)charData.chapterCount();
 			int buffAmount = Math.min(maxBuff, (int)Math.ceil(maxBuff * appearanceFactor));
 			GBAFEClassData bossClass = classData.classForID(boss.getClassID());
-			boss.setBaseHP(Math.min(boss.getBaseHP() + buffAmount, (bossClass.getMaxHP() - bossClass.getBaseHP())));
-			boss.setBaseSTR(Math.min(boss.getBaseSTR() + buffAmount, (bossClass.getMaxSTR() - bossClass.getBaseSTR())));
-			boss.setBaseSKL(Math.min(boss.getBaseSKL() + buffAmount, (bossClass.getMaxSKL() - bossClass.getBaseSKL())));
-			boss.setBaseSPD(Math.min(boss.getBaseSPD() + buffAmount, (bossClass.getMaxSPD() - bossClass.getBaseSPD())));
-			boss.setBaseDEF(Math.min(boss.getBaseDEF() + buffAmount, (bossClass.getMaxDEF() - bossClass.getBaseDEF())));
-			boss.setBaseRES(Math.min(boss.getBaseRES() + buffAmount, (bossClass.getMaxRES() - bossClass.getBaseRES())));
-			boss.setBaseLCK(Math.min(boss.getBaseLCK() + buffAmount, (bossClass.getMaxLCK() - bossClass.getBaseLCK())));
+			if (buffStats.hp) { boss.setBaseHP(Math.min(boss.getBaseHP() + buffAmount, (bossClass.getMaxHP() - bossClass.getBaseHP()))); }
+			if (buffStats.str) { boss.setBaseSTR(Math.min(boss.getBaseSTR() + buffAmount, (bossClass.getMaxSTR() - bossClass.getBaseSTR()))); }
+			if (buffStats.skl) { boss.setBaseSKL(Math.min(boss.getBaseSKL() + buffAmount, (bossClass.getMaxSKL() - bossClass.getBaseSKL()))); }
+			if (buffStats.spd) { boss.setBaseSPD(Math.min(boss.getBaseSPD() + buffAmount, (bossClass.getMaxSPD() - bossClass.getBaseSPD()))); }
+			if (buffStats.def) { boss.setBaseDEF(Math.min(boss.getBaseDEF() + buffAmount, (bossClass.getMaxDEF() - bossClass.getBaseDEF()))); }
+			if (buffStats.res) { boss.setBaseRES(Math.min(boss.getBaseRES() + buffAmount, (bossClass.getMaxRES() - bossClass.getBaseRES()))); }
+			if (buffStats.lck) { boss.setBaseLCK(Math.min(boss.getBaseLCK() + buffAmount, (bossClass.getMaxLCK() - bossClass.getBaseLCK()))); }
 		}
 	}
 	
-	public static void scaleEnemyGrowthRates(int scaleAmount, ClassDataLoader classData) {
+	public static void scaleEnemyGrowthRates(int scaleAmount, ClassDataLoader classData, EnemyOptions.BuffStats buffStats) {
 		GBAFEClassData[] allClasses = classData.allClasses();
 		double multiplier = 1 + (double)scaleAmount / 100.0;
 		for (GBAFEClassData currentClass : allClasses) {
-			currentClass.setHPGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getHPGrowth() * multiplier)));
-			currentClass.setSTRGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getSTRGrowth() * multiplier)));
-			currentClass.setSKLGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getSKLGrowth() * multiplier)));
-			currentClass.setSPDGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getSPDGrowth() * multiplier)));
-			currentClass.setDEFGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getDEFGrowth() * multiplier)));
-			currentClass.setRESGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getRESGrowth() * multiplier)));
-			currentClass.setLCKGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getLCKGrowth() * multiplier)));
+			if (buffStats.hp) { currentClass.setHPGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getHPGrowth() * multiplier))); }
+			if (buffStats.str) { currentClass.setSTRGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getSTRGrowth() * multiplier))); }
+			if (buffStats.skl) { currentClass.setSKLGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getSKLGrowth() * multiplier))); }
+			if (buffStats.spd) { currentClass.setSPDGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getSPDGrowth() * multiplier))); }
+			if (buffStats.def) { currentClass.setDEFGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getDEFGrowth() * multiplier))); }
+			if (buffStats.res) { currentClass.setRESGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getRESGrowth() * multiplier))); }
+			if (buffStats.lck) { currentClass.setLCKGrowth(Math.min(MaximumGrowthRate, (int)(currentClass.getLCKGrowth() * multiplier))); }
 		}
 	}
 	
-	public static void buffBossStatsWithEaseInOutCurve(int maxBuff, CharacterDataLoader charData, ClassDataLoader classData) {
+	public static void buffBossStatsWithEaseInOutCurve(int maxBuff, CharacterDataLoader charData, ClassDataLoader classData, EnemyOptions.BuffStats buffStats) {
 		for (GBAFECharacterData boss : charData.bossCharacters()) {
 			double appearanceFactor = (double)charData.appearanceChapter(boss) / (double)charData.chapterCount();
 			appearanceFactor = Math.pow(appearanceFactor, 2) / (Math.pow(appearanceFactor, 2) + Math.pow(1 - appearanceFactor, 2));
 			int buffAmount = Math.min(maxBuff, (int)Math.ceil(maxBuff * appearanceFactor));
 			GBAFEClassData bossClass = classData.classForID(boss.getClassID());
-			boss.setBaseHP(Math.min(boss.getBaseHP() + buffAmount, (bossClass.getMaxHP() - bossClass.getBaseHP())));
-			boss.setBaseSTR(Math.min(boss.getBaseSTR() + buffAmount, (bossClass.getMaxSTR() - bossClass.getBaseSTR())));
-			boss.setBaseSKL(Math.min(boss.getBaseSKL() + buffAmount, (bossClass.getMaxSKL() - bossClass.getBaseSKL())));
-			boss.setBaseSPD(Math.min(boss.getBaseSPD() + buffAmount, (bossClass.getMaxSPD() - bossClass.getBaseSPD())));
-			boss.setBaseDEF(Math.min(boss.getBaseDEF() + buffAmount, (bossClass.getMaxDEF() - bossClass.getBaseDEF())));
-			boss.setBaseRES(Math.min(boss.getBaseRES() + buffAmount, (bossClass.getMaxRES() - bossClass.getBaseRES())));
-			boss.setBaseLCK(Math.min(boss.getBaseLCK() + buffAmount, (bossClass.getMaxLCK() - bossClass.getBaseLCK())));
+			if (buffStats.hp) { boss.setBaseHP(Math.min(boss.getBaseHP() + buffAmount, (bossClass.getMaxHP() - bossClass.getBaseHP()))); }
+			if (buffStats.str) { boss.setBaseSTR(Math.min(boss.getBaseSTR() + buffAmount, (bossClass.getMaxSTR() - bossClass.getBaseSTR()))); }
+			if (buffStats.skl) { boss.setBaseSKL(Math.min(boss.getBaseSKL() + buffAmount, (bossClass.getMaxSKL() - bossClass.getBaseSKL()))); }
+			if (buffStats.spd) { boss.setBaseSPD(Math.min(boss.getBaseSPD() + buffAmount, (bossClass.getMaxSPD() - bossClass.getBaseSPD()))); }
+			if (buffStats.def) { boss.setBaseDEF(Math.min(boss.getBaseDEF() + buffAmount, (bossClass.getMaxDEF() - bossClass.getBaseDEF()))); }
+			if (buffStats.res) { boss.setBaseRES(Math.min(boss.getBaseRES() + buffAmount, (bossClass.getMaxRES() - bossClass.getBaseRES()))); }
+			if (buffStats.lck) { boss.setBaseLCK(Math.min(boss.getBaseLCK() + buffAmount, (bossClass.getMaxLCK() - bossClass.getBaseLCK()))); }
 		}
 	}
 	

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -545,10 +545,10 @@ public class GBARandomizer extends Randomizer {
 		if (enemies != null) {
 			if (enemies.minionMode == EnemyOptions.MinionGrowthMode.FLAT) {
 				updateStatusString("Buffing enemies...");
-				EnemyBuffer.buffMinionGrowthRates(enemies.minionBuff, classData);
+				EnemyBuffer.buffMinionGrowthRates(enemies.minionBuff, classData, enemies.minionBuffStats);
 			} else if (enemies.minionMode == EnemyOptions.MinionGrowthMode.SCALING) {
 				updateStatusString("Buffing enemies...");
-				EnemyBuffer.scaleEnemyGrowthRates(enemies.minionBuff, classData);
+				EnemyBuffer.scaleEnemyGrowthRates(enemies.minionBuff, classData, enemies.minionBuffStats);
 			}
 			
 			if (enemies.improveMinionWeapons) {
@@ -559,10 +559,10 @@ public class GBARandomizer extends Randomizer {
 			
 			if (enemies.bossMode == BossStatMode.LINEAR) {
 				updateStatusString("Buffing Bosses...");
-				EnemyBuffer.buffBossStatsLinearly(enemies.bossBuff, charData, classData);
+				EnemyBuffer.buffBossStatsLinearly(enemies.bossBuff, charData, classData, enemies.bossBuffStats);
 			} else if (enemies.bossMode == BossStatMode.EASE_IN_OUT) {
 				updateStatusString("Buffing Bosses...");
-				EnemyBuffer.buffBossStatsWithEaseInOutCurve(enemies.bossBuff, charData, classData);
+				EnemyBuffer.buffBossStatsWithEaseInOutCurve(enemies.bossBuff, charData, classData, enemies.bossBuffStats);
 			}
 			
 			if (enemies.improveBossWeapons) {
@@ -2189,9 +2189,11 @@ public class GBARandomizer extends Randomizer {
 			break;
 		case FLAT:
 			rk.addHeaderItem("Buff Minions", "Flat Buff (Growths +" + enemies.minionBuff + "%)");
+			rk.addHeaderItem("Buffed Minion Stats", enemies.minionBuffStats.buffString());
 			break;
 		case SCALING:
 			rk.addHeaderItem("Buff Minions", "Scaling Buff (Growths x" + String.format("%.2f", (enemies.minionBuff / 100.0) + 1) + ")");
+			rk.addHeaderItem("Buffed Minion Stats", enemies.minionBuffStats.buffString());
 			break;
 		}
 		
@@ -2207,9 +2209,11 @@ public class GBARandomizer extends Randomizer {
 			break;
 		case LINEAR:
 			rk.addHeaderItem("Buff Bosses", "Linear - Max Gain: +" + enemies.bossBuff);
+			rk.addHeaderItem("Buffed Boss Stats", enemies.bossBuffStats.buffString());
 			break;
 		case EASE_IN_OUT:
 			rk.addHeaderItem("Buff Bosses", "Ease In/Ease Out - Max Gain: +" + enemies.bossBuff);
+			rk.addHeaderItem("Buffed Boss Stats", enemies.bossBuffStats.buffString());
 			break;
 		}
 		

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9EnemyBuffer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9EnemyBuffer.java
@@ -15,43 +15,44 @@ import random.gcnwii.fe9.loader.FE9CharacterDataLoader;
 import random.gcnwii.fe9.loader.FE9ClassDataLoader;
 import random.gcnwii.fe9.loader.FE9ItemDataLoader;
 import random.gcnwii.fe9.loader.FE9SkillDataLoader;
+import ui.model.FE9EnemyBuffOptions;
 
 public class FE9EnemyBuffer {
 	
 	public static final int rngSalt = 9139;
 	
-	public static void flatBuffMinionGrowths(int buffAmount, FE9ClassDataLoader classData) {
+	public static void flatBuffMinionGrowths(int buffAmount, FE9ClassDataLoader classData, FE9EnemyBuffOptions.BuffStats buffStats) {
 		for (FE9Class charClass : classData.allValidClasses()) {
-			charClass.setHPGrowth(Math.min(charClass.getHPGrowth() + buffAmount, 255));
-			charClass.setSTRGrowth(Math.min(charClass.getSTRGrowth() + buffAmount, 255));
-			charClass.setMAGGrowth(Math.min(charClass.getMAGGrowth() + buffAmount, 255));
-			charClass.setSKLGrowth(Math.min(charClass.getSKLGrowth() + buffAmount, 255));
-			charClass.setSPDGrowth(Math.min(charClass.getSPDGrowth() + buffAmount, 255));
-			charClass.setLCKGrowth(Math.min(charClass.getLCKGrowth() + buffAmount, 255));
-			charClass.setDEFGrowth(Math.min(charClass.getDEFGrowth() + buffAmount, 255));
-			charClass.setRESGrowth(Math.min(charClass.getRESGrowth() + buffAmount, 255));
+			if (buffStats.hp) { charClass.setHPGrowth(Math.min(charClass.getHPGrowth() + buffAmount, 255)); }
+			if (buffStats.str) { charClass.setSTRGrowth(Math.min(charClass.getSTRGrowth() + buffAmount, 255)); }
+			if (buffStats.mag) { charClass.setMAGGrowth(Math.min(charClass.getMAGGrowth() + buffAmount, 255)); }
+			if (buffStats.skl) { charClass.setSKLGrowth(Math.min(charClass.getSKLGrowth() + buffAmount, 255)); }
+			if (buffStats.spd) { charClass.setSPDGrowth(Math.min(charClass.getSPDGrowth() + buffAmount, 255)); }
+			if (buffStats.lck) { charClass.setLCKGrowth(Math.min(charClass.getLCKGrowth() + buffAmount, 255)); }
+			if (buffStats.def) { charClass.setDEFGrowth(Math.min(charClass.getDEFGrowth() + buffAmount, 255)); }
+			if (buffStats.res) { charClass.setRESGrowth(Math.min(charClass.getRESGrowth() + buffAmount, 255)); }
 		}
 		
 		classData.commit();
 	}
 	
-	public static void scaleBuffMinionGrowths(int buffAmount, FE9ClassDataLoader classData) {
+	public static void scaleBuffMinionGrowths(int buffAmount, FE9ClassDataLoader classData, FE9EnemyBuffOptions.BuffStats buffStats) {
 		double multiplier = 1 + (double)buffAmount / (double)100;
 		for (FE9Class charClass : classData.allValidClasses()) {
-			charClass.setHPGrowth(Math.min((int)(charClass.getHPGrowth() * multiplier), 255));
-			charClass.setSTRGrowth(Math.min((int)(charClass.getSTRGrowth() * multiplier), 255));
-			charClass.setMAGGrowth(Math.min((int)(charClass.getMAGGrowth() * multiplier), 255));
-			charClass.setSKLGrowth(Math.min((int)(charClass.getSKLGrowth() * multiplier), 255));
-			charClass.setSPDGrowth(Math.min((int)(charClass.getSPDGrowth() * multiplier), 255));
-			charClass.setLCKGrowth(Math.min((int)(charClass.getLCKGrowth() * multiplier), 255));
-			charClass.setDEFGrowth(Math.min((int)(charClass.getDEFGrowth() * multiplier), 255));
-			charClass.setRESGrowth(Math.min((int)(charClass.getRESGrowth() * multiplier), 255));
+			if (buffStats.hp) { charClass.setHPGrowth(Math.min((int)(charClass.getHPGrowth() * multiplier), 255)); }
+			if (buffStats.str) { charClass.setSTRGrowth(Math.min((int)(charClass.getSTRGrowth() * multiplier), 255)); }
+			if (buffStats.mag) { charClass.setMAGGrowth(Math.min((int)(charClass.getMAGGrowth() * multiplier), 255)); }
+			if (buffStats.skl) { charClass.setSKLGrowth(Math.min((int)(charClass.getSKLGrowth() * multiplier), 255)); }
+			if (buffStats.spd) { charClass.setSPDGrowth(Math.min((int)(charClass.getSPDGrowth() * multiplier), 255)); }
+			if (buffStats.lck) { charClass.setLCKGrowth(Math.min((int)(charClass.getLCKGrowth() * multiplier), 255)); }
+			if (buffStats.def) { charClass.setDEFGrowth(Math.min((int)(charClass.getDEFGrowth() * multiplier), 255)); }
+			if (buffStats.res) { charClass.setRESGrowth(Math.min((int)(charClass.getRESGrowth() * multiplier), 255)); }
 		}
 		
 		classData.commit();
 	}
 
-	public static void buffBossStatsLinearly(int buffAmount, FE9CharacterDataLoader charData, FE9ClassDataLoader classData) {
+	public static void buffBossStatsLinearly(int buffAmount, FE9CharacterDataLoader charData, FE9ClassDataLoader classData, FE9EnemyBuffOptions.BuffStats buffStats) {
 		double divisor = FE9Data.Chapter.allChapters().size();
 		double dividend = 0;
 		for (FE9Data.Chapter chapter : FE9Data.Chapter.allChapters()) {
@@ -60,14 +61,14 @@ public class FE9EnemyBuffer {
 			for (FE9Data.Character character : bosses) {
 				FE9Character boss = charData.characterWithID(character.getPID());
 				FE9Class bossClass = classData.classWithID(charData.getJIDForCharacter(boss));
-				boss.setBaseHP(Math.min(bossClass.getMaxHP() - bossClass.getBaseHP(), boss.getBaseHP() + delta));
-				boss.setBaseSTR(Math.min(bossClass.getMaxSTR() - bossClass.getBaseSTR(), boss.getBaseSTR() + delta));
-				boss.setBaseMAG(Math.min(bossClass.getMaxMAG() - bossClass.getBaseMAG(), boss.getBaseMAG() + delta));
-				boss.setBaseSKL(Math.min(bossClass.getMaxSKL() - bossClass.getBaseSKL(), boss.getBaseSKL() + delta));
-				boss.setBaseSPD(Math.min(bossClass.getMaxSPD() - bossClass.getBaseSPD(), boss.getBaseSPD() + delta));
-				boss.setBaseLCK(Math.min(bossClass.getMaxLCK() - bossClass.getBaseLCK(), boss.getBaseLCK() + delta));
-				boss.setBaseDEF(Math.min(bossClass.getMaxDEF() - bossClass.getBaseDEF(), boss.getBaseDEF() + delta));
-				boss.setBaseRES(Math.min(bossClass.getMaxRES() - bossClass.getBaseRES(), boss.getBaseRES() + delta));
+				if (buffStats.hp) { boss.setBaseHP(Math.min(bossClass.getMaxHP() - bossClass.getBaseHP(), boss.getBaseHP() + delta)); }
+				if (buffStats.str) { boss.setBaseSTR(Math.min(bossClass.getMaxSTR() - bossClass.getBaseSTR(), boss.getBaseSTR() + delta)); }
+				if (buffStats.mag) { boss.setBaseMAG(Math.min(bossClass.getMaxMAG() - bossClass.getBaseMAG(), boss.getBaseMAG() + delta)); }
+				if (buffStats.skl) { boss.setBaseSKL(Math.min(bossClass.getMaxSKL() - bossClass.getBaseSKL(), boss.getBaseSKL() + delta)); }
+				if (buffStats.spd) { boss.setBaseSPD(Math.min(bossClass.getMaxSPD() - bossClass.getBaseSPD(), boss.getBaseSPD() + delta)); }
+				if (buffStats.lck) { boss.setBaseLCK(Math.min(bossClass.getMaxLCK() - bossClass.getBaseLCK(), boss.getBaseLCK() + delta)); }
+				if (buffStats.def) { boss.setBaseDEF(Math.min(bossClass.getMaxDEF() - bossClass.getBaseDEF(), boss.getBaseDEF() + delta)); }
+				if (buffStats.res) { boss.setBaseRES(Math.min(bossClass.getMaxRES() - bossClass.getBaseRES(), boss.getBaseRES() + delta)); }
 			}
 			dividend += 1;
 		}
@@ -75,7 +76,7 @@ public class FE9EnemyBuffer {
 		charData.commit();
 	}
 	
-	public static void buffBossStatsByEasing(int buffAmount, FE9CharacterDataLoader charData, FE9ClassDataLoader classData) {
+	public static void buffBossStatsByEasing(int buffAmount, FE9CharacterDataLoader charData, FE9ClassDataLoader classData, FE9EnemyBuffOptions.BuffStats buffStats) {
 		double[] factors = new double[] {
 				1.0 / 31.0, // Prologue (not used) 
 				1.4 / 31.0, // Ch 1 (+ 0.4)
@@ -116,14 +117,14 @@ public class FE9EnemyBuffer {
 			for (FE9Data.Character character : bosses) {
 				FE9Character boss = charData.characterWithID(character.getPID());
 				FE9Class bossClass = classData.classWithID(charData.getJIDForCharacter(boss));
-				boss.setBaseHP(Math.min(bossClass.getMaxHP() - bossClass.getBaseHP(), boss.getBaseHP() + delta));
-				boss.setBaseSTR(Math.min(bossClass.getMaxSTR() - bossClass.getBaseSTR(), boss.getBaseSTR() + delta));
-				boss.setBaseMAG(Math.min(bossClass.getMaxMAG() - bossClass.getBaseMAG(), boss.getBaseMAG() + delta));
-				boss.setBaseSKL(Math.min(bossClass.getMaxSKL() - bossClass.getBaseSKL(), boss.getBaseSKL() + delta));
-				boss.setBaseSPD(Math.min(bossClass.getMaxSPD() - bossClass.getBaseSPD(), boss.getBaseSPD() + delta));
-				boss.setBaseLCK(Math.min(bossClass.getMaxLCK() - bossClass.getBaseLCK(), boss.getBaseLCK() + delta));
-				boss.setBaseDEF(Math.min(bossClass.getMaxDEF() - bossClass.getBaseDEF(), boss.getBaseDEF() + delta));
-				boss.setBaseRES(Math.min(bossClass.getMaxRES() - bossClass.getBaseRES(), boss.getBaseRES() + delta));
+				if (buffStats.hp) { boss.setBaseHP(Math.min(bossClass.getMaxHP() - bossClass.getBaseHP(), boss.getBaseHP() + delta)); }
+				if (buffStats.str) { boss.setBaseSTR(Math.min(bossClass.getMaxSTR() - bossClass.getBaseSTR(), boss.getBaseSTR() + delta)); }
+				if (buffStats.mag) { boss.setBaseMAG(Math.min(bossClass.getMaxMAG() - bossClass.getBaseMAG(), boss.getBaseMAG() + delta)); }
+				if (buffStats.skl) { boss.setBaseSKL(Math.min(bossClass.getMaxSKL() - bossClass.getBaseSKL(), boss.getBaseSKL() + delta)); }
+				if (buffStats.spd) { boss.setBaseSPD(Math.min(bossClass.getMaxSPD() - bossClass.getBaseSPD(), boss.getBaseSPD() + delta)); }
+				if (buffStats.lck) { boss.setBaseLCK(Math.min(bossClass.getMaxLCK() - bossClass.getBaseLCK(), boss.getBaseLCK() + delta)); }
+				if (buffStats.def) { boss.setBaseDEF(Math.min(bossClass.getMaxDEF() - bossClass.getBaseDEF(), boss.getBaseDEF() + delta)); }
+				if (buffStats.res) { boss.setBaseRES(Math.min(bossClass.getMaxRES() - bossClass.getBaseRES(), boss.getBaseRES() + delta)); }
 			}
 		}
 		

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -141,6 +141,10 @@ public class FE9Randomizer extends Randomizer {
 		mainTOC.addAnchorWithTitle("item-data", "Item Data");
 		changelogBuilder.addElement(itemSection);
 		
+		ChangelogSection classSection = new ChangelogSection("class-data");
+		mainTOC.addAnchorWithTitle("class-data", "Class Data");
+		changelogBuilder.addElement(classSection);
+		
 		ChangelogSection chapterSection = new ChangelogSection("chapter-data");
 		mainTOC.addAnchorWithTitle("chapter-data", "Chapter Data");
 		changelogBuilder.addElement(chapterSection);
@@ -161,6 +165,7 @@ public class FE9Randomizer extends Randomizer {
 			
 			charData.recordOriginalCharacterData(changelogBuilder, characterSection, textData, classData, skillData, itemData, chapterData);
 			itemData.recordOriginalItemData(changelogBuilder, itemSection, textData);
+			classData.recordOriginalClassData(changelogBuilder, classSection, textData);
 			chapterData.recordOriginalChapterData(changelogBuilder, chapterSection, textData, charData, classData, skillData, itemData);
 			
 			makePreRandomizationAdjustments();
@@ -184,6 +189,7 @@ public class FE9Randomizer extends Randomizer {
 			
 			charData.recordUpdatedCharacterData(characterSection, textData, classData, skillData, itemData, chapterData);
 			itemData.recordUpdatedItemData(itemSection, textData);
+			classData.recordUpdatedClassData(classSection, textData);
 			chapterData.recordUpdatedChapterData(chapterSection, textData, charData, classData, skillData, itemData);
 			
 			ChangelogAsset.registerAssets(changelogBuilder);
@@ -671,10 +677,10 @@ public class FE9Randomizer extends Randomizer {
 			
 			switch (enemyBuffOptions.minionMode) {
 			case FLAT:
-				FE9EnemyBuffer.flatBuffMinionGrowths(enemyBuffOptions.minionBuff, classData);
+				FE9EnemyBuffer.flatBuffMinionGrowths(enemyBuffOptions.minionBuff, classData, enemyBuffOptions.minionBuffStats);
 				break;
 			case SCALING:
-				FE9EnemyBuffer.scaleBuffMinionGrowths(enemyBuffOptions.minionBuff, classData);
+				FE9EnemyBuffer.scaleBuffMinionGrowths(enemyBuffOptions.minionBuff, classData, enemyBuffOptions.minionBuffStats);
 				break;
 			default:
 				break;
@@ -688,10 +694,10 @@ public class FE9Randomizer extends Randomizer {
 			
 			switch (enemyBuffOptions.bossMode) {
 			case LINEAR:
-				FE9EnemyBuffer.buffBossStatsLinearly(enemyBuffOptions.bossBuff, charData, classData);
+				FE9EnemyBuffer.buffBossStatsLinearly(enemyBuffOptions.bossBuff, charData, classData, enemyBuffOptions.bossBuffStats);
 				break;
 			case EASE_IN_OUT:
-				FE9EnemyBuffer.buffBossStatsByEasing(enemyBuffOptions.bossBuff, charData, classData);
+				FE9EnemyBuffer.buffBossStatsByEasing(enemyBuffOptions.bossBuff, charData, classData, enemyBuffOptions.bossBuffStats);
 				break;
 			default:
 				break;
@@ -887,9 +893,11 @@ public class FE9Randomizer extends Randomizer {
 				break;
 			case FLAT:
 				table.addRow(new String[] {"Buff Minions", "Flat Buff (+" + enemyBuffOptions.minionBuff + "%)"});
+				table.addRow(new String[] {"Buffed Minion Stats", enemyBuffOptions.minionBuffStats.buffString()});
 				break;
 			case SCALING:
 				table.addRow(new String[] {"Buff Minions", "Scaling Buff (+" + enemyBuffOptions.minionBuff + "%)"});
+				table.addRow(new String[] {"Buffed Minion Stats", enemyBuffOptions.minionBuffStats.buffString()});
 				break;
 			}
 			table.addRow(new String[] {"Improve Minion Weapons", enemyBuffOptions.improveMinionWeapons ? "YES (" + enemyBuffOptions.minionImprovementChance + "%)" : "NO"});
@@ -901,9 +909,11 @@ public class FE9Randomizer extends Randomizer {
 				break;
 			case LINEAR:
 				table.addRow(new String[] {"Buff Bosses", "YES (Max Boost: " + enemyBuffOptions.bossBuff + " - Linear)"});
+				table.addRow(new String[] {"Buffed Boss Stats", enemyBuffOptions.bossBuffStats.buffString()});
 				break;
 			case EASE_IN_OUT:
 				table.addRow(new String[] {"Buff Bosses", "YES (Max Boost: " + enemyBuffOptions.bossBuff + " - Ease In/Ease Out);"});
+				table.addRow(new String[] {"Buffed Boss Stats", enemyBuffOptions.bossBuffStats.buffString()});
 				break;
 			}
 			table.addRow(new String[] {"Improve Boss Weapons", enemyBuffOptions.improveBossWeapons ? "YES (" + enemyBuffOptions.bossImprovementChance + "%)" : "NO"});

--- a/Universal FE Randomizer/src/ui/EnemyBuffsView.java
+++ b/Universal FE Randomizer/src/ui/EnemyBuffsView.java
@@ -5,6 +5,7 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
@@ -32,6 +33,14 @@ public class EnemyBuffsView extends Composite {
 	private Label minionWeaponSpinnerLabel;
 	private Spinner weaponSpinner;
 	
+	private Button minionHP;
+	private Button minionSTR;
+	private Button minionSKL;
+	private Button minionSPD;
+	private Button minionLCK;
+	private Button minionDEF;
+	private Button minionRES;
+	
 	private Button buffBossStatButton;
 	private Label bossStatSpinnerLabel;
 	private Spinner bossStatSpinner;
@@ -42,6 +51,14 @@ public class EnemyBuffsView extends Composite {
 	private Button improveBossWeaponButton;
 	private Label bossWeaponSpinnerLabel;
 	private Spinner bossWeaponSpinner;
+	
+	private Button bossHP;
+	private Button bossSTR;
+	private Button bossSKL;
+	private Button bossSPD;
+	private Button bossLCK;
+	private Button bossDEF;
+	private Button bossRES;
 	
 	public EnemyBuffsView(Composite parent, int style) {
 		super(parent, style);
@@ -87,6 +104,14 @@ public class EnemyBuffsView extends Composite {
 				
 				flatBonusButton.setEnabled(buffEnemyGrowthsButton.getSelection());
 				scalingBonusButton.setEnabled(buffEnemyGrowthsButton.getSelection());
+				
+				minionHP.setEnabled(buffEnemyGrowthsButton.getSelection());
+				minionSTR.setEnabled(buffEnemyGrowthsButton.getSelection());
+				minionSKL.setEnabled(buffEnemyGrowthsButton.getSelection());
+				minionSPD.setEnabled(buffEnemyGrowthsButton.getSelection());
+				minionLCK.setEnabled(buffEnemyGrowthsButton.getSelection());
+				minionDEF.setEnabled(buffEnemyGrowthsButton.getSelection());
+				minionRES.setEnabled(buffEnemyGrowthsButton.getSelection());
 			}
 		});
 		
@@ -150,6 +175,58 @@ public class EnemyBuffsView extends Composite {
 		paramContainerData.right = new FormAttachment(100, -5);
 		buffParamContainer.setLayoutData(paramContainerData);
 		
+		Composite minionStatGroup = new Composite(minionGroup, SWT.NONE);
+		RowLayout rowLayout = new RowLayout();
+		minionStatGroup.setLayout(rowLayout);
+		
+		minionHP = new Button(minionStatGroup, SWT.CHECK);
+		minionHP.setText("HP");
+		minionHP.setToolTipText("Apply buff to minion health.");
+		minionHP.setEnabled(false);
+		minionHP.setSelection(true);
+		
+		minionSTR = new Button(minionStatGroup, SWT.CHECK);
+		minionSTR.setText("STR/MAG");
+		minionSTR.setToolTipText("Apply buff to minion attack power.");
+		minionSTR.setEnabled(false);
+		minionSTR.setSelection(true);
+		
+		minionSKL = new Button(minionStatGroup, SWT.CHECK);
+		minionSKL.setText("SKL");
+		minionSKL.setToolTipText("Apply buff to minion accuracy and critical chance.");
+		minionSKL.setEnabled(false);
+		minionSKL.setSelection(true);
+		
+		minionSPD = new Button(minionStatGroup, SWT.CHECK);
+		minionSPD.setText("SPD");
+		minionSPD.setToolTipText("Apply buff to minion speed and evasion.");
+		minionSPD.setEnabled(false);
+		minionSPD.setSelection(true);
+		
+		minionLCK = new Button(minionStatGroup, SWT.CHECK);
+		minionLCK.setText("LCK");
+		minionLCK.setToolTipText("Apply buff to minion accuracy and critical evasion.");
+		minionLCK.setEnabled(false);
+		minionLCK.setSelection(true);
+		
+		minionDEF = new Button(minionStatGroup, SWT.CHECK);
+		minionDEF.setText("DEF");
+		minionDEF.setToolTipText("Apply buff to minion physical defense.");
+		minionDEF.setEnabled(false);
+		minionDEF.setSelection(true);
+		
+		minionRES = new Button(minionStatGroup, SWT.CHECK);
+		minionRES.setText("RES");
+		minionRES.setToolTipText("Apply buff to minion magical defense.");
+		minionRES.setEnabled(false);
+		minionRES.setSelection(true);
+		
+		FormData minionGroupData = new FormData();
+		minionGroupData.left = new FormAttachment(0, 10);
+		minionGroupData.right = new FormAttachment(100, -10);
+		minionGroupData.top = new FormAttachment(buffParamContainer, 0);
+		minionStatGroup.setLayoutData(minionGroupData);
+		
 		//////////////////////////////////////////////////////////////////
 		
 		improveEnemyWeaponsButton = new Button(minionGroup, SWT.CHECK);
@@ -165,7 +242,7 @@ public class EnemyBuffsView extends Composite {
 		
 		FormData improveWeaponsData = new FormData();
 		improveWeaponsData.left = new FormAttachment(0, 5);
-		improveWeaponsData.top = new FormAttachment(buffParamContainer, 5);
+		improveWeaponsData.top = new FormAttachment(minionStatGroup, 10);
 		improveEnemyWeaponsButton.setLayoutData(improveWeaponsData);
 		
 		minionWeaponSpinnerLabel = new Label(minionGroup, SWT.RIGHT);
@@ -218,6 +295,14 @@ public class EnemyBuffsView extends Composite {
 				bossStatSpinner.setEnabled(enabled);
 				linearBossButton.setEnabled(enabled);
 				easeInOutBossButton.setEnabled(enabled);
+				
+				bossHP.setEnabled(enabled);
+				bossSTR.setEnabled(enabled);
+				bossSKL.setEnabled(enabled);
+				bossSPD.setEnabled(enabled);
+				bossLCK.setEnabled(enabled);
+				bossDEF.setEnabled(enabled);
+				bossRES.setEnabled(enabled);
 			}
 		});
 		
@@ -261,6 +346,58 @@ public class EnemyBuffsView extends Composite {
 		labelData.top = new FormAttachment(bossStatSpinner, 0, SWT.CENTER);
 		bossStatSpinnerLabel.setLayoutData(labelData);
 		
+		Composite bossStatGroup = new Composite(bossGroup, SWT.NONE);
+		rowLayout = new RowLayout();
+		bossStatGroup.setLayout(rowLayout);
+		
+		bossHP = new Button(bossStatGroup, SWT.CHECK);
+		bossHP.setText("HP");
+		bossHP.setToolTipText("Apply buff to boss health.");
+		bossHP.setEnabled(false);
+		bossHP.setSelection(true);
+		
+		bossSTR = new Button(bossStatGroup, SWT.CHECK);
+		bossSTR.setText("STR/MAG");
+		bossSTR.setToolTipText("Apply buff to boss attack power.");
+		bossSTR.setEnabled(false);
+		bossSTR.setSelection(true);
+		
+		bossSKL = new Button(bossStatGroup, SWT.CHECK);
+		bossSKL.setText("SKL");
+		bossSKL.setToolTipText("Apply buff to boss accuracy and critical chance.");
+		bossSKL.setEnabled(false);
+		bossSKL.setSelection(true);
+		
+		bossSPD = new Button(bossStatGroup, SWT.CHECK);
+		bossSPD.setText("SPD");
+		bossSPD.setToolTipText("Apply buff to boss speed and evasion.");
+		bossSPD.setEnabled(false);
+		bossSPD.setSelection(true);
+		
+		bossLCK = new Button(bossStatGroup, SWT.CHECK);
+		bossLCK.setText("LCK");
+		bossLCK.setToolTipText("Apply buff to boss accuracy and critical evasion.");
+		bossLCK.setEnabled(false);
+		bossLCK.setSelection(true);
+		
+		bossDEF = new Button(bossStatGroup, SWT.CHECK);
+		bossDEF.setText("DEF");
+		bossDEF.setToolTipText("Apply buff to boss physical defense.");
+		bossDEF.setEnabled(false);
+		bossDEF.setSelection(true);
+		
+		bossRES = new Button(bossStatGroup, SWT.CHECK);
+		bossRES.setText("RES");
+		bossRES.setToolTipText("Apply buff to boss magical defense.");
+		bossRES.setEnabled(false);
+		bossRES.setSelection(true);
+		
+		FormData bossGroupData = new FormData();
+		bossGroupData.left = new FormAttachment(0, 10);
+		bossGroupData.right = new FormAttachment(100, -10);
+		bossGroupData.top = new FormAttachment(bossStatSpinner, 5);
+		bossStatGroup.setLayoutData(bossGroupData);
+		
 		improveBossWeaponButton = new Button(bossGroup, SWT.CHECK);
 		improveBossWeaponButton.setText("Improve Boss Weapons");
 		improveBossWeaponButton.setToolTipText("Adds a chance for bosses to spawn with a higher tier weapon than usual.");
@@ -277,7 +414,7 @@ public class EnemyBuffsView extends Composite {
 		
 		optionData = new FormData();
 		optionData.left = new FormAttachment(buffBossStatButton, 0, SWT.LEFT);
-		optionData.top = new FormAttachment(bossStatSpinnerLabel, 10);
+		optionData.top = new FormAttachment(bossStatGroup, 10);
 		improveBossWeaponButton.setLayoutData(optionData);
 		
 		bossWeaponSpinner = new Spinner(bossGroup, SWT.NONE);
@@ -319,7 +456,10 @@ public class EnemyBuffsView extends Composite {
 			else if (easeInOutBossButton.getSelection()) { bossMode = BossStatMode.EASE_IN_OUT; }
 		}
 		
-		return new EnemyOptions(minionMode, buffSpinner.getSelection(), buffMinionWeapons, minionWeaponChance, bossMode, bossStatSpinner.getSelection(), buffBossWeapons, bossWeaponChance);
+		return new EnemyOptions(minionMode, buffSpinner.getSelection(), buffMinionWeapons, minionWeaponChance, 
+				new EnemyOptions.BuffStats(minionHP.getSelection(), minionSTR.getSelection(), minionSKL.getSelection(), minionSPD.getSelection(), minionLCK.getSelection(), minionDEF.getSelection(), minionRES.getSelection()), 
+				bossMode, bossStatSpinner.getSelection(), buffBossWeapons, bossWeaponChance,
+				new EnemyOptions.BuffStats(bossHP.getSelection(), bossSTR.getSelection(), bossSKL.getSelection(), bossSPD.getSelection(), bossLCK.getSelection(), bossDEF.getSelection(), bossRES.getSelection()));
 	}
 	
 	public void setEnemyOptions(EnemyOptions options) {
@@ -355,6 +495,26 @@ public class EnemyBuffsView extends Composite {
 					minionSpinnerLabel.setEnabled(true);
 					buffSpinner.setSelection(options.minionBuff);
 					break;
+				}
+				
+				if (options.minionMode != EnemyOptions.MinionGrowthMode.NONE) {
+					minionHP.setEnabled(true);
+					minionSTR.setEnabled(true);
+					minionSKL.setEnabled(true);
+					minionSPD.setEnabled(true);
+					minionDEF.setEnabled(true);
+					minionRES.setEnabled(true);
+					minionLCK.setEnabled(true);
+					
+					if (options.minionBuffStats != null) {
+						minionHP.setSelection(options.minionBuffStats.hp);
+						minionSTR.setSelection(options.minionBuffStats.str);
+						minionSKL.setSelection(options.minionBuffStats.skl);
+						minionSPD.setSelection(options.minionBuffStats.spd);
+						minionDEF.setSelection(options.minionBuffStats.def);
+						minionRES.setSelection(options.minionBuffStats.res);
+						minionLCK.setSelection(options.minionBuffStats.lck);
+					}
 				}
 			}
 			if (options.improveMinionWeapons) {
@@ -397,6 +557,26 @@ public class EnemyBuffsView extends Composite {
 					
 					bossStatSpinner.setSelection(options.bossBuff);
 					break;
+				}
+				
+				if (options.bossMode != EnemyOptions.BossStatMode.NONE) {
+					bossHP.setEnabled(true);
+					bossSTR.setEnabled(true);
+					bossSKL.setEnabled(true);
+					bossSPD.setEnabled(true);
+					bossDEF.setEnabled(true);
+					bossRES.setEnabled(true);
+					bossLCK.setEnabled(true);
+					
+					if (options.bossBuffStats != null) {
+						bossHP.setSelection(options.bossBuffStats.hp);
+						bossSTR.setSelection(options.bossBuffStats.str);
+						bossSKL.setSelection(options.bossBuffStats.skl);
+						bossSPD.setSelection(options.bossBuffStats.spd);
+						bossDEF.setSelection(options.bossBuffStats.def);
+						bossRES.setSelection(options.bossBuffStats.res);
+						bossLCK.setSelection(options.bossBuffStats.lck);
+					}
 				}
 			}
 			if (options.improveBossWeapons) {

--- a/Universal FE Randomizer/src/ui/MainView.java
+++ b/Universal FE Randomizer/src/ui/MainView.java
@@ -692,7 +692,7 @@ public class MainView implements FileFlowDelegate {
 			FormData enemyData = new FormData();
 			enemyData.top = new FormAttachment(fe9ClassesView, 5); 
 			enemyData.left = new FormAttachment(fe9ClassesView, 0, SWT.LEFT);
-			enemyData.right = new FormAttachment(fe9ClassesView, 0, SWT.RIGHT);
+			enemyData.right = new FormAttachment(100, -5);
 			fe9EnemyView.setLayoutData(enemyData);
 			
 			FormData randomizeData = new FormData();

--- a/Universal FE Randomizer/src/ui/fe9/FE9EnemyBuffView.java
+++ b/Universal FE Randomizer/src/ui/fe9/FE9EnemyBuffView.java
@@ -5,6 +5,7 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
@@ -15,6 +16,7 @@ import org.eclipse.swt.widgets.Spinner;
 
 import ui.model.FE9EnemyBuffOptions;
 import ui.model.FE9EnemyBuffOptions.BossStatMode;
+import ui.model.FE9EnemyBuffOptions.BuffStats;
 import ui.model.FE9EnemyBuffOptions.MinionGrowthMode;
 
 public class FE9EnemyBuffView extends Composite {
@@ -28,6 +30,15 @@ public class FE9EnemyBuffView extends Composite {
 	private Spinner minionGrowthSpinner;
 	private Button minionModeFlatButton;
 	private Button minionModeScalingButton;
+	
+	private Button minionHP;
+	private Button minionSTR;
+	private Button minionMAG;
+	private Button minionSKL;
+	private Button minionSPD;
+	private Button minionLCK;
+	private Button minionDEF;
+	private Button minionRES;
 	
 	private Button improveMinionWeaponButton;
 	private Label minionWeaponLabel;
@@ -44,6 +55,15 @@ public class FE9EnemyBuffView extends Composite {
 	private Spinner bossStatSpinner;
 	private Button bossModeLinearButton;
 	private Button bossModeEaseInOutButton;
+	
+	private Button bossHP;
+	private Button bossSTR;
+	private Button bossMAG;
+	private Button bossSKL;
+	private Button bossSPD;
+	private Button bossLCK;
+	private Button bossDEF;
+	private Button bossRES;
 	
 	private Button improveBossWeaponButton;
 	private Label bossWeaponLabel;
@@ -96,6 +116,15 @@ public class FE9EnemyBuffView extends Composite {
 				minionGrowthLabel.setEnabled(isEnabled);
 				minionModeFlatButton.setEnabled(isEnabled);
 				minionModeScalingButton.setEnabled(isEnabled);
+				
+				minionHP.setEnabled(isEnabled);
+				minionSTR.setEnabled(isEnabled);
+				minionMAG.setEnabled(isEnabled);
+				minionSKL.setEnabled(isEnabled);
+				minionSPD.setEnabled(isEnabled);
+				minionLCK.setEnabled(isEnabled);
+				minionDEF.setEnabled(isEnabled);
+				minionRES.setEnabled(isEnabled);
 			}
 		});
 		
@@ -156,6 +185,65 @@ public class FE9EnemyBuffView extends Composite {
 		minionGrowthBuffContainerData.right = new FormAttachment(100, -5);
 		minionBuffParamContainer.setLayoutData(minionGrowthBuffContainerData);
 		
+		Composite minionStatGroup = new Composite(minionGroup, SWT.NONE);
+		RowLayout rowLayout = new RowLayout();
+		minionStatGroup.setLayout(rowLayout);
+		
+		minionHP = new Button(minionStatGroup, SWT.CHECK);
+		minionHP.setText("HP");
+		minionHP.setToolTipText("Apply buff to minion health.");
+		minionHP.setEnabled(false);
+		minionHP.setSelection(true);
+		
+		minionSTR = new Button(minionStatGroup, SWT.CHECK);
+		minionSTR.setText("STR");
+		minionSTR.setToolTipText("Apply buff to minion physical attack power.");
+		minionSTR.setEnabled(false);
+		minionSTR.setSelection(true);
+		
+		minionMAG = new Button(minionStatGroup, SWT.CHECK);
+		minionMAG.setText("MAG");
+		minionMAG.setToolTipText("Apply buff to minion magical attack power.");
+		minionMAG.setEnabled(false);
+		minionMAG.setSelection(true);
+		
+		minionSKL = new Button(minionStatGroup, SWT.CHECK);
+		minionSKL.setText("SKL");
+		minionSKL.setToolTipText("Apply buff to minion accuracy and critical chance.");
+		minionSKL.setEnabled(false);
+		minionSKL.setSelection(true);
+		
+		minionSPD = new Button(minionStatGroup, SWT.CHECK);
+		minionSPD.setText("SPD");
+		minionSPD.setToolTipText("Apply buff to minion speed and evasion.");
+		minionSPD.setEnabled(false);
+		minionSPD.setSelection(true);
+		
+		minionLCK = new Button(minionStatGroup, SWT.CHECK);
+		minionLCK.setText("LCK");
+		minionLCK.setToolTipText("Apply buff to minion accuracy and critical evasion.");
+		minionLCK.setEnabled(false);
+		minionLCK.setSelection(true);
+		
+		minionDEF = new Button(minionStatGroup, SWT.CHECK);
+		minionDEF.setText("DEF");
+		minionDEF.setToolTipText("Apply buff to minion physical defense.");
+		minionDEF.setEnabled(false);
+		minionDEF.setSelection(true);
+		
+		minionRES = new Button(minionStatGroup, SWT.CHECK);
+		minionRES.setText("RES");
+		minionRES.setToolTipText("Apply buff to minion magical defense.");
+		minionRES.setEnabled(false);
+		minionRES.setSelection(true);
+		
+		FormData minionGroupData = new FormData();
+		minionGroupData.left = new FormAttachment(0, 10);
+		minionGroupData.right = new FormAttachment(100, -10);
+		minionGroupData.top = new FormAttachment(minionBuffParamContainer, 0);
+		minionGroupData.width = 100;
+		minionStatGroup.setLayoutData(minionGroupData);
+		
 		//////////////////////////////////////////////////////////////////
 		
 		improveMinionWeaponButton = new Button(minionGroup, SWT.CHECK);
@@ -171,7 +259,7 @@ public class FE9EnemyBuffView extends Composite {
 		
 		FormData minionWeaponData = new FormData();
 		minionWeaponData.left = new FormAttachment(0, 5);
-		minionWeaponData.top = new FormAttachment(minionBuffParamContainer, 5);
+		minionWeaponData.top = new FormAttachment(minionStatGroup, 5);
 		improveMinionWeaponButton.setLayoutData(minionWeaponData);
 		
 		minionWeaponLabel = new Label(minionGroup, SWT.NONE);
@@ -259,6 +347,15 @@ public class FE9EnemyBuffView extends Composite {
 				bossStatSpinner.setEnabled(isEnabled);
 				bossModeLinearButton.setEnabled(isEnabled);
 				bossModeEaseInOutButton.setEnabled(isEnabled);
+				
+				bossHP.setEnabled(isEnabled);
+				bossSTR.setEnabled(isEnabled);
+				bossMAG.setEnabled(isEnabled);
+				bossSKL.setEnabled(isEnabled);
+				bossSPD.setEnabled(isEnabled);
+				bossLCK.setEnabled(isEnabled);
+				bossDEF.setEnabled(isEnabled);
+				bossRES.setEnabled(isEnabled);
 			}
 		});
 		
@@ -319,6 +416,65 @@ public class FE9EnemyBuffView extends Composite {
 		bossStatBuffContainerData.right = new FormAttachment(100, -5);
 		bossBuffParamContainer.setLayoutData(bossStatBuffContainerData);
 		
+		Composite bossStatGroup = new Composite(bossGroup, SWT.NONE);
+		rowLayout = new RowLayout();
+		bossStatGroup.setLayout(rowLayout);
+		
+		bossHP = new Button(bossStatGroup, SWT.CHECK);
+		bossHP.setText("HP");
+		bossHP.setToolTipText("Apply buff to boss health.");
+		bossHP.setEnabled(false);
+		bossHP.setSelection(true);
+		
+		bossSTR = new Button(bossStatGroup, SWT.CHECK);
+		bossSTR.setText("STR");
+		bossSTR.setToolTipText("Apply buff to boss physical attack power.");
+		bossSTR.setEnabled(false);
+		bossSTR.setSelection(true);
+		
+		bossMAG = new Button(bossStatGroup, SWT.CHECK);
+		bossMAG.setText("MAG");
+		bossMAG.setToolTipText("Apply buff to boss magical attack power.");
+		bossMAG.setEnabled(false);
+		bossMAG.setSelection(true);
+		
+		bossSKL = new Button(bossStatGroup, SWT.CHECK);
+		bossSKL.setText("SKL");
+		bossSKL.setToolTipText("Apply buff to boss accuracy and critical chance.");
+		bossSKL.setEnabled(false);
+		bossSKL.setSelection(true);
+		
+		bossSPD = new Button(bossStatGroup, SWT.CHECK);
+		bossSPD.setText("SPD");
+		bossSPD.setToolTipText("Apply buff to boss speed and evasion.");
+		bossSPD.setEnabled(false);
+		bossSPD.setSelection(true);
+		
+		bossLCK = new Button(bossStatGroup, SWT.CHECK);
+		bossLCK.setText("LCK");
+		bossLCK.setToolTipText("Apply buff to boss accuracy and critical evasion.");
+		bossLCK.setEnabled(false);
+		bossLCK.setSelection(true);
+		
+		bossDEF = new Button(bossStatGroup, SWT.CHECK);
+		bossDEF.setText("DEF");
+		bossDEF.setToolTipText("Apply buff to boss physical defense.");
+		bossDEF.setEnabled(false);
+		bossDEF.setSelection(true);
+		
+		bossRES = new Button(bossStatGroup, SWT.CHECK);
+		bossRES.setText("RES");
+		bossRES.setToolTipText("Apply buff to boss magical defense.");
+		bossRES.setEnabled(false);
+		bossRES.setSelection(true);
+		
+		FormData bossGroupData = new FormData();
+		bossGroupData.left = new FormAttachment(0, 10);
+		bossGroupData.right = new FormAttachment(100, -10);
+		bossGroupData.top = new FormAttachment(bossBuffParamContainer, 0);
+		bossGroupData.width = 100;
+		bossStatGroup.setLayoutData(bossGroupData);
+		
 		//////////////////////////////////////////////////////////////////
 		
 		improveBossWeaponButton = new Button(bossGroup, SWT.CHECK);
@@ -334,7 +490,7 @@ public class FE9EnemyBuffView extends Composite {
 		
 		FormData bossWeaponData = new FormData();
 		bossWeaponData.left = new FormAttachment(0, 5);
-		bossWeaponData.top = new FormAttachment(bossBuffParamContainer, 5);
+		bossWeaponData.top = new FormAttachment(bossStatGroup, 5);
 		improveBossWeaponButton.setLayoutData(bossWeaponData);
 		
 		bossWeaponLabel = new Label(bossGroup, SWT.NONE);
@@ -417,8 +573,12 @@ public class FE9EnemyBuffView extends Composite {
 		boolean bossSkills = bossSkillButton.getSelection();
 		int bossSkillChance = bossSkillSpinner.getSelection();
 		
-		return new FE9EnemyBuffOptions(minionMode, minionAmount, minionWeapons, minionWeaponChance, minionSkills, minionSkillChance, 
-				bossMode, bossAmount, bossWeapons, bossWeaponChance, bossSkills, bossSkillChance);
+		return new FE9EnemyBuffOptions(minionMode, minionAmount,
+				new FE9EnemyBuffOptions.BuffStats(minionHP.getSelection(), minionSTR.getSelection(), minionMAG.getSelection(), minionSKL.getSelection(), minionSPD.getSelection(), minionLCK.getSelection(), minionDEF.getSelection(), minionRES.getSelection()),
+				minionWeapons, minionWeaponChance, minionSkills, minionSkillChance, 
+				bossMode, bossAmount,
+				new FE9EnemyBuffOptions.BuffStats(bossHP.getSelection(), bossSTR.getSelection(), bossMAG.getSelection(), bossSKL.getSelection(), bossSPD.getSelection(), bossLCK.getSelection(), bossDEF.getSelection(), bossRES.getSelection()),
+				bossWeapons, bossWeaponChance, bossSkills, bossSkillChance);
 	}
 	
 	public void setEnemyBuffOptions(FE9EnemyBuffOptions options) {
@@ -458,6 +618,28 @@ public class FE9EnemyBuffView extends Composite {
 					
 					minionGrowthSpinner.setSelection(options.minionBuff);
 					break;
+				}
+				
+				if (options.minionMode != FE9EnemyBuffOptions.MinionGrowthMode.NONE) {
+					minionHP.setEnabled(true);
+					minionSTR.setEnabled(true);
+					minionMAG.setEnabled(true);
+					minionSKL.setEnabled(true);
+					minionSPD.setEnabled(true);
+					minionLCK.setEnabled(true);
+					minionDEF.setEnabled(true);
+					minionRES.setEnabled(true);
+					
+					if (options.minionBuffStats != null) {
+						minionHP.setSelection(options.minionBuffStats.hp);
+						minionSTR.setSelection(options.minionBuffStats.str);
+						minionMAG.setSelection(options.minionBuffStats.mag);
+						minionSKL.setSelection(options.minionBuffStats.skl);
+						minionSPD.setSelection(options.minionBuffStats.spd);
+						minionLCK.setSelection(options.minionBuffStats.lck);
+						minionDEF.setSelection(options.minionBuffStats.def);
+						minionRES.setSelection(options.minionBuffStats.res);
+					}
 				}
 			}
 			if (options.improveMinionWeapons) {
@@ -506,6 +688,28 @@ public class FE9EnemyBuffView extends Composite {
 					
 					bossStatSpinner.setSelection(options.bossBuff);
 					break;
+				}
+				
+				if (options.bossMode != FE9EnemyBuffOptions.BossStatMode.NONE) {
+					bossHP.setEnabled(true);
+					bossSTR.setEnabled(true);
+					bossMAG.setEnabled(true);
+					bossSKL.setEnabled(true);
+					bossSPD.setEnabled(true);
+					bossLCK.setEnabled(true);
+					bossDEF.setEnabled(true);
+					bossRES.setEnabled(true);
+					
+					if (options.bossBuffStats != null) {
+						bossHP.setSelection(options.bossBuffStats.hp);
+						bossSTR.setSelection(options.bossBuffStats.str);
+						bossMAG.setSelection(options.bossBuffStats.mag);
+						bossSKL.setSelection(options.bossBuffStats.skl);
+						bossSPD.setSelection(options.bossBuffStats.spd);
+						bossLCK.setSelection(options.bossBuffStats.lck);
+						bossDEF.setSelection(options.bossBuffStats.def);
+						bossRES.setSelection(options.bossBuffStats.res);
+					}
 				}
 			}
 			if (options.improveBossWeapons) {

--- a/Universal FE Randomizer/src/ui/model/EnemyOptions.java
+++ b/Universal FE Randomizer/src/ui/model/EnemyOptions.java
@@ -1,5 +1,8 @@
 package ui.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class EnemyOptions {
 
 	public enum MinionGrowthMode {
@@ -10,28 +13,64 @@ public class EnemyOptions {
 		NONE, LINEAR, EASE_IN_OUT
 	}
 	
+	public static class BuffStats {
+		public final boolean hp;
+		public final boolean str;
+		public final boolean skl;
+		public final boolean spd;
+		public final boolean lck;
+		public final boolean def;
+		public final boolean res;
+		
+		public BuffStats(boolean hp, boolean str, boolean skl, boolean spd, boolean lck, boolean def, boolean res) {
+			this.hp = hp;
+			this.str = str;
+			this.skl = skl;
+			this.spd = spd;
+			this.lck = lck;
+			this.def = def;
+			this.res = res;
+		}
+		
+		public String buffString() {
+			List<String> statStrings = new ArrayList<String>();
+			if (hp) { statStrings.add("HP"); }
+			if (str) { statStrings.add("STR"); }
+			if (skl) { statStrings.add("SKL"); }
+			if (spd) { statStrings.add("SPD"); }
+			if (lck) { statStrings.add("LCK"); }
+			if (def) { statStrings.add("DEF"); }
+			if (res) { statStrings.add("RES"); }
+			return String.join(", ", statStrings);
+		}
+	}
+	
 	public final MinionGrowthMode minionMode;
 	public final int minionBuff;
+	public final BuffStats minionBuffStats;
 	
 	public final boolean improveMinionWeapons;
 	public final int minionImprovementChance;
 	
 	public final BossStatMode bossMode;
 	public final int bossBuff;
+	public final BuffStats bossBuffStats;
 	
 	public final boolean improveBossWeapons;
 	public final int bossImprovementChance;
 	
-	public EnemyOptions(MinionGrowthMode mode, int buffAmount, boolean minionWeapons, int minionWeaponChance, BossStatMode bossMode, int bossBuff, boolean bossWeapons, int bossWeaponChance) {
+	public EnemyOptions(MinionGrowthMode mode, int buffAmount, boolean minionWeapons, int minionWeaponChance, BuffStats minionBuffStats, BossStatMode bossMode, int bossBuff, boolean bossWeapons, int bossWeaponChance, BuffStats bossBuffStats) {
 		super();
 		this.minionMode = mode;
 		this.minionBuff = buffAmount;
 		this.improveMinionWeapons = minionWeapons;
 		this.minionImprovementChance = minionWeaponChance;
+		this.minionBuffStats = minionBuffStats;
 		
 		this.bossMode = bossMode;
 		this.bossBuff = bossBuff;
 		this.improveBossWeapons = bossWeapons;
 		this.bossImprovementChance = bossWeaponChance;
+		this.bossBuffStats = bossBuffStats;
 	}
 }

--- a/Universal FE Randomizer/src/ui/model/FE9EnemyBuffOptions.java
+++ b/Universal FE Randomizer/src/ui/model/FE9EnemyBuffOptions.java
@@ -1,5 +1,8 @@
 package ui.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class FE9EnemyBuffOptions {
 	
 	public enum MinionGrowthMode {
@@ -10,8 +13,44 @@ public class FE9EnemyBuffOptions {
 		NONE, LINEAR, EASE_IN_OUT
 	}
 	
+	public static class BuffStats {
+		public final boolean hp;
+		public final boolean str;
+		public final boolean mag;
+		public final boolean skl;
+		public final boolean spd;
+		public final boolean lck;
+		public final boolean def;
+		public final boolean res;
+		
+		public BuffStats(boolean hp, boolean str, boolean mag, boolean skl, boolean spd, boolean lck, boolean def, boolean res) {
+			this.hp = hp;
+			this.str = str;
+			this.mag = mag;
+			this.skl = skl;
+			this.spd = spd;
+			this.lck = lck;
+			this.def = def;
+			this.res = res;
+		}
+		
+		public String buffString() {
+			List<String> statStrings = new ArrayList<String>();
+			if (hp) { statStrings.add("HP"); }
+			if (str) { statStrings.add("STR"); }
+			if (mag) { statStrings.add("MAG"); }
+			if (skl) { statStrings.add("SKL"); }
+			if (spd) { statStrings.add("SPD"); }
+			if (lck) { statStrings.add("LCK"); }
+			if (def) { statStrings.add("DEF"); }
+			if (res) { statStrings.add("RES"); }
+			return String.join(", ", statStrings);
+		}
+	}
+	
 	public final MinionGrowthMode minionMode;
 	public final int minionBuff;
+	public final BuffStats minionBuffStats;
 	
 	public final boolean improveMinionWeapons;
 	public final int minionImprovementChance;
@@ -20,6 +59,7 @@ public class FE9EnemyBuffOptions {
 	
 	public final BossStatMode bossMode;
 	public final int bossBuff;
+	public final BuffStats bossBuffStats;
 	
 	public final boolean improveBossWeapons;
 	public final int bossImprovementChance;
@@ -28,12 +68,14 @@ public class FE9EnemyBuffOptions {
 	
 	public FE9EnemyBuffOptions(MinionGrowthMode minionMode,
 			int minionBuff,
+			BuffStats minionBuffStats,
 			boolean improveMinionWeapons,
 			int minionImprovementChance,
 			boolean giveMinionSkills,
 			int minionSkillChance,
 			BossStatMode bossMode,
 			int bossBuff,
+			BuffStats bossBuffStats,
 			boolean improveBossWeapons,
 			int bossImprovementChance,
 			boolean giveBossSkills,
@@ -41,6 +83,7 @@ public class FE9EnemyBuffOptions {
 		
 		this.minionMode = minionMode;
 		this.minionBuff = minionBuff;
+		this.minionBuffStats = minionBuffStats;
 		this.improveMinionWeapons = improveMinionWeapons;
 		this.minionImprovementChance = minionImprovementChance;
 		this.giveMinionsSkills = giveMinionSkills;
@@ -48,6 +91,7 @@ public class FE9EnemyBuffOptions {
 		
 		this.bossMode = bossMode;
 		this.bossBuff = bossBuff;
+		this.bossBuffStats = bossBuffStats;
 		this.improveBossWeapons = improveBossWeapons;
 		this.bossImprovementChance = bossImprovementChance;
 		this.giveBossSkills = giveBossSkills;

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -26,7 +26,7 @@ import ui.model.WeaponOptions;
 
 public class OptionRecorder {
 	private static final Integer FE4OptionBundleVersion = 3;
-	private static final Integer GBAOptionBundleVersion = 10;
+	private static final Integer GBAOptionBundleVersion = 11;
 	private static final Integer FE9OptionBundleVersion = 10;
 	
 	public static class AllOptions {


### PR DESCRIPTION
Fixed #295 - Added an option to specify which stats you want to buff for an enemy. This is useful for disabling certain stats that we don't want to inflate. For example, disabling DEF and RES will make enemies continue to hit harder, but not be harder to kill (outside of higher evasion).

![image](https://user-images.githubusercontent.com/1689159/117556430-cde7e900-b01d-11eb-9c9e-ab673206a31f.png)
