### PR TITLE
Added the option to assign classes evenly for FE4

### DIFF
--- a/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
+++ b/Universal FE Randomizer/src/random/snes/fe4/randomizer/FE4Randomizer.java
@@ -928,6 +928,7 @@ public class FE4Randomizer extends Randomizer {
 				rk.addHeaderItem("Include Julia", classOptions.includeJulia ? "YES" : "NO");
 				rk.addHeaderItem("Retain Healers", classOptions.retainHealers ? "YES" : "NO");
 				rk.addHeaderItem("Retain Horesback Units", classOptions.retainHorses ? "YES" : "NO");
+				rk.addHeaderItem("Assign Classes Evenly", classOptions.assignEvenly ? "YES" : "NO");
 				
 				switch (classOptions.childOption) {
 				case MATCH_STRICT:

--- a/Universal FE Randomizer/src/ui/MiscellaneousView.java
+++ b/Universal FE Randomizer/src/ui/MiscellaneousView.java
@@ -73,7 +73,16 @@ public class MiscellaneousView extends Composite {
 		if (gameType.hasEnglishPatch()) {
 			applyEnglishPatch = new Button(container, SWT.CHECK);
 			applyEnglishPatch.setText("Apply English Patch");
-			applyEnglishPatch.setToolTipText("Given a raw Japanese version of the game, apply the localization patch from Serenes Forest on it. The result is an English version of the game.");
+			switch (gameType) {
+			case FE4:
+				applyEnglishPatch.setToolTipText("Applies the Project Naga localization patch.");
+				break;
+			case FE6:
+				applyEnglishPatch.setToolTipText("Applies the FE6 Localization Patch v1.1.1.");
+				break;
+			default:
+				break;
+			}
 			
 			FormData patchData = new FormData();
 			patchData.left = new FormAttachment(0, 5);
@@ -107,7 +116,7 @@ public class MiscellaneousView extends Composite {
 		randomizeChestVillageRewards = new Button(container, SWT.CHECK);
 		if (gameType == GameType.FE4) {
 			randomizeChestVillageRewards.setText("Randomize Rings");
-			randomizeChestVillageRewards.setToolTipText("Every instance of obtainable ring is randomized to a different kind of ring.");
+			randomizeChestVillageRewards.setToolTipText("Every instance of an obtainable ring is randomized to a different kind of ring.");
 		} else {
 			randomizeChestVillageRewards.setText("Randomize Rewards");
 			randomizeChestVillageRewards.setToolTipText("Rewards from chests, villages, and story events will now give out random rewards. Plot-important promotion items are excluded.");

--- a/Universal FE Randomizer/src/ui/fe4/FE4ClassOptions.java
+++ b/Universal FE Randomizer/src/ui/fe4/FE4ClassOptions.java
@@ -33,6 +33,7 @@ public class FE4ClassOptions {
 	public final boolean includeThieves;
 	public final boolean includeDancers;
 	public final boolean includeJulia;
+	public final boolean assignEvenly;
 	public final ChildOptions childOption;
 	public final BloodOptions playerBloodOption;
 	public final ShopOptions shopOption;
@@ -47,7 +48,7 @@ public class FE4ClassOptions {
 	public final boolean randomizeBosses;
 	public final BloodOptions bossBloodOption;
 	
-	public FE4ClassOptions(boolean pcs, boolean lords, boolean healers, boolean horses, boolean thieves, boolean dancers, boolean julia, ChildOptions children, BloodOptions playerBlood, ShopOptions shops, boolean adjustConvoWeapons, boolean adjustSTRMAG, ItemAssignmentOptions itemOptions, boolean minions, boolean arena, boolean bosses, BloodOptions bossBlood) {
+	public FE4ClassOptions(boolean pcs, boolean lords, boolean healers, boolean horses, boolean thieves, boolean dancers, boolean julia, boolean assignEvenly, ChildOptions children, BloodOptions playerBlood, ShopOptions shops, boolean adjustConvoWeapons, boolean adjustSTRMAG, ItemAssignmentOptions itemOptions, boolean minions, boolean arena, boolean bosses, BloodOptions bossBlood) {
 		super();
 		this.randomizePlayableCharacters = pcs;
 		this.includeLords = lords;
@@ -56,6 +57,7 @@ public class FE4ClassOptions {
 		this.includeThieves = thieves;
 		this.includeDancers = dancers;
 		this.includeJulia = julia;
+		this.assignEvenly = assignEvenly;
 		this.childOption = children;
 		this.playerBloodOption = playerBlood;
 		this.shopOption = shops;

--- a/Universal FE Randomizer/src/ui/fe4/FE4ClassesView.java
+++ b/Universal FE Randomizer/src/ui/fe4/FE4ClassesView.java
@@ -26,6 +26,7 @@ public class FE4ClassesView extends Composite {
 	private Button includeThieves;
 	private Button includeDancers;
 	private Button includeJulia;
+	private Button assignEvenly;
 	
 	private Button adjustChildrenStrict;
 	private Button adjustChildrenLoose;
@@ -87,6 +88,7 @@ public class FE4ClassesView extends Composite {
 				includeThieves.setEnabled(enabled);
 				includeDancers.setEnabled(enabled);
 				includeJulia.setEnabled(enabled);
+				assignEvenly.setEnabled(enabled);
 				
 				adjustChildrenStrict.setEnabled(enabled);
 				adjustChildrenLoose.setEnabled(enabled);
@@ -194,6 +196,17 @@ public class FE4ClassesView extends Composite {
 		optionData.top = new FormAttachment(retainHealers, 5);
 		retainHorses.setLayoutData(optionData);
 		
+		assignEvenly = new Button(container, SWT.CHECK);
+		assignEvenly.setText("Assign Classes Evenly");
+		assignEvenly.setToolTipText("Attempts to avoid duplicate class assignments where possible.\n\nEach generation will have its own class pool.");
+		assignEvenly.setEnabled(false);
+		assignEvenly.setSelection(false);
+		
+		optionData = new FormData();
+		optionData.left = new FormAttachment(retainHorses, 0, SWT.LEFT);
+		optionData.top = new FormAttachment(retainHorses, 5);
+		assignEvenly.setLayoutData(optionData);
+		
 		Group childGroup = new Group(container, SWT.NONE);
 		childGroup.setText("Children Options");
 		
@@ -205,8 +218,8 @@ public class FE4ClassesView extends Composite {
 		childGroup.setLayout(groupLayout);
 		
 		FormData groupData = new FormData();
-		groupData.left = new FormAttachment(retainHorses, 0, SWT.LEFT);
-		groupData.top = new FormAttachment(retainHorses, 5);
+		groupData.left = new FormAttachment(assignEvenly, 0, SWT.LEFT);
+		groupData.top = new FormAttachment(assignEvenly, 5);
 		groupData.right = new FormAttachment(100, -5);
 		childGroup.setLayoutData(groupData);
 		
@@ -615,7 +628,7 @@ public class FE4ClassesView extends Composite {
 		if (bossBloodShuffle.getSelection()) { bossBloodOptions = BloodOptions.SHUFFLE; }
 		if (bossBloodRandomize.getSelection()) { bossBloodOptions = BloodOptions.RANDOMIZE; }
 		
-		return new FE4ClassOptions(randomizePCs.getSelection(), includeLords.getSelection(), retainHealers.getSelection(), retainHorses.getSelection(), includeThieves.getSelection(), includeDancers.getSelection(), includeJulia.getSelection(), childOptions, playerBloodOptions, shopOptions, adjustConvoItems.getSelection(), adjustSTRMAG.getSelection(), itemOptions,
+		return new FE4ClassOptions(randomizePCs.getSelection(), includeLords.getSelection(), retainHealers.getSelection(), retainHorses.getSelection(), includeThieves.getSelection(), includeDancers.getSelection(), includeJulia.getSelection(), assignEvenly.getSelection(), childOptions, playerBloodOptions, shopOptions, adjustConvoItems.getSelection(), adjustSTRMAG.getSelection(), itemOptions,
 				randomizeMinions.getSelection(), randomizeArenas.getSelection(), randomizeBosses.getSelection(), bossBloodOptions);
 	}
 	
@@ -632,6 +645,7 @@ public class FE4ClassesView extends Composite {
 				includeThieves.setEnabled(true);
 				includeDancers.setEnabled(true);
 				includeJulia.setEnabled(true);
+				assignEvenly.setEnabled(true);
 				
 				adjustChildrenStrict.setEnabled(true);
 				adjustChildrenLoose.setEnabled(true);
@@ -658,6 +672,7 @@ public class FE4ClassesView extends Composite {
 				includeThieves.setSelection(options.includeThieves);
 				includeDancers.setSelection(options.includeDancers);
 				includeJulia.setSelection(options.includeJulia);
+				assignEvenly.setSelection(options.assignEvenly);
 				
 				adjustChildrenStrict.setSelection(options.childOption == ChildOptions.MATCH_STRICT);
 				adjustChildrenLoose.setSelection(options.childOption == ChildOptions.MATCH_LOOSE);

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -25,7 +25,7 @@ import ui.model.RecruitmentOptions;
 import ui.model.WeaponOptions;
 
 public class OptionRecorder {
-	private static final Integer FE4OptionBundleVersion = 4;
+	private static final Integer FE4OptionBundleVersion = 5;
 	private static final Integer GBAOptionBundleVersion = 11;
 	private static final Integer FE9OptionBundleVersion = 12;
 	


### PR DESCRIPTION
Fixed #345 - An option has been added to try to avoid duplicate class assignments when randomizing FE4 classes. This isn't a guarantee, due to the sheer number of other restrictions in place, but whenever possible, this option assigns a class that has not been assigned before. The pool resets between generations and substitutes have their own pool separate from the child character they replace.