### PR TITLE
Read list of targeted items in FE6 like in FE7

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFEChapterTargetedItemData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEChapterTargetedItemData.java
@@ -1,0 +1,5 @@
+package fedata.gba;
+
+public interface GBAFEChapterTargetedItemData extends GBAFEChapterItemData {
+	public int getTargetID();
+}

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6ChapterTargetedItem.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6ChapterTargetedItem.java
@@ -1,8 +1,8 @@
-package fedata.gba.fe7;
+package fedata.gba.fe6;
 
 import fedata.gba.GBAFEChapterTargetedItemData;
 
-public class FE7ChapterTargetedItem implements GBAFEChapterTargetedItemData {
+public class FE6ChapterTargetedItem implements GBAFEChapterTargetedItemData {
 
 	private byte[] originalData;
 	private byte[] data;
@@ -12,7 +12,7 @@ public class FE7ChapterTargetedItem implements GBAFEChapterTargetedItemData {
 	private Boolean wasModified = false;
 	private Boolean hasChanges = false;
 	
-	public FE7ChapterTargetedItem(byte[] data, long originalOffset) {
+	public FE6ChapterTargetedItem(byte[] data, long originalOffset) {
 		super();
 		this.originalData = data;
 		this.data = data;
@@ -56,9 +56,9 @@ public class FE7ChapterTargetedItem implements GBAFEChapterTargetedItemData {
 
 	@Override
 	public Type getRewardType() {
-		if (data[0] == 0x5C) { return Type.ITGC; }
+		if (data[0] == 0x27) { return Type.ITGC; }
 		
-		return data[0] == 0x5B ? Type.ITGV : Type.CHES;
+		return data[0] == 0x26 ? Type.ITGV : Type.CHES;
 	}
 	
 	public int getTargetID() {

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1478,6 +1478,35 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			}
 		}
 		
+		public Character[] targetedRewardRecipientsToTrack() {
+			switch (this) {
+			case CHAPTER_8X:
+			case CHAPTER_12X:
+			case CHAPTER_14X:
+			case CHAPTER_16X:
+			case CHAPTER_20AX:
+			case CHAPTER_20BX:
+			case CHAPTER_21:
+			case CHAPTER_21X:
+				return new Character[] {Character.ROY};
+			case CHAPTER_10A:
+			case CHAPTER_11B:
+				return new Character[] {Character.ROY};
+			case CHAPTER_11A:
+			case CHAPTER_10B:
+				return new Character[] {Character.ROY, Character.KLEIN, Character.THITO};
+			case CHAPTER_13:
+			case CHAPTER_15:
+				return new Character[] {Character.PERCIVAL};
+			case CHAPTER_20A:
+				return new Character[] {Character.ROY};
+			default:
+				break;
+			}
+			
+			return new Character[] {};
+		}
+		
 		public CharacterNudge[] nudgesRequired() {
 			switch(this) {
 			case CHAPTER_6:

--- a/Universal FE Randomizer/src/random/gba/loader/ChapterLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ChapterLoader.java
@@ -62,11 +62,15 @@ public class ChapterLoader {
 					for (int index = 0; index < chapter.blacklistedClasses().length; index++) {
 						classBlacklist[index] = chapter.blacklistedClasses()[index].ID;
 					}
+					int[] trackedRewardRecipients = new int[chapter.targetedRewardRecipientsToTrack().length];
+					for (int index = 0; index < chapter.targetedRewardRecipientsToTrack().length; index++) {
+						trackedRewardRecipients[index] = chapter.targetedRewardRecipientsToTrack()[index].ID;
+					}
 					
 					CharacterNudge[] nudges = chapter.nudgesRequired();
 					long chapterOffset = baseAddress + (4 * chapter.chapterID);
 					DebugPrinter.log(DebugPrinter.Key.CHAPTER_LOADER, "Loading " + chapter.toString());
-					FE6Chapter fe6Chapter = new FE6Chapter(handler, chapterOffset, chapter.isClassSafe(), chapter.shouldRemoveFightScenes(), classBlacklist, chapter.getMetadata().getFriendlyName(), chapter.shouldBeEasy(), nudges); 
+					FE6Chapter fe6Chapter = new FE6Chapter(handler, chapterOffset, chapter.isClassSafe(), chapter.shouldRemoveFightScenes(), trackedRewardRecipients, classBlacklist, chapter.getMetadata().getFriendlyName(), chapter.shouldBeEasy(), nudges); 
 					chapters[i++] = fe6Chapter;
 					mappedChapters.put(chapterID, fe6Chapter);
 					DebugPrinter.log(DebugPrinter.Key.CHAPTER_LOADER, "Chapter " + chapter.toString() + " loaded " + fe6Chapter.allUnits().length + " characters and " + fe6Chapter.allRewards().length + " rewards");


### PR DESCRIPTION
This pretty much just ports the ITGC detection from FE7 to FE6. Might be helpful in the future? (I don't know if this affects the behavior of the randomizer at all; I was just using Yune as a way to extract them all to a list for myself.)