### PR TITLE
Fixed issues with the autoleveler when randomizing recruitment

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
@@ -26,6 +26,7 @@ public interface GBAFECharacterData extends FEModifiableData, FELockableData, FE
 	public void setFaceID(int faceID);
 	
 	public int getLevel();
+	public void setLevel(int level);
 	
 	// Growths
 	

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
@@ -132,6 +132,12 @@ public class FE6Character implements GBAFECharacterData {
 		return data[11] & 0xFF;
 	}
 	
+	public void setLevel(int level) {
+		assert !isReadOnly : "Attempted to modify a locked character.";
+		data[11] = (byte)(level & 0xFF);
+		wasModified = true;
+	}
+	
 	public int getHPGrowth() {
 		return data[28] & 0xFF;
 	}

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1966,6 +1966,22 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public int canonicalID(int characterID) {
 		return Character.canonicalIDForCharacterID(characterID);
 	}
+	
+	public Integer canonicalLevelForCharacter(GBAFECharacter character) {
+		Character fe6Character = Character.valueOf(character.getID());
+		switch (fe6Character) {
+		case DAYAN: return 12;
+		case YODEL: return 20;
+		case GARET: return 1;
+		case PERCIVAL: return 5;
+		case IGRENE: return 1;
+		case NIIME: return 18;
+		case REI: return 12;
+		case NOAH: return 7;
+		case TRECK: return 4;
+		default: return null;
+		}
+	}
 
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses) {
 		FE6Character charData = new FE6Character(data, offset, hasLimitedClasses);

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
@@ -142,6 +142,12 @@ public class FE7Character implements GBAFECharacterData {
 		return data[11] & 0xFF;
 	}
 	
+	public void setLevel(int level) {
+		assert !isReadOnly : "Attempted to modify a locked character.";
+		data[11] = (byte)(level & 0xFF);
+		wasModified = true;
+	}
+	
 	public int getHPGrowth() {
 		return data[28] & 0xFF;
 	}

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -2508,6 +2508,18 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public int canonicalID(int characterID) {
 		return Character.canonicalIDForCharacterID(characterID);
 	}
+	
+	public Integer canonicalLevelForCharacter(GBAFECharacter character) {
+		Character fe7Char = Character.valueOf(character.getID());
+		switch (fe7Char) {
+		case RAVEN: return 5;
+		case GUY: return 3;
+		case LOUISE: return 4;
+		case KAREL: return 8;
+		case WIL_TUTORIAL: return 2;
+		default: return null;
+		}
+	}
 
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses) {
 		FE7Character charData = new FE7Character(data, offset, hasLimitedClasses);

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
@@ -146,6 +146,12 @@ public class FE8Character implements GBAFECharacterData {
 		return data[11] & 0xFF;
 	}
 	
+	public void setLevel(int level) {
+		assert !isReadOnly : "Attempted to modify a locked character.";
+		data[11] = (byte)(level & 0xFF);
+		wasModified = true;
+	}
+	
 	public int getHPGrowth() {
 		return data[28] & 0xFF;
 	}

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2677,6 +2677,18 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public int canonicalID(int characterID) {
 		return Character.canonicalIDForCharacterID(characterID);
 	}
+	
+	public Integer canonicalLevelForCharacter(GBAFECharacter character) {
+		Character fe8Char = Character.valueOf(character.getID());
+		switch (fe8Char) {
+		case FORDE: return 6;
+		case KYLE: return 5;
+		case SALEH: return 1;
+		case EWAN: return 1;
+		case KNOLL: return 10;
+		default: return null;
+		}
+	}
 
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses) {
 		FE8Character character = new FE8Character(data, offset, hasLimitedClasses);

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFECharacterProvider.java
@@ -41,6 +41,11 @@ public interface GBAFECharacterProvider {
 	
 	public int canonicalID(int characterID);
 	
+	// Some characters have levels in their character data that don't match with their chapter data.
+	// Since our calculations rely on character data and not chapter data, some discrepancies might be significant.
+	// This method will return the "correct" character level as they appear in gameplay if it doesn't match.
+	// If the character data is consistent with the canonical level, this method should return null.
+	public Integer canonicalLevelForCharacter(GBAFECharacter character);
+	
 	public GBAFECharacterData characterDataWithData(byte[] data, long offset, Boolean hasLimitedClasses);
-
 }

--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -60,6 +60,17 @@ public class CharacterDataLoader {
 		}
 	}
 	
+	public void applyLevelCorrectionsIfNecessary() {
+		for (GBAFECharacter character : provider.allPlayableCharacters()) {
+			Integer canonicalLevel = provider.canonicalLevelForCharacter(character);
+			if (canonicalLevel != null) {
+				GBAFECharacterData characterData = characterWithID(character.getID());
+				characterData.setLevel(canonicalLevel);
+				characterData.commitChanges();
+			}
+		}
+	}
+	
 	public String debugStringForCharacter(int characterID) {
 		return provider.characterWithID(characterID).toString();
 	}
@@ -260,6 +271,7 @@ public class CharacterDataLoader {
 		if (isInitial) {
 			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Name", name);
 			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Class", classValue);
+			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Level", Integer.toString(character.getLevel()));
 			
 			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "HP Growth", String.format("%d%%", character.getHPGrowth()));
 			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "STR/MAG Growth", String.format("%d%%", character.getSTRGrowth()));
@@ -292,6 +304,7 @@ public class CharacterDataLoader {
 		} else {
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Name", name);
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Class", classValue);
+			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Level", Integer.toString(character.getLevel()));
 			
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "HP Growth", String.format("%d%%", character.getHPGrowth()));
 			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "STR/MAG Growth", String.format("%d%%", character.getSTRGrowth()));

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -635,6 +635,9 @@ public class GBARandomizer extends Randomizer {
 				
 			}
 		}
+		
+		// Some characters have discrepancies between character data and chapter data. We'll try to address that before we get to any modifications.
+		charData.applyLevelCorrectionsIfNecessary();
 	}
 	
 	private void makeFinalAdjustments(String seed) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/RecruitmentRandomizer.java
@@ -455,6 +455,15 @@ public class RecruitmentRandomizer {
 				textData.getStringAtIndex(fill.getNameIndex(), true) + "](" + textData.getStringAtIndex(fillSourceClass.getNameIndex(), true) + ")");
 		
 		GBAFECharacterData[] linkedSlots = characterData.linkedCharactersForCharacter(slotReference);
+		
+		// Used only for FE8 trainees that can promote twice.
+		int additionalPromoHP = 0;
+		int additionalPromoSTR = 0;
+		int additionalPromoSKL = 0;
+		int additionalPromoSPD = 0;
+		int additionalPromoDEF = 0;
+		int additionalPromoRES = 0;
+		
 		for (GBAFECharacterData linkedSlot : linkedSlots) {
 			// Do not modify if they happen to have a different class.
 			if (linkedSlot.getClassID() != slotReference.getClassID()) { continue; }
@@ -484,12 +493,12 @@ public class RecruitmentRandomizer {
 				levelsToAdd -= 3;
 			}
 			
-			int promoAdjustHP = 0;
-			int promoAdjustSTR = 0;
-			int promoAdjustSKL = 0;
-			int promoAdjustSPD = 0;
-			int promoAdjustDEF = 0;
-			int promoAdjustRES = 0;
+			int promoAdjustHP = additionalPromoHP;
+			int promoAdjustSTR = additionalPromoSTR;
+			int promoAdjustSKL = additionalPromoSKL;
+			int promoAdjustSPD = additionalPromoSPD;
+			int promoAdjustDEF = additionalPromoDEF;
+			int promoAdjustRES = additionalPromoRES;
 			
 			DebugPrinter.log(DebugPrinter.Key.GBA_RANDOM_RECRUITMENT, "Adjusted Slot level: " + Integer.toString(targetLevel) + "\tAdjusted Fill Level: " + Integer.toString(sourceLevel) + "\tLevels To Add: " + Integer.toString(levelsToAdd));
 			
@@ -509,6 +518,15 @@ public class RecruitmentRandomizer {
 							promoAdjustSPD += targetClass.getPromoSPD();
 							promoAdjustDEF += targetClass.getPromoDEF();
 							promoAdjustRES += targetClass.getPromoRES();
+							
+							// Save these if we need them for later for additional linked slots after we've determined our class.
+							additionalPromoHP = targetClass.getPromoHP();
+							additionalPromoSTR = targetClass.getPromoSTR();
+							additionalPromoSKL = targetClass.getPromoSKL();
+							additionalPromoSPD = targetClass.getPromoSPD();
+							additionalPromoDEF = targetClass.getPromoDEF();
+							additionalPromoRES = targetClass.getPromoRES();
+							
 							promotionOptions = classData.promotionOptions(targetClass.getID());
 							DebugPrinter.log(DebugPrinter.Key.GBA_RANDOM_RECRUITMENT, "Promotion Options: [" + String.join(", ", promotionOptions.stream().map(charClass -> (textData.getStringAtIndex(charClass.getNameIndex(), true))).collect(Collectors.toList())) + "]");
 							if (!promotionOptions.isEmpty()) {
@@ -525,22 +543,22 @@ public class RecruitmentRandomizer {
 					}
 					
 					DebugPrinter.log(DebugPrinter.Key.GBA_RANDOM_RECRUITMENT, "Selected Class: " + (targetClass != null ? textData.getStringAtIndex(targetClass.getNameIndex(), true) : "None"));
-					
-					promoAdjustHP += targetClass.getPromoHP();
-					promoAdjustSTR += targetClass.getPromoSTR();
-					promoAdjustSKL += targetClass.getPromoSKL();
-					promoAdjustSPD += targetClass.getPromoSPD();
-					promoAdjustDEF += targetClass.getPromoDEF();
-					promoAdjustRES += targetClass.getPromoRES();
-					
-					// For some reason, some promoted class seem to have lower bases than their unpromoted variants (FE8 lords are an example). If they are lower, adjust upwards.
-					if (targetClass.getBaseHP() < fillSourceClass.getBaseHP()) { promoAdjustHP += fillSourceClass.getBaseHP() - targetClass.getBaseHP(); }
-					if (targetClass.getBaseSTR() < fillSourceClass.getBaseSTR()) { promoAdjustSTR += fillSourceClass.getBaseSTR() - targetClass.getBaseSTR(); }
-					if (targetClass.getBaseSKL() < fillSourceClass.getBaseSKL()) { promoAdjustSKL += fillSourceClass.getBaseSKL() - targetClass.getBaseSKL(); }
-					if (targetClass.getBaseSPD() < fillSourceClass.getBaseSPD()) { promoAdjustSPD += fillSourceClass.getBaseSPD() - targetClass.getBaseSPD(); }
-					if (targetClass.getBaseDEF() < fillSourceClass.getBaseDEF()) { promoAdjustDEF += fillSourceClass.getBaseDEF() - targetClass.getBaseDEF(); }
-					if (targetClass.getBaseRES() < fillSourceClass.getBaseRES()) { promoAdjustRES += fillSourceClass.getBaseRES() - targetClass.getBaseRES(); }
 				}
+				
+				promoAdjustHP += targetClass.getPromoHP();
+				promoAdjustSTR += targetClass.getPromoSTR();
+				promoAdjustSKL += targetClass.getPromoSKL();
+				promoAdjustSPD += targetClass.getPromoSPD();
+				promoAdjustDEF += targetClass.getPromoDEF();
+				promoAdjustRES += targetClass.getPromoRES();
+				
+				// For some reason, some promoted class seem to have lower bases than their unpromoted variants (FE8 lords are an example). If they are lower, adjust upwards.
+				if (targetClass.getBaseHP() < fillSourceClass.getBaseHP()) { promoAdjustHP += fillSourceClass.getBaseHP() - targetClass.getBaseHP(); }
+				if (targetClass.getBaseSTR() < fillSourceClass.getBaseSTR()) { promoAdjustSTR += fillSourceClass.getBaseSTR() - targetClass.getBaseSTR(); }
+				if (targetClass.getBaseSKL() < fillSourceClass.getBaseSKL()) { promoAdjustSKL += fillSourceClass.getBaseSKL() - targetClass.getBaseSKL(); }
+				if (targetClass.getBaseSPD() < fillSourceClass.getBaseSPD()) { promoAdjustSPD += fillSourceClass.getBaseSPD() - targetClass.getBaseSPD(); }
+				if (targetClass.getBaseDEF() < fillSourceClass.getBaseDEF()) { promoAdjustDEF += fillSourceClass.getBaseDEF() - targetClass.getBaseDEF(); }
+				if (targetClass.getBaseRES() < fillSourceClass.getBaseRES()) { promoAdjustRES += fillSourceClass.getBaseRES() - targetClass.getBaseRES(); }
 				
 				setSlotClass(inventoryOptions, linkedSlot, targetClass, characterData, classData, itemData, textData, chapterData, rng);
 			} else if (!shouldBePromoted && isPromoted) {
@@ -560,22 +578,22 @@ public class RecruitmentRandomizer {
 					}
 					
 					DebugPrinter.log(DebugPrinter.Key.GBA_RANDOM_RECRUITMENT, "Selected Class: " + (targetClass != null ? textData.getStringAtIndex(targetClass.getNameIndex(), true) : "None"));
-					
-					promoAdjustHP = fillSourceClass.getPromoHP() * -1;
-					promoAdjustSTR = fillSourceClass.getPromoSTR() * -1;
-					promoAdjustSKL = fillSourceClass.getPromoSKL() * -1;
-					promoAdjustSPD = fillSourceClass.getPromoSPD() * -1;
-					promoAdjustDEF = fillSourceClass.getPromoDEF() * -1;
-					promoAdjustRES = fillSourceClass.getPromoRES() * -1;
-					
-					// For some reason, some promoted class seem to have lower bases than their unpromoted variants (FE8 lords are an example). If our demoted class has higher bases, adjust downwards
-					if (targetClass.getBaseHP() > fillSourceClass.getBaseHP()) { promoAdjustHP -= targetClass.getBaseHP() - fillSourceClass.getBaseHP(); }
-					if (targetClass.getBaseSTR() > fillSourceClass.getBaseSTR()) { promoAdjustSTR -= targetClass.getBaseSTR() - fillSourceClass.getBaseSTR(); }
-					if (targetClass.getBaseSKL() > fillSourceClass.getBaseSKL()) { promoAdjustSKL -= targetClass.getBaseSKL() - fillSourceClass.getBaseSKL(); }
-					if (targetClass.getBaseSPD() > fillSourceClass.getBaseSPD()) { promoAdjustSPD -= targetClass.getBaseSPD() - fillSourceClass.getBaseSPD(); }
-					if (targetClass.getBaseDEF() > fillSourceClass.getBaseDEF()) { promoAdjustDEF -= targetClass.getBaseDEF() - fillSourceClass.getBaseDEF(); }
-					if (targetClass.getBaseRES() > fillSourceClass.getBaseRES()) { promoAdjustRES -= targetClass.getBaseRES() - fillSourceClass.getBaseRES(); }
 				}
+				
+				promoAdjustHP = fillSourceClass.getPromoHP() * -1;
+				promoAdjustSTR = fillSourceClass.getPromoSTR() * -1;
+				promoAdjustSKL = fillSourceClass.getPromoSKL() * -1;
+				promoAdjustSPD = fillSourceClass.getPromoSPD() * -1;
+				promoAdjustDEF = fillSourceClass.getPromoDEF() * -1;
+				promoAdjustRES = fillSourceClass.getPromoRES() * -1;
+				
+				// For some reason, some promoted class seem to have lower bases than their unpromoted variants (FE8 lords are an example). If our demoted class has higher bases, adjust downwards
+				if (targetClass.getBaseHP() > fillSourceClass.getBaseHP()) { promoAdjustHP -= targetClass.getBaseHP() - fillSourceClass.getBaseHP(); }
+				if (targetClass.getBaseSTR() > fillSourceClass.getBaseSTR()) { promoAdjustSTR -= targetClass.getBaseSTR() - fillSourceClass.getBaseSTR(); }
+				if (targetClass.getBaseSKL() > fillSourceClass.getBaseSKL()) { promoAdjustSKL -= targetClass.getBaseSKL() - fillSourceClass.getBaseSKL(); }
+				if (targetClass.getBaseSPD() > fillSourceClass.getBaseSPD()) { promoAdjustSPD -= targetClass.getBaseSPD() - fillSourceClass.getBaseSPD(); }
+				if (targetClass.getBaseDEF() > fillSourceClass.getBaseDEF()) { promoAdjustDEF -= targetClass.getBaseDEF() - fillSourceClass.getBaseDEF(); }
+				if (targetClass.getBaseRES() > fillSourceClass.getBaseRES()) { promoAdjustRES -= targetClass.getBaseRES() - fillSourceClass.getBaseRES(); }
 				
 				setSlotClass(inventoryOptions, linkedSlot, targetClass, characterData, classData, itemData, textData, chapterData, rng);
 			} else {


### PR DESCRIPTION
Fixed #327 - Fixed issues with the autoleveling routine.

* Added logic to the randomizer to resolve discrepancies between the character's nominal level in the character data and the character's canonical level in the chapter data. This should fix issues where the incorrect amount of levels were being used to determine stat adjustments when autoleveling.

* Fixed an issue where promo bonuses were not being given/taken properly for characters with linked slots. The most immediate example are tutorial versions of characters in FE7, where the non-tutorial version of characters have promo bonuses correctly removed and non-tutorial versions of the same character that incorrectly retain promo bonuses.