### PR TITLE
Personal Growths for Class Randomization

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -434,6 +434,30 @@ public class ClassRandomizer {
 			break;
 		}
 		
+		switch (classOptions.growthOptions) {
+		case TRANSFER_PERSONAL_GROWTHS:
+			int hpOffset = character.getHPGrowth() - sourceClass.getHPGrowth();
+			int strOffset = character.getSTRGrowth() - sourceClass.getSTRGrowth();
+			int sklOffset = character.getSKLGrowth() - sourceClass.getSKLGrowth();
+			int spdOffset = character.getSPDGrowth() - sourceClass.getSPDGrowth();
+			int lckOffset = character.getLCKGrowth() - sourceClass.getLCKGrowth();
+			int defOffset = character.getDEFGrowth() - sourceClass.getDEFGrowth();
+			int resOffset = character.getRESGrowth() - sourceClass.getRESGrowth();
+			
+			character.setHPGrowth(Math.max(0, targetClass.getHPGrowth() + hpOffset));
+			character.setSTRGrowth(Math.max(0, targetClass.getSTRGrowth() + strOffset));
+			character.setSKLGrowth(Math.max(0, targetClass.getSKLGrowth() + sklOffset));
+			character.setSPDGrowth(Math.max(0, targetClass.getSPDGrowth() + spdOffset));
+			character.setLCKGrowth(Math.max(0, targetClass.getLCKGrowth() + lckOffset));
+			character.setDEFGrowth(Math.max(0, targetClass.getDEFGrowth() + defOffset));
+			character.setRESGrowth(Math.max(0, targetClass.getRESGrowth() + resOffset));
+			break;
+		case CLASS_RELATIVE_GROWTHS:
+			adjustGrowthsToMatchClass(character, sourceClass, targetClass);
+			break;
+		default:
+			break;
+		}
 		
 		for (GBAFEChapterData chapter : chapterData.allChapters()) {
 			GBAFEChapterItemData reward = chapter.chapterItemGivenToCharacter(character.getID());
@@ -513,7 +537,19 @@ public class ClassRandomizer {
 		character.setBaseSPD(mappedStats.get(2) - targetClass.getBaseSPD());
 		character.setBaseDEF(mappedStats.get(3) - targetClass.getBaseDEF());
 		character.setBaseRES(mappedStats.get(4) - targetClass.getBaseRES());
+	}
+	
+	private static void adjustGrowthsToMatchClass(GBAFECharacterData character, GBAFEClassData sourceClass, GBAFEClassData targetClass) {
+		List<Integer> mappedGrowths = RelativeValueMapper.mappedValues(Arrays.asList(character.getHPGrowth(), character.getSTRGrowth(), character.getSKLGrowth(), character.getSPDGrowth(), character.getDEFGrowth(), character.getRESGrowth(), character.getLCKGrowth()),
+				Arrays.asList(targetClass.getHPGrowth(), targetClass.getSTRGrowth(), targetClass.getSKLGrowth(), targetClass.getSPDGrowth(), targetClass.getDEFGrowth(), targetClass.getRESGrowth(), targetClass.getLCKGrowth()));
 		
+		character.setHPGrowth(mappedGrowths.get(0));
+		character.setSTRGrowth(mappedGrowths.get(1));
+		character.setSKLGrowth(mappedGrowths.get(2));
+		character.setSPDGrowth(mappedGrowths.get(3));
+		character.setDEFGrowth(mappedGrowths.get(4));
+		character.setRESGrowth(mappedGrowths.get(5));
+		character.setLCKGrowth(mappedGrowths.get(6));
 	}
 	
 	// TODO: Offer an option for sidegrade strictness?

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -2147,6 +2147,18 @@ public class GBARandomizer extends Randomizer {
 			}
 			if (sb.length() == 0) { sb.append("YES"); }
 			rk.addHeaderItem("Randomize Playable Character Classes", sb.toString());
+			
+			switch (classes.growthOptions) {
+			case NO_CHANGE:
+				rk.addHeaderItem("Growth Transfer Option", "No Change");
+				break;
+			case TRANSFER_PERSONAL_GROWTHS:
+				rk.addHeaderItem("Growth Transfer Option", "Transfer Personal Growths");
+				break;
+			case CLASS_RELATIVE_GROWTHS:
+				rk.addHeaderItem("Growth Transfer Option", "Class Relative Growths");
+				break;
+			}
 		} else {
 			rk.addHeaderItem("Randomize Playable Character Classes", "NO");
 		}

--- a/Universal FE Randomizer/src/ui/ClassesView.java
+++ b/Universal FE Randomizer/src/ui/ClassesView.java
@@ -15,6 +15,7 @@ import fedata.general.FEBase.GameType;
 import ui.model.ClassOptions;
 import ui.model.ClassOptions.BaseTransferOption;
 import ui.model.ClassOptions.GenderRestrictionOption;
+import ui.model.ClassOptions.GrowthAdjustmentOption;
 
 public class ClassesView extends Composite {
 	
@@ -45,6 +46,13 @@ public class ClassesView extends Composite {
 	private Button basesNoChangeButton;
 	private Button basesAdjustMatchButton;
 	private Button basesAdjustClassButton;
+	
+	private Group growthAdjustmentGroup;
+	private Button growthNoAdjustmentButton;
+	private Button personalGrowthButton;
+	// Maybe enable this option in the future, but it does result in basically every character of the same class have the same exact growth spread,
+	// which, on reflection, doesn't sound very interesting.
+//	private Button classRelativeGrowthButton;
 
 	public ClassesView(Composite parent, int style, GameType type) {
 		super(parent, style);
@@ -80,6 +88,11 @@ public class ClassesView extends Composite {
 				basesNoChangeButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection());
 				basesAdjustMatchButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection());
 				basesAdjustClassButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection());
+				
+				growthAdjustmentGroup.setEnabled(randomizePCButton.getSelection());
+				growthNoAdjustmentButton.setEnabled(randomizePCButton.getSelection());
+				personalGrowthButton.setEnabled(randomizePCButton.getSelection());
+//				classRelativeGrowthButton.setEnabled(randomizePCButton.getSelection());
 				
 				forceChangeButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection() || randomizeEnemiesButton.getSelection());
 				strictGenderButton.setEnabled(randomizePCButton.getSelection() || randomizeBossesButton.getSelection());
@@ -178,6 +191,55 @@ public class ClassesView extends Composite {
 		optionData.top = new FormAttachment(randomizePCSpecialButton, 5);
 		evenClassesButton.setLayoutData(optionData);
 		
+		growthAdjustmentGroup = new Group(container, SWT.NONE);
+		growthAdjustmentGroup.setText("Growths");
+		
+		FormLayout groupLayout = new FormLayout();
+		groupLayout.marginLeft = 5;
+		groupLayout.marginRight = 5;
+		groupLayout.marginTop = 5;
+		groupLayout.marginBottom = 5;
+		growthAdjustmentGroup.setLayout(groupLayout);
+		
+		FormData groupData = new FormData();
+		groupData.left = new FormAttachment(0, 10);
+		groupData.right = new FormAttachment(100, 0);
+		groupData.top = new FormAttachment(evenClassesButton, 10);
+		growthAdjustmentGroup.setLayoutData(groupData);
+		
+		growthNoAdjustmentButton = new Button(growthAdjustmentGroup, SWT.RADIO);
+		growthNoAdjustmentButton.setText("No Adjustment");
+		growthNoAdjustmentButton.setToolTipText("Do not adjust growth rates.");
+		growthNoAdjustmentButton.setEnabled(false);
+		growthNoAdjustmentButton.setSelection(true);
+		
+		FormData noAdjustData = new FormData();
+		noAdjustData.left = new FormAttachment(0, 0);
+		noAdjustData.top = new FormAttachment(0, 0);
+		growthNoAdjustmentButton.setLayoutData(noAdjustData);
+		
+		personalGrowthButton = new Button(growthAdjustmentGroup, SWT.RADIO);
+		personalGrowthButton.setText("Transfer Personal Growths");
+		personalGrowthButton.setToolTipText("Apply personal growth offsets from the old class growths to the new class growths.\n\nFor example, if a character's old SPD growth was 10% higher than the old class's SPD growth,\ntheir new SPD growth would be 10% higher than the new class's SPD growth.");
+		personalGrowthButton.setEnabled(false);
+		personalGrowthButton.setSelection(false);
+		
+		FormData personalData = new FormData();
+		personalData.left = new FormAttachment(0, 0);
+		personalData.top = new FormAttachment(growthNoAdjustmentButton, 5);
+		personalGrowthButton.setLayoutData(personalData);
+		
+//		classRelativeGrowthButton = new Button(growthAdjustmentGroup, SWT.RADIO);
+//		classRelativeGrowthButton.setText("Class Relative Growths");
+//		classRelativeGrowthButton.setToolTipText("Match the character's growth values to the class's growth spread.\n\nFor example, a character becoming a myrmidon will rearrange their growths such that Speed is their highest growth value.");
+//		classRelativeGrowthButton.setEnabled(false);
+//		classRelativeGrowthButton.setSelection(false);
+//		
+//		FormData classRelativeData = new FormData();
+//		classRelativeData.left = new FormAttachment(0, 0);
+//		classRelativeData.top = new FormAttachment(personalGrowthButton, 5);
+//		classRelativeGrowthButton.setLayoutData(classRelativeData);
+		
 		//////////////////////////////////////////////////////////////////
 		
 		randomizeEnemiesButton = new Button(container, SWT.CHECK);
@@ -194,7 +256,7 @@ public class ClassesView extends Composite {
 		
 		FormData enemyFormData = new FormData();
 		enemyFormData.left = new FormAttachment(randomizePCButton, 0, SWT.LEFT);
-		enemyFormData.top = new FormAttachment(evenClassesButton, 10);
+		enemyFormData.top = new FormAttachment(growthAdjustmentGroup, 10);
 		randomizeEnemiesButton.setLayoutData(enemyFormData);
 		
 		//////////////////////////////////////////////////////////////////
@@ -229,14 +291,14 @@ public class ClassesView extends Composite {
 		baseTransferGroup = new Group(container, SWT.NONE);
 		baseTransferGroup.setText("Bases");
 		
-		FormLayout groupLayout = new FormLayout();
+		groupLayout = new FormLayout();
 		groupLayout.marginLeft = 5;
 		groupLayout.marginRight = 5;
 		groupLayout.marginTop = 5;
 		groupLayout.marginBottom = 5;
 		baseTransferGroup.setLayout(groupLayout);
 		
-		FormData groupData = new FormData();
+		groupData = new FormData();
 		groupData.left = new FormAttachment(randomizeBossesButton, 0, SWT.LEFT);
 		groupData.top = new FormAttachment(randomizeBossesButton, 10);
 		groupData.right = new FormAttachment(100, -5);
@@ -378,10 +440,14 @@ public class ClassesView extends Composite {
 		if (looseGenderButton.getSelection()) { genderOption = GenderRestrictionOption.LOOSE; }
 		else if (strictGenderButton.getSelection()) { genderOption = GenderRestrictionOption.STRICT; }
 		
+		GrowthAdjustmentOption growthOption = GrowthAdjustmentOption.NO_CHANGE;
+		if (personalGrowthButton.getSelection()) { growthOption = GrowthAdjustmentOption.TRANSFER_PERSONAL_GROWTHS; }
+//		else if (classRelativeGrowthButton.getSelection()) { growthOption = GrowthAdjustmentOption.CLASS_RELATIVE_GROWTHS; }
+		
 		if (hasMonsterOption) {
-			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, !mixMonsterClasses.getSelection(), forceChangeButton.getSelection(), genderOption, evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption);
+			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, !mixMonsterClasses.getSelection(), forceChangeButton.getSelection(), genderOption, evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption, growthOption);
 		} else {
-			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, forceChangeButton.getSelection(), genderOption, evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption);
+			return new ClassOptions(pcsEnabled, lordsEnabled, newPrfs, unbreakablePrfs, thievesEnabled, specialEnabled, forceChangeButton.getSelection(), genderOption, evenClassesButton.getSelection(), randomizeEnemiesButton.getSelection(), randomizeBossesButton.getSelection(), baseOption, growthOption);
 		}
 	}
 	
@@ -409,6 +475,15 @@ public class ClassesView extends Composite {
 				randomizePCThievesButton.setSelection(options.includeThieves != null ? options.includeThieves : false);
 				randomizePCSpecialButton.setSelection(options.includeSpecial != null ? options.includeSpecial : false);
 				evenClassesButton.setSelection(options.assignEvenly);
+				
+				growthAdjustmentGroup.setEnabled(true);
+				growthNoAdjustmentButton.setEnabled(true);
+				personalGrowthButton.setEnabled(true);
+//				classRelativeGrowthButton.setEnabled(true);
+				
+				growthNoAdjustmentButton.setSelection(options.growthOptions == null || options.growthOptions == GrowthAdjustmentOption.NO_CHANGE);
+				personalGrowthButton.setSelection(options.growthOptions == GrowthAdjustmentOption.TRANSFER_PERSONAL_GROWTHS);
+//				classRelativeGrowthButton.setSelection(options.growthOptions == GrowthAdjustmentOption.CLASS_RELATIVE_GROWTHS);
 			}
 			
 			randomizeEnemiesButton.setSelection(options.randomizeEnemies);

--- a/Universal FE Randomizer/src/ui/WeaponsView.java
+++ b/Universal FE Randomizer/src/ui/WeaponsView.java
@@ -346,7 +346,7 @@ public class WeaponsView extends Composite {
 		
 		if (type.isGBA()) {
 			noEffectsForSteelButton = new Button(container, SWT.CHECK);
-			noEffectsForSteelButton.setText("Include Steel Weapons");
+			noEffectsForSteelButton.setText("Safe Steel Weapons");
 			noEffectsForSteelButton.setToolTipText("Steel Weapons (and Thunder) remain unchanged.");
 			noEffectsForSteelButton.setEnabled(false);
 			
@@ -356,7 +356,7 @@ public class WeaponsView extends Composite {
 			noEffectsForSteelButton.setLayoutData(steelData);
 			
 			noEffectsForBasicThrownButton = new Button(container, SWT.CHECK);
-			noEffectsForBasicThrownButton.setText("Include Basic Thrown Weapons");
+			noEffectsForBasicThrownButton.setText("Safe Basic Thrown Weapons");
 			noEffectsForBasicThrownButton.setToolTipText("Thrown Weapons (Javelin, Hand Axe) remain unchanged.");
 			noEffectsForBasicThrownButton.setEnabled(false);
 			

--- a/Universal FE Randomizer/src/ui/model/ClassOptions.java
+++ b/Universal FE Randomizer/src/ui/model/ClassOptions.java
@@ -10,6 +10,10 @@ public class ClassOptions {
 		STRICT, LOOSE, NONE
 	}
 	
+	public enum GrowthAdjustmentOption {
+		NO_CHANGE, TRANSFER_PERSONAL_GROWTHS, CLASS_RELATIVE_GROWTHS
+	}
+	
 	public final Boolean randomizePCs;
 	public final Boolean createPrfs;
 	public final Boolean unbreakablePrfs;
@@ -28,8 +32,9 @@ public class ClassOptions {
 	public final Boolean randomizeBosses;
 	
 	public final BaseTransferOption basesTransfer;
+	public final GrowthAdjustmentOption growthOptions;
 	
-	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, boolean forceChange, GenderRestrictionOption genderOption, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer) {
+	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, boolean forceChange, GenderRestrictionOption genderOption, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer, GrowthAdjustmentOption growthOptions) {
 		super();
 		randomizePCs = pcs;
 		createPrfs = newPrfs;
@@ -45,12 +50,13 @@ public class ClassOptions {
 		randomizeBosses = bosses;
 		
 		this.basesTransfer = basesTransfer;
+		this.growthOptions = growthOptions;
 		
 		this.forceChange = forceChange;
 		this.genderOption = genderOption;
 	}
 	
-	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, Boolean separateMonsters, boolean forceChange, GenderRestrictionOption genderOption, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer) {
+	public ClassOptions(Boolean pcs, Boolean lords, Boolean newPrfs, Boolean unbreakablePrfs, Boolean thieves, Boolean special, Boolean separateMonsters, boolean forceChange, GenderRestrictionOption genderOption, boolean assignEvenly, Boolean enemies, Boolean bosses, BaseTransferOption basesTransfer, GrowthAdjustmentOption growthOptions) {
 		super();
 		randomizePCs = pcs;
 		createPrfs = newPrfs;
@@ -66,6 +72,7 @@ public class ClassOptions {
 		randomizeBosses = bosses;
 		
 		this.basesTransfer = basesTransfer;
+		this.growthOptions = growthOptions;
 		
 		this.forceChange = forceChange;
 		this.genderOption = genderOption;


### PR DESCRIPTION
Fixed #300 - Added an option to adjust growths when randomizing classes so that their growths better fit their new class.

Also renamed some UI to make it less confusing.