### PR TITLE
Issue #178 + Proposed Refactor GBA + FE4 Record Keeper

### DIFF
--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -34,6 +34,7 @@ public class CharacterDataLoader {
 	private Map<Integer, GBAFECharacterData> minionData = new HashMap<Integer, GBAFECharacterData>();
 	
 	public static final String RecordKeeperCategoryKey = "Characters";
+	public static final String RecordKeeperCategoryKeyBosses = "Characters - Bosses";
 	
 	public CharacterDataLoader(GBAFECharacterProvider provider, FileHandler handler) {
 		super();
@@ -249,14 +250,16 @@ public class CharacterDataLoader {
 
 	public void recordCharacters(RecordKeeper rk, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData) {
 		for (GBAFECharacterData character : playableCharacters()) {
-			recordCharacter(rk, character, isInitial, classData, itemData, textData);
+			recordCharacter(rk, character, isInitial, classData, itemData, textData, RecordKeeperCategoryKey, false);
 		}
+		rk.registerCategory(RecordKeeperCategoryKeyBosses);
 		for (GBAFECharacterData boss : bossCharacters()) {
-			recordCharacter(rk, boss, isInitial, classData, itemData, textData);
+			recordCharacter(rk, boss, isInitial, classData, itemData, textData, RecordKeeperCategoryKeyBosses,true);
 		}
+		rk.sortKeysInCategory(RecordKeeperCategoryKeyBosses);
 	}
-	
-	private void recordCharacter(RecordKeeper rk, GBAFECharacterData character, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData) {
+
+	private void recordCharacter(RecordKeeper rk, GBAFECharacterData character, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData, String category, boolean enemy) {
 		int nameIndex = character.getNameIndex();
 		int classID = character.getClassID();
 		GBAFEClassData charClass = classData.classForID(classID);
@@ -269,71 +272,72 @@ public class CharacterDataLoader {
 		
 		String classValue = className + " (0x" + Integer.toHexString(classID).toUpperCase() + ")";
 		if (isInitial) {
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Name", name);
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Class", classValue);
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Level", Integer.toString(character.getLevel()));
+			rk.recordOriginalEntry(category, internalName, "Name", name);
+			rk.recordOriginalEntry(category, internalName, "Class", classValue);
+			rk.recordOriginalEntry(category, internalName, "Level", Integer.toString(character.getLevel()));
 			
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "HP Growth", String.format("%d%%", character.getHPGrowth()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "STR/MAG Growth", String.format("%d%%", character.getSTRGrowth()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "SKL Growth", String.format("%d%%", character.getSKLGrowth()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "SPD Growth", String.format("%d%%", character.getSPDGrowth()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "LCK Growth", String.format("%d%%", character.getLCKGrowth()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "DEF Growth", String.format("%d%%", character.getDEFGrowth()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "RES Growth", String.format("%d%%", character.getRESGrowth()));
+			rk.recordOriginalEntry(category, internalName, "HP Growth", String.format("%d%%", character.getHPGrowth()));
+			rk.recordOriginalEntry(category, internalName, "STR/MAG Growth", String.format("%d%%", character.getSTRGrowth()));
+			rk.recordOriginalEntry(category, internalName, "SKL Growth", String.format("%d%%", character.getSKLGrowth()));
+			rk.recordOriginalEntry(category, internalName, "SPD Growth", String.format("%d%%", character.getSPDGrowth()));
+			rk.recordOriginalEntry(category, internalName, "LCK Growth", String.format("%d%%", character.getLCKGrowth()));
+			rk.recordOriginalEntry(category, internalName, "DEF Growth", String.format("%d%%", character.getDEFGrowth()));
+			rk.recordOriginalEntry(category, internalName, "RES Growth", String.format("%d%%", character.getRESGrowth()));
 			
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base HP", Integer.toString(character.getBaseHP() + charClass.getBaseHP()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base STR/MAG", Integer.toString(character.getBaseSTR() + charClass.getBaseSTR()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base SKL", Integer.toString(character.getBaseSKL() + charClass.getBaseSKL()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base SPD", Integer.toString(character.getBaseSPD() + charClass.getBaseSPD()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base LCK", Integer.toString(character.getBaseLCK() + charClass.getBaseLCK()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base DEF", Integer.toString(character.getBaseDEF() + charClass.getBaseDEF()));
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base RES", Integer.toString(character.getBaseRES() + charClass.getBaseRES()));
+			rk.recordOriginalEntry(category, internalName, "Base HP", Integer.toString(character.getBaseHP() + charClass.getBaseHP()));
+			rk.recordOriginalEntry(category, internalName, "Base STR/MAG", Integer.toString(character.getBaseSTR() + charClass.getBaseSTR()));
+			rk.recordOriginalEntry(category, internalName, "Base SKL", Integer.toString(character.getBaseSKL() + charClass.getBaseSKL()));
+			rk.recordOriginalEntry(category, internalName, "Base SPD", Integer.toString(character.getBaseSPD() + charClass.getBaseSPD()));
+			rk.recordOriginalEntry(category, internalName, "Base LCK", Integer.toString(character.getBaseLCK() + charClass.getBaseLCK()));
+			rk.recordOriginalEntry(category, internalName, "Base DEF", Integer.toString(character.getBaseDEF() + charClass.getBaseDEF()));
+			rk.recordOriginalEntry(category, internalName, "Base RES", Integer.toString(character.getBaseRES() + charClass.getBaseRES()));
 			
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Base CON", Integer.toString(character.getConstitution() + charClass.getCON()));
+			rk.recordOriginalEntry(category, internalName, "Base CON", Integer.toString(character.getConstitution() + charClass.getCON()));
 			
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Sword Rank", itemData.rankForValue(character.getSwordRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Lance Rank", itemData.rankForValue(character.getLanceRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Axe Rank", itemData.rankForValue(character.getAxeRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Bow Rank", itemData.rankForValue(character.getBowRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Anima Rank", itemData.rankForValue(character.getAnimaRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Light Rank", itemData.rankForValue(character.getLightRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Dark Rank", itemData.rankForValue(character.getDarkRank()).displayString());
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Staff Rank", itemData.rankForValue(character.getStaffRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Sword Rank", itemData.rankForValue(character.getSwordRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Lance Rank", itemData.rankForValue(character.getLanceRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Axe Rank", itemData.rankForValue(character.getAxeRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Bow Rank", itemData.rankForValue(character.getBowRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Anima Rank", itemData.rankForValue(character.getAnimaRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Light Rank", itemData.rankForValue(character.getLightRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Dark Rank", itemData.rankForValue(character.getDarkRank()).displayString());
+			rk.recordOriginalEntry(category, internalName, "Staff Rank", itemData.rankForValue(character.getStaffRank()).displayString());
 			
-			rk.recordOriginalEntry(RecordKeeperCategoryKey, internalName, "Affinity", character.getAffinityName() + " (0x" + Integer.toHexString(character.getAffinityValue()).toUpperCase() + ")");
+			rk.recordOriginalEntry(category, internalName, "Affinity", character.getAffinityName() + " (0x" + Integer.toHexString(character.getAffinityValue()).toUpperCase() + ")");
 		} else {
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Name", name);
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Class", classValue);
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Level", Integer.toString(character.getLevel()));
+			rk.recordUpdatedEntry(category, internalName, "Name", name);
+			rk.recordUpdatedEntry(category, internalName, "Class", classValue);
+			rk.recordUpdatedEntry(category, internalName, "Level", Integer.toString(character.getLevel()));
 			
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "HP Growth", String.format("%d%%", character.getHPGrowth()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "STR/MAG Growth", String.format("%d%%", character.getSTRGrowth()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "SKL Growth", String.format("%d%%", character.getSKLGrowth()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "SPD Growth", String.format("%d%%", character.getSPDGrowth()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "LCK Growth", String.format("%d%%", character.getLCKGrowth()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "DEF Growth", String.format("%d%%", character.getDEFGrowth()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "RES Growth", String.format("%d%%", character.getRESGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "HP Growth", String.format("%d%%", character.getHPGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "STR/MAG Growth", String.format("%d%%", character.getSTRGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "SKL Growth", String.format("%d%%", character.getSKLGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "SPD Growth", String.format("%d%%", character.getSPDGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "LCK Growth", String.format("%d%%", character.getLCKGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "DEF Growth", String.format("%d%%", character.getDEFGrowth()));
+			rk.recordUpdatedEntry(category, internalName, "RES Growth", String.format("%d%%", character.getRESGrowth()));
 			
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base HP", Integer.toString(character.getBaseHP() + charClass.getBaseHP()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base STR/MAG", Integer.toString(character.getBaseSTR() + charClass.getBaseSTR()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base SKL", Integer.toString(character.getBaseSKL() + charClass.getBaseSKL()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base SPD", Integer.toString(character.getBaseSPD() + charClass.getBaseSPD()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base LCK", Integer.toString(character.getBaseLCK() + charClass.getBaseLCK()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base DEF", Integer.toString(character.getBaseDEF() + charClass.getBaseDEF()));
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base RES", Integer.toString(character.getBaseRES() + charClass.getBaseRES()));
+			rk.recordUpdatedEntry(category, internalName, "Base HP", Integer.toString(character.getBaseHP() + charClass.getBaseHP()));
+			rk.recordUpdatedEntry(category, internalName, "Base STR/MAG", Integer.toString(character.getBaseSTR() + charClass.getBaseSTR()));
+			rk.recordUpdatedEntry(category, internalName, "Base SKL", Integer.toString(character.getBaseSKL() + charClass.getBaseSKL()));
+			rk.recordUpdatedEntry(category, internalName, "Base SPD", Integer.toString(character.getBaseSPD() + charClass.getBaseSPD()));
+			rk.recordUpdatedEntry(category, internalName, "Base LCK", Integer.toString(character.getBaseLCK() + charClass.getBaseLCK()));
+			rk.recordUpdatedEntry(category, internalName, "Base DEF", Integer.toString(character.getBaseDEF() + charClass.getBaseDEF()));
+			rk.recordUpdatedEntry(category, internalName, "Base RES", Integer.toString(character.getBaseRES() + charClass.getBaseRES()));
 			
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Base CON", Integer.toString(character.getConstitution() + charClass.getCON()));
+			rk.recordUpdatedEntry(category, internalName, "Base CON", Integer.toString(character.getConstitution() + charClass.getCON()));
 			
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Sword Rank", itemData.rankForValue(character.getSwordRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Lance Rank", itemData.rankForValue(character.getLanceRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Axe Rank", itemData.rankForValue(character.getAxeRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Bow Rank", itemData.rankForValue(character.getBowRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Anima Rank", itemData.rankForValue(character.getAnimaRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Light Rank", itemData.rankForValue(character.getLightRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Dark Rank", itemData.rankForValue(character.getDarkRank()).displayString());
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Staff Rank", itemData.rankForValue(character.getStaffRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Sword Rank", itemData.rankForValue(character.getSwordRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Lance Rank", itemData.rankForValue(character.getLanceRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Axe Rank", itemData.rankForValue(character.getAxeRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Bow Rank", itemData.rankForValue(character.getBowRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Anima Rank", itemData.rankForValue(character.getAnimaRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Light Rank", itemData.rankForValue(character.getLightRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Dark Rank", itemData.rankForValue(character.getDarkRank()).displayString());
+			rk.recordUpdatedEntry(category, internalName, "Staff Rank", itemData.rankForValue(character.getStaffRank()).displayString());
 			
-			rk.recordUpdatedEntry(RecordKeeperCategoryKey, internalName, "Affinity", character.getAffinityName() + " (0x" + Integer.toHexString(character.getAffinityValue()).toUpperCase() + ")");
+			rk.recordUpdatedEntry(category, internalName, "Affinity", character.getAffinityName() + " (0x" + Integer.toHexString(character.getAffinityValue()).toUpperCase() + ")");
 		}
+		
 	}
 }

--- a/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/CharacterDataLoader.java
@@ -250,16 +250,16 @@ public class CharacterDataLoader {
 
 	public void recordCharacters(RecordKeeper rk, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData) {
 		for (GBAFECharacterData character : playableCharacters()) {
-			recordCharacter(rk, character, isInitial, classData, itemData, textData, RecordKeeperCategoryKey, false);
+			recordCharacter(rk, character, isInitial, classData, itemData, textData, RecordKeeperCategoryKey);
 		}
 		rk.registerCategory(RecordKeeperCategoryKeyBosses);
 		for (GBAFECharacterData boss : bossCharacters()) {
-			recordCharacter(rk, boss, isInitial, classData, itemData, textData, RecordKeeperCategoryKeyBosses,true);
+			recordCharacter(rk, boss, isInitial, classData, itemData, textData, RecordKeeperCategoryKeyBosses);
 		}
 		rk.sortKeysInCategory(RecordKeeperCategoryKeyBosses);
 	}
 
-	private void recordCharacter(RecordKeeper rk, GBAFECharacterData character, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData, String category, boolean enemy) {
+	private void recordCharacter(RecordKeeper rk, GBAFECharacterData character, Boolean isInitial, ClassDataLoader classData, ItemDataLoader itemData, TextLoader textData, String category) {
 		int nameIndex = character.getNameIndex();
 		int classID = character.getClassID();
 		GBAFEClassData charClass = classData.classForID(classID);

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ChapterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ChapterDataLoader.java
@@ -25,17 +25,17 @@ import io.gcn.GCNISOHandler;
 import io.gcn.GCNMessageFileHandler;
 import util.DebugPrinter;
 import util.WhyDoesJavaNotHaveThese;
-import util.recordkeeper.Base64Asset;
-import util.recordkeeper.ChangelogAsset;
-import util.recordkeeper.ChangelogBuilder;
-import util.recordkeeper.ChangelogHeader;
-import util.recordkeeper.ChangelogHeader.HeaderLevel;
-import util.recordkeeper.ChangelogText.Style;
-import util.recordkeeper.ChangelogSection;
-import util.recordkeeper.ChangelogStyleRule;
-import util.recordkeeper.ChangelogTOC;
-import util.recordkeeper.ChangelogTable;
-import util.recordkeeper.ChangelogText;
+import util.recordkeeper.fe9.Base64Asset;
+import util.recordkeeper.fe9.ChangelogAsset;
+import util.recordkeeper.fe9.ChangelogBuilder;
+import util.recordkeeper.fe9.ChangelogHeader;
+import util.recordkeeper.fe9.ChangelogSection;
+import util.recordkeeper.fe9.ChangelogStyleRule;
+import util.recordkeeper.fe9.ChangelogTOC;
+import util.recordkeeper.fe9.ChangelogTable;
+import util.recordkeeper.fe9.ChangelogText;
+import util.recordkeeper.fe9.ChangelogHeader.HeaderLevel;
+import util.recordkeeper.fe9.ChangelogText.Style;
 
 public class FE9ChapterDataLoader {
 	

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9CharacterDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9CharacterDataLoader.java
@@ -25,18 +25,18 @@ import random.gcnwii.fe9.loader.FE9ItemDataLoader.WeaponType;
 import util.DebugPrinter;
 import util.Diff;
 import util.WhyDoesJavaNotHaveThese;
-import util.recordkeeper.Base64Asset;
-import util.recordkeeper.ChangelogAsset;
-import util.recordkeeper.ChangelogBuilder;
-import util.recordkeeper.ChangelogElement;
-import util.recordkeeper.ChangelogHeader;
-import util.recordkeeper.ChangelogHeader.HeaderLevel;
-import util.recordkeeper.ChangelogSection;
-import util.recordkeeper.ChangelogStyleRule;
-import util.recordkeeper.ChangelogTOC;
-import util.recordkeeper.ChangelogTable;
-import util.recordkeeper.ChangelogText;
-import util.recordkeeper.ChangelogText.Style;
+import util.recordkeeper.fe9.Base64Asset;
+import util.recordkeeper.fe9.ChangelogAsset;
+import util.recordkeeper.fe9.ChangelogBuilder;
+import util.recordkeeper.fe9.ChangelogElement;
+import util.recordkeeper.fe9.ChangelogHeader;
+import util.recordkeeper.fe9.ChangelogSection;
+import util.recordkeeper.fe9.ChangelogStyleRule;
+import util.recordkeeper.fe9.ChangelogTOC;
+import util.recordkeeper.fe9.ChangelogTable;
+import util.recordkeeper.fe9.ChangelogText;
+import util.recordkeeper.fe9.ChangelogHeader.HeaderLevel;
+import util.recordkeeper.fe9.ChangelogText.Style;
 
 public class FE9CharacterDataLoader {
 	

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ClassDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ClassDataLoader.java
@@ -20,13 +20,13 @@ import random.gcnwii.fe9.loader.FE9ItemDataLoader.WeaponType;
 import util.DebugPrinter;
 import util.Diff;
 import util.WhyDoesJavaNotHaveThese;
-import util.recordkeeper.ChangelogBuilder;
-import util.recordkeeper.ChangelogHeader;
-import util.recordkeeper.ChangelogSection;
-import util.recordkeeper.ChangelogStyleRule;
-import util.recordkeeper.ChangelogTOC;
-import util.recordkeeper.ChangelogTable;
-import util.recordkeeper.ChangelogHeader.HeaderLevel;
+import util.recordkeeper.fe9.ChangelogBuilder;
+import util.recordkeeper.fe9.ChangelogHeader;
+import util.recordkeeper.fe9.ChangelogSection;
+import util.recordkeeper.fe9.ChangelogStyleRule;
+import util.recordkeeper.fe9.ChangelogTOC;
+import util.recordkeeper.fe9.ChangelogTable;
+import util.recordkeeper.fe9.ChangelogHeader.HeaderLevel;
 
 public class FE9ClassDataLoader {
 	

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/loader/FE9ItemDataLoader.java
@@ -28,13 +28,13 @@ import ui.model.MinMaxOption;
 import util.DebugPrinter;
 import util.Diff;
 import util.WhyDoesJavaNotHaveThese;
-import util.recordkeeper.ChangelogBuilder;
-import util.recordkeeper.ChangelogHeader;
-import util.recordkeeper.ChangelogSection;
-import util.recordkeeper.ChangelogStyleRule;
-import util.recordkeeper.ChangelogTOC;
-import util.recordkeeper.ChangelogTable;
-import util.recordkeeper.ChangelogHeader.HeaderLevel;
+import util.recordkeeper.fe9.ChangelogBuilder;
+import util.recordkeeper.fe9.ChangelogHeader;
+import util.recordkeeper.fe9.ChangelogSection;
+import util.recordkeeper.fe9.ChangelogStyleRule;
+import util.recordkeeper.fe9.ChangelogTOC;
+import util.recordkeeper.fe9.ChangelogTable;
+import util.recordkeeper.fe9.ChangelogHeader.HeaderLevel;
 
 public class FE9ItemDataLoader {
 	

--- a/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
+++ b/Universal FE Randomizer/src/random/gcnwii/fe9/randomizer/FE9Randomizer.java
@@ -50,15 +50,15 @@ import ui.model.WeaponOptions;
 import util.DebugPrinter;
 import util.SeedGenerator;
 import util.WhyDoesJavaNotHaveThese;
-import util.recordkeeper.ChangelogAsset;
-import util.recordkeeper.ChangelogBuilder;
-import util.recordkeeper.ChangelogDivider;
-import util.recordkeeper.ChangelogHeader;
-import util.recordkeeper.ChangelogSection;
-import util.recordkeeper.ChangelogStyleRule;
-import util.recordkeeper.ChangelogTOC;
-import util.recordkeeper.ChangelogTable;
-import util.recordkeeper.ChangelogHeader.HeaderLevel;
+import util.recordkeeper.fe9.ChangelogAsset;
+import util.recordkeeper.fe9.ChangelogBuilder;
+import util.recordkeeper.fe9.ChangelogDivider;
+import util.recordkeeper.fe9.ChangelogHeader;
+import util.recordkeeper.fe9.ChangelogSection;
+import util.recordkeeper.fe9.ChangelogStyleRule;
+import util.recordkeeper.fe9.ChangelogTOC;
+import util.recordkeeper.fe9.ChangelogTable;
+import util.recordkeeper.fe9.ChangelogHeader.HeaderLevel;
 
 public class FE9Randomizer extends Randomizer {
 	private String sourcePath;

--- a/Universal FE Randomizer/src/random/general/Randomizer.java
+++ b/Universal FE Randomizer/src/random/general/Randomizer.java
@@ -3,8 +3,8 @@ package random.general;
 import org.eclipse.swt.widgets.Display;
 
 import util.DebugPrinter;
-import util.recordkeeper.ChangelogBuilder;
 import util.recordkeeper.RecordKeeper;
+import util.recordkeeper.fe9.ChangelogBuilder;
 
 public abstract class Randomizer extends Thread {
 

--- a/Universal FE Randomizer/src/random/general/RandomizerListener.java
+++ b/Universal FE Randomizer/src/random/general/RandomizerListener.java
@@ -1,7 +1,7 @@
 package random.general;
 
-import util.recordkeeper.ChangelogBuilder;
 import util.recordkeeper.RecordKeeper;
+import util.recordkeeper.fe9.ChangelogBuilder;
 
 public interface RandomizerListener {
 	

--- a/Universal FE Randomizer/src/ui/MainView.java
+++ b/Universal FE Randomizer/src/ui/MainView.java
@@ -82,12 +82,12 @@ import util.WhyDoesJavaNotHaveThese;
 import util.OptionRecorder.FE4OptionBundle;
 import util.OptionRecorder.FE9OptionBundle;
 import util.OptionRecorder.GBAOptionBundle;
-import util.recordkeeper.ChangelogBuilder;
-import util.recordkeeper.ChangelogHeader;
-import util.recordkeeper.ChangelogHeader.HeaderLevel;
-import util.recordkeeper.ChangelogSection;
-import util.recordkeeper.ChangelogTable;
 import util.recordkeeper.RecordKeeper;
+import util.recordkeeper.fe9.ChangelogBuilder;
+import util.recordkeeper.fe9.ChangelogHeader;
+import util.recordkeeper.fe9.ChangelogSection;
+import util.recordkeeper.fe9.ChangelogTable;
+import util.recordkeeper.fe9.ChangelogHeader.HeaderLevel;
 
 public class MainView implements FileFlowDelegate {
 	

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordBuilder.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordBuilder.java
@@ -16,15 +16,16 @@ public class RecordBuilder {
         this.outputPath = path;
     }
 
-    public void appendBasicTable(Set<Map.Entry<String, String>> entrySet) {
+    public RecordBuilder appendBasicTable(Set<Map.Entry<String, String>> entrySet) {
         output.append("<table>\n");
         entrySet.forEach(e -> {
             output.append("<tr><td>").append(e.getKey()).append("</td><td>").append(e.getValue()).append("</td></tr>\n");
         });
         output.append("</table>\n");
+        return this;
     }
 
-    public void appendTOC(List<String> entries, int columns) {
+    public RecordBuilder appendTOC(List<String> entries, int columns) {
         output.append("<table>\n");
         int currentColumn = 0;
         for (String entry : entries) {
@@ -39,13 +40,15 @@ public class RecordBuilder {
             }
         }
         output.append("</table>\n");
+        return this;
     }
 
-    public void appendLinkToTOC(String category) {
+    public RecordBuilder appendLinkToTOC(String category) {
         output.append(String.format("<a href=\"#%s\">Back to %s</a>\n", keyFromString(category), category));
+        return this;
     }
 
-    public void appendEntryComparison(RecordEntry recordCategory) {
+    public RecordBuilder appendEntryComparison(RecordEntry recordCategory) {
         output.append("<table>\n");
         for (String key : recordCategory.getInfoKeys()) {
             RecordInformation entry = recordCategory.getInfo(key);
@@ -58,36 +61,42 @@ public class RecordBuilder {
                     .append("</tr>");
         }
         output.append("</table>\n");
+        return this;
     }
 
-    public void appendHorizontalSpacer() {
+    public RecordBuilder appendHorizontalSpacer() {
         output.append("<br><hr><br>\n");
+        return this;
     }
 
-    public void appendUnorderedList(List<String> values) {
+    public RecordBuilder appendUnorderedList(List<String> values) {
         output.append("<ul>");
         values.forEach(v -> output.append("<li>").append(v).append("</li>\n"));
         output.append("</ul>");
+        return this;
     }
 
-    public void appendLiteral(String literal) {
+    public RecordBuilder appendLiteral(String literal) {
         output.append(literal);
+        return this;
     }
 
-    public void appendSectionHeader(String title, int size) {
+    public RecordBuilder appendSectionHeader(String title, int size) {
         assert (size > 0 && size < 7);
         String startTag = String.format("<h%d ", size);
         String endTag = String.format("<h%d/>", size);
         output.append(startTag).append("id=\"").append(keyFromString(title)).append("\">").append(title).append(endTag).append("<br>\n");
+        return this;
     }
 
-    public void buildHeader(String title) {
+    public RecordBuilder buildHeader(String title) {
         output.append("<html><meta http-equiv=\"Content-Type\" content = \"text/html; charset=utf-8\" /><head><style>\n")
                 .append("table, th, td {\n\tborder: 1px solid black;\n}\n")
                 .append(".notes {\n\twidth: 66%;\n\tmargin: auto;\n}\n")
                 .append("</style></head><body>\n")
                 .append("<center><h1><p>Changelog for ").append(title).append("</p></h1><br>\n")
                 .append("<hr>\n");
+        return this;
     }
 
     public void write() {

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordBuilder.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordBuilder.java
@@ -1,0 +1,105 @@
+package util.recordkeeper;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RecordBuilder {
+    private final String outputPath;
+    private StringBuilder output = new StringBuilder();
+
+    public RecordBuilder(String path) {
+        this.outputPath = path;
+    }
+
+    public void appendBasicTable(Set<Map.Entry<String, String>> entrySet) {
+        output.append("<table>\n");
+        entrySet.forEach(e -> {
+            output.append("<tr><td>").append(e.getKey()).append("</td><td>").append(e.getValue()).append("</td></tr>\n");
+        });
+        output.append("</table>\n");
+    }
+
+    public void appendTOC(List<String> entries, int columns) {
+        output.append("<table>\n");
+        int currentColumn = 0;
+        for (String entry : entries) {
+            if (currentColumn == 0)
+                output.append("<tr>\n");
+
+            output.append(String.format("<td><a href=\"#%s\">%s</a></td>\n", entry, entry));
+            currentColumn += 1;
+            if (currentColumn == columns) {
+                output.append("</tr>\n");
+                currentColumn = 0;
+            }
+        }
+        output.append("</table>\n");
+    }
+
+    public void appendLinkToTOC(String category) {
+        output.append(String.format("<a href=\"#%s\">Back to %s</a>\n", keyFromString(category), category));
+    }
+
+    public void appendEntryComparison(RecordEntry recordCategory) {
+        output.append("<table>\n");
+        for (String key : recordCategory.getInfoKeys()) {
+            RecordInformation entry = recordCategory.getInfo(key);
+            String oldValue = entry.originalValue;
+            String newValue = entry.updatedValue;
+            output.append("<tr>\n").append(String.format("<td>%s</td>\n", key))
+                    .append(String.format("<td>%s</td>\n", oldValue != null ? oldValue : "(null)"))
+                    .append(String.format("<td>%s</td>\n", newValue != null ? newValue : "(null)"))
+                    .append(entry.additionalInfo != null ? String.format("<td>%s</td>",  entry.additionalInfo) : "")
+                    .append("</tr>");
+        }
+        output.append("</table>\n");
+    }
+
+    public void appendHorizontalSpacer() {
+        output.append("<br><hr><br>\n");
+    }
+
+    public void appendUnorderedList(List<String> values) {
+        output.append("<ul>");
+        values.forEach(v -> output.append("<li>").append(v).append("</li>\n"));
+        output.append("</ul>");
+    }
+
+    public void appendLiteral(String literal) {
+        output.append(literal);
+    }
+
+    public void appendSectionHeader(String title, int size) {
+        assert (size > 0 && size < 7);
+        String startTag = String.format("<h%d ", size);
+        String endTag = String.format("<h%d/>", size);
+        output.append(startTag).append("id=\"").append(keyFromString(title)).append("\">").append(title).append(endTag).append("<br>\n");
+    }
+
+    public void buildHeader(String title) {
+        output.append("<html><meta http-equiv=\"Content-Type\" content = \"text/html; charset=utf-8\" /><head><style>\n")
+                .append("table, th, td {\n\tborder: 1px solid black;\n}\n")
+                .append(".notes {\n\twidth: 66%;\n\tmargin: auto;\n}\n")
+                .append("</style></head><body>\n")
+                .append("<center><h1><p>Changelog for ").append(title).append("</p></h1><br>\n")
+                .append("<hr>\n");
+    }
+
+    public void write() {
+        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(outputPath), StandardCharsets.UTF_8.newEncoder())) {
+            writer.write(output.toString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private String keyFromString(String string) {
+        return string.replace(' ', '_');
+    }
+}

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordCategoryMap.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordCategoryMap.java
@@ -1,0 +1,35 @@
+package util.recordkeeper;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RecordCategoryMap {
+	private boolean sorted = false;
+	private Map<String, RecordEntry> entries = new HashMap<>();
+
+	public void addEntry(String key, RecordEntry entry) {
+		if (!entries.containsKey(key))
+			entries.put(key, entry);
+	}
+
+	public RecordEntry getEntry(String key) {
+		return entries.get(key);
+	}
+
+	public Map<String, RecordEntry> getEntries() {
+		return entries;
+	}
+
+	public List<String> getKeyList() {
+		List<RecordEntry> entryList = new ArrayList<>(entries.values());
+		if (sorted) {
+			Collections.sort(entryList, entryList.get(0).getComparator());
+		}
+		return entryList.stream().map(e -> e.entryKey).collect(Collectors.toList());
+	}
+
+	public void setSorted() {
+		this.sorted = true;
+	}
+
+}

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordEntry.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordEntry.java
@@ -1,0 +1,54 @@
+package util.recordkeeper;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RecordEntry {
+	protected String entryKey;
+	protected List<String> allInfoKeys = new ArrayList<>();
+    protected Map<String, RecordInformation> recordInformation = new HashMap<>();
+
+    public RecordEntry() {
+    	
+    }
+    
+    public RecordEntry(String entryKey) {
+    	this.entryKey = entryKey;
+    }
+    
+    public List<String> getInfoKeys(){
+    	return this.allInfoKeys;
+    }
+    
+    public void addInfo(String key, RecordInformation info) {
+    	this.allInfoKeys.add(key);
+        recordInformation.putIfAbsent(key, info);
+    }
+
+    public Map<String, RecordInformation> getInfos() {
+        return this.recordInformation;
+    }
+
+    public RecordInformation getInfo(String key) {
+        return this.recordInformation.get(key);
+    }
+
+    public void removeInfo(String key) {
+    	this.allInfoKeys.remove(key);
+    	this.recordInformation.remove(key);
+    }
+    
+    public Comparator<RecordEntry> getComparator() {
+    	return new Comparator<RecordEntry>() {
+
+			@Override
+			public int compare(RecordEntry o1, RecordEntry o2) {
+				return o1.entryKey.compareTo(o2.entryKey);
+			}
+    		
+		};
+    }
+}

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordHeader.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordHeader.java
@@ -1,0 +1,21 @@
+package util.recordkeeper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RecordHeader {
+    String title;
+    Map<String, String> randomizationOptions = new HashMap<>();
+    protected boolean sorted;
+    
+    public List<String> getKeyList(){
+    	ArrayList<String> keys = new ArrayList<>(randomizationOptions.keySet());
+    	if(sorted) {
+    		Collections.sort(keys);
+    	}
+    	return keys;
+    }
+}

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordInformation.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordInformation.java
@@ -1,0 +1,15 @@
+package util.recordkeeper;
+
+public class RecordInformation {
+    String originalValue;
+    String updatedValue;
+    String additionalInfo;
+
+    public RecordInformation(String originalValue){
+        this.originalValue = originalValue;
+    }
+    public RecordInformation(String originalValue, String updatedValue){
+        this.originalValue = originalValue;
+        this.updatedValue = updatedValue;
+    }
+}

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordKeeper.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordKeeper.java
@@ -137,31 +137,26 @@ public class RecordKeeper {
 	
 	public Boolean exportRecordsToHTML(String outputPath) {
 		RecordBuilder builder = new RecordBuilder(outputPath);
-		builder.buildHeader(header.title);
-		builder.appendBasicTable(header.randomizationOptions.entrySet());
-		builder.appendHorizontalSpacer();
-		builder.appendLiteral("<h2>Notes</h2><br>\n</center>\n");
-		builder.appendLiteral("<div class=\"notes\"><ul>");
-		builder.appendUnorderedList(notes);
-		builder.appendLiteral("</ul></div>\n<center>\n<br><hr><br>\n");
-		builder.appendHorizontalSpacer();
+		builder.buildHeader(header.title)
+			.appendBasicTable(header.randomizationOptions.entrySet()).appendHorizontalSpacer()
+			.appendLiteral("<h2>Notes</h2><br>\n</center>\n")
+			.appendLiteral("<div class=\"notes\"><ul>")
+			.appendUnorderedList(notes)
+			.appendLiteral("</ul></div>\n<center>\n<br><hr><br>\n").appendHorizontalSpacer();
 		for (String category : allCategories) {
-			builder.appendSectionHeader(category, 2);
-			builder.appendTOC(entriesByCategory.get(category).getKeyList(), 4);
-			builder.appendHorizontalSpacer();
+			builder.appendSectionHeader(category, 2)
+				.appendTOC(entriesByCategory.get(category).getKeyList(), 4).appendHorizontalSpacer();
 		}
 		for (String category : allCategories) {
 			RecordCategoryMap categoryMap = entriesByCategory.get(category);
 			for (String entryKey : categoryMap.getKeyList()) {
 				RecordEntry entry = categoryMap.getEntry(entryKey);
-				builder.appendSectionHeader(entryKey, 3);
-				builder.appendEntryComparison(entry);
-				builder.appendLinkToTOC(category);
+				builder.appendSectionHeader(entryKey, 3)
+				.appendEntryComparison(entry)
+				.appendLinkToTOC(category).appendHorizontalSpacer();
 			}
-			builder.appendHorizontalSpacer();
 		}
-		builder.appendLiteral("</body></html>\n");
-		builder.write();
+		builder.appendLiteral("</body></html>\n").write();
 		
 		return true;
 	}

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordKeeper.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordKeeper.java
@@ -11,67 +11,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Record Keeper for FE4 & GBAFE
+ */
 public class RecordKeeper {
 	
-	private class Entry {
-		List<String> allKeys;
-		Map<String, String> originalValues;
-		Map<String, String> updatedValues; 
-		
-		Map<String, String> additionalInfo;
-		
-		private Entry() {
-			allKeys = new ArrayList<String>();
-			originalValues = new HashMap<String, String>();
-			updatedValues = new HashMap<String, String>();
-			additionalInfo = new HashMap<String, String>();
-		}
-	}
-	
-	private class EntryMap {
-		List<String> keyList;
-		Map<String, Entry> entriesByKey;
-		
-		private EntryMap() {
-			keyList = new ArrayList<String>();
-			entriesByKey = new HashMap<String, Entry>();
-		}
-	}
-	
-	private class Header {
-		String title;
-		
-		List<String> keyList;
-		Map<String, String> values;
-		
-		private Header() {
-			keyList = new ArrayList<String>();
-			values = new HashMap<String, String>();
-		}
-	}
-	
-	private Header header;
+	private RecordHeader header;
 	private List<String> allCategories;
-	private Map<String, EntryMap> entriesByCategory;
+	private Map<String, RecordCategoryMap> entriesByCategory;
 	
 	private List<String> notes;
 	
 	public RecordKeeper(String title) {
-		allCategories = new ArrayList<String>();
-		entriesByCategory = new HashMap<String, EntryMap>();
-		header = new Header();
+		allCategories = new ArrayList<>();
+		entriesByCategory = new HashMap<>();
+		header = new RecordHeader();
 		header.title = title;
 		
-		header.keyList = new ArrayList<String>();
-		header.values = new HashMap<String, String>();
 		
 		notes = new ArrayList<String>();
 	}
 	
 	public void addHeaderItem(String title, String value) {
-		if (header.keyList.contains(title)) { header.keyList.remove(title); }
-		header.keyList.add(title);
-		header.values.put(title, value);
+		header.randomizationOptions.put(title, value);
 	}
 	
 	public void addNote(String note) {
@@ -79,173 +41,128 @@ public class RecordKeeper {
 	}
 	
 	public void registerCategory(String category) {
-		if (allCategories.contains(category)) {
+		if (entriesByCategory.containsKey(category)) {
 			return;
 		}
-		
-		EntryMap map = new EntryMap();
-		entriesByCategory.put(category, map);
 		allCategories.add(category);
+		entriesByCategory.put(category, new RecordCategoryMap());
 	}
 	
 	public void setAdditionalInfo(String category, String entryKey, String key, String info) {
-		EntryMap entryMap = entriesByCategory.get(category);
+		RecordCategoryMap entryMap = entriesByCategory.get(category);
 		if (entryMap == null) { return; }
-		Entry entry = entryMap.entriesByKey.get(entryKey);
+		RecordEntry entry = entryMap.getEntry(key);
 		if (entry == null) { return; }
 		
-		entry.additionalInfo.put(key, info);
+		if(entry.getInfo(key) != null) {
+			entry.getInfo(key).additionalInfo = info;
+		}
 	}
 	
 	public void clearAdditionalInfo(String category, String entryKey, String key) {
-		EntryMap entryMap = entriesByCategory.get(category);
+		RecordCategoryMap entryMap = entriesByCategory.get(category);
 		if (entryMap == null) { return; }
-		Entry entry = entryMap.entriesByKey.get(entryKey);
+		RecordEntry entry = entryMap.getEntry(key);
 		if (entry == null) { return; }
-		
-		entry.additionalInfo.remove(key);
+		if(entry.getInfo(key) != null) {
+			entry.getInfo(key).additionalInfo = null;
+		}
 	}
 
-	public void recordOriginalEntry(String category, String entryKey, String key, String originalValue) {
-		 EntryMap entryMap = entriesByCategory.get(category);
+	public RecordEntry recordOriginalEntry(String category, String entryKey, String key, String originalValue) {
+		RecordCategoryMap entryMap = entriesByCategory.get(category);
 		 if (entryMap == null) {
-			 entryMap = new EntryMap();
+			 entryMap = new RecordCategoryMap();
 			 entriesByCategory.put(category, entryMap);
 			 allCategories.add(category);
 		 }
 		 
-		 Entry entry = entryMap.entriesByKey.get(entryKey);
+		 RecordEntry entry = entryMap.getEntry(entryKey);
 		 if (entry == null) {
-			 entry = new Entry();
-			 entryMap.keyList.add(entryKey);
-			 entryMap.entriesByKey.put(entryKey, entry);
+			 entry = new RecordEntry(entryKey);
+			 entryMap.addEntry(entryKey, entry);
 		 }
 		 
-		 if (!entry.allKeys.contains(key)) { 
-			 entry.allKeys.add(key);
-		 }
-		 entry.originalValues.put(key, originalValue);
+		 RecordInformation info = entry.getInfo(key);
+		 if(info == null) {
+			 // If the information is new, create a new object for it
+			 entry.addInfo(key, new RecordInformation(originalValue));
+			 return entry;
+		 } 
+		 
+		 // if it already existed for some reason, just update
+		 entry.getInfo(key).originalValue = originalValue;
+		 return entry;
 	}
 	
-	public void recordUpdatedEntry(String category, String entryKey, String key, String updatedValue) {
-		EntryMap entryMap = entriesByCategory.get(category);
+	public RecordEntry recordUpdatedEntry(String category, String entryKey, String key, String updatedValue) {
+		RecordCategoryMap entryMap = entriesByCategory.get(category);
 		 if (entryMap == null) {
-			 entryMap = new EntryMap();
+			 entryMap = new RecordCategoryMap();
 			 entriesByCategory.put(category, entryMap);
 			 allCategories.add(category);
 		 }
 		 
-		 Entry entry = entryMap.entriesByKey.get(entryKey);
+		 RecordEntry entry = entryMap.getEntry(entryKey);
 		 if (entry == null) {
-			 entry = new Entry();
-			 entryMap.keyList.add(entryKey);
-			 entryMap.entriesByKey.put(entryKey, entry);
+			 entry = new RecordEntry(entryKey);
+			 entryMap.addEntry(entryKey, entry);
 		 }
-		 if (!entry.allKeys.contains(key)) { 
-			 entry.allKeys.add(key);
-		 }
-		 entry.updatedValues.put(key, updatedValue);
+		 RecordInformation info = entry.getInfo(key);
+		 if(info == null) {
+			 // If the information is new, create a new object for it
+			 entry.addInfo(key, new RecordInformation(null, updatedValue));
+			 return entry;
+		 } 
+		 
+		 // if it already existed for some reason, just update
+		 entry.getInfo(key).updatedValue = updatedValue;
+		 return entry;
 	}
 	
 	public void sortKeysInCategory(String category) {
-		EntryMap entryMap = entriesByCategory.get(category);
-		if (entryMap != null) {
-			Collections.sort(entryMap.keyList);
-		}
+		RecordCategoryMap entryMap = entriesByCategory.get(category);
+		entryMap.setSorted();
 	}
 	
 	public void sortKeysInCategoryAndSubcategories(String category) {
 		Set<String> keys = entriesByCategory.keySet();
 		for (String key : keys) {
 			if (key.startsWith(category)) {
-				EntryMap entryMap = entriesByCategory.get(key);
-				if (entryMap != null) {
-					Collections.sort(entryMap.keyList);
-				}
+				RecordCategoryMap entryMap = entriesByCategory.get(key);
+				entryMap.setSorted();
 			}
 		}
 	}
 	
 	public Boolean exportRecordsToHTML(String outputPath) {
-		try {
-			OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(outputPath), Charset.forName("UTF-8").newEncoder());
-			writer.write("<html><meta http-equiv=\"Content-Type\" content = \"text/html; charset=utf-8\" /><head><style>\n");
-			writer.write("table, th, td {\n\tborder: 1px solid black;\n}\n");
-			writer.write(".notes {\n\twidth: 66%;\n\tmargin: auto;\n}\n");
-			writer.write("</style></head><body>\n");
-			writer.write("<center><h1><p>Changelog for " + header.title + "</p></h1><br>\n");
-			writer.write("<hr>\n");
-			writer.write("<table>\n");
-			for (String key : header.keyList) {
-				String value = header.values.get(key);
-				writer.write("<tr><td>" + key + "</td><td>" + value + "</td></tr>\n");
-			}
-			writer.write("</table>\n");
-			writer.write("<br><hr><br>\n");
-			
-			if (!notes.isEmpty()) {
-				writer.write("<h2>Notes</h2><br>\n</center>\n");
-				writer.write("<div class=\"notes\"><ul>");
-				for (String note : notes) {
-					writer.write("<li>" + note + "</li>\n");
-				}
-				writer.write("</ul></div>\n<center>\n<br><hr><br>\n");
-			}
-			
-			for (String category : allCategories) {
-				writer.write("<h2 id=\"" + keyFromString(category) + "\">" + category + "</h2>");
-				int column = 0;
-				writer.write("<table>\n");
-				EntryMap entries = entriesByCategory.get(category);
-				for (String entryKey : entries.keyList) {
-					if (column == 0) { writer.write("<tr>\n"); }
-					writer.write("<td><a href=\"#" + keyFromString(entryKey) + "\">" + entryKey + "</a></td>\n");
-					column += 1;
-					if (column == 4) {
-						column = 0;
-						writer.write("</tr>\n");
-					}
-				}
-				writer.write("</table>\n");
-				writer.write("<br><hr><br>\n");
-			}
-			
-			for (String category : allCategories) {
-				EntryMap entries = entriesByCategory.get(category);
-				for (String entryKey : entries.keyList) {
-					Entry entry = entries.entriesByKey.get(entryKey);
-					writer.write("<h3 id=\"" + keyFromString(entryKey) + "\">" + entryKey + "</h3><br>\n");
-					writer.write("<table>\n");
-					boolean hasAdditionalInfo = !entry.additionalInfo.isEmpty();
-					for (String key : entry.allKeys) {
-						String oldValue = entry.originalValues.get(key);
-						String newValue = entry.updatedValues.get(key);
-						writer.write("<tr><td>" + key + "</td><td>" + (oldValue != null ? oldValue : "(null)") + "</td><td>" + (newValue != null ? newValue : "(null)") + "</td>");
-						if (hasAdditionalInfo) {
-							boolean hasInfoForKey = entry.additionalInfo.containsKey(key);
-							writer.write("<td>" + (hasInfoForKey ? entry.additionalInfo.get(key) : "") + "</td>");
-						}
-						writer.write("</tr>\n");
-					}
-					writer.write("</table>\n");
-					writer.write("<a href=\"#" + keyFromString(category) + "\">Back to " + category + "</a>\n");
-				}
-				writer.write("<br><hr><br>\n");
-			}
-			
-			writer.write("</body></html>\n");
-			writer.close();
-			
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-			return false;
+		RecordBuilder builder = new RecordBuilder(outputPath);
+		builder.buildHeader(header.title);
+		builder.appendBasicTable(header.randomizationOptions.entrySet());
+		builder.appendHorizontalSpacer();
+		builder.appendLiteral("<h2>Notes</h2><br>\n</center>\n");
+		builder.appendLiteral("<div class=\"notes\"><ul>");
+		builder.appendUnorderedList(notes);
+		builder.appendLiteral("</ul></div>\n<center>\n<br><hr><br>\n");
+		builder.appendHorizontalSpacer();
+		for (String category : allCategories) {
+			builder.appendSectionHeader(category, 2);
+			builder.appendTOC(entriesByCategory.get(category).getKeyList(), 4);
+			builder.appendHorizontalSpacer();
 		}
+		for (String category : allCategories) {
+			RecordCategoryMap categoryMap = entriesByCategory.get(category);
+			for (String entryKey : categoryMap.getKeyList()) {
+				RecordEntry entry = categoryMap.getEntry(entryKey);
+				builder.appendSectionHeader(entryKey, 3);
+				builder.appendEntryComparison(entry);
+				builder.appendLinkToTOC(category);
+			}
+			builder.appendHorizontalSpacer();
+		}
+		builder.appendLiteral("</body></html>\n");
+		builder.write();
 		
 		return true;
-	}
-	
-	private String keyFromString(String string) {
-		return string.replace(' ', '_');
 	}
 }

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordKeeper.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordKeeper.java
@@ -139,10 +139,12 @@ public class RecordKeeper {
 		RecordBuilder builder = new RecordBuilder(outputPath);
 		builder.buildHeader(header.title)
 			.appendBasicTable(header.randomizationOptions.entrySet()).appendHorizontalSpacer()
-			.appendLiteral("<h2>Notes</h2><br>\n</center>\n")
-			.appendLiteral("<div class=\"notes\"><ul>")
+			.appendSectionHeader("Notes", 2)
+		    .appendLiteral("</center>\n")
+			.appendLiteral("<div class=\"notes\">")
 			.appendUnorderedList(notes)
-			.appendLiteral("</ul></div>\n<center>\n<br><hr><br>\n").appendHorizontalSpacer();
+			.appendLiteral("</div>\n")
+			.appendLiteral("<center>\n").appendHorizontalSpacer();
 		for (String category : allCategories) {
 			builder.appendSectionHeader(category, 2)
 				.appendTOC(entriesByCategory.get(category).getKeyList(), 4).appendHorizontalSpacer();

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/Base64Asset.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/Base64Asset.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 public class Base64Asset {
 	String name;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogAsset.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogAsset.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogBuilder.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogBuilder.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogDivider.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogDivider.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.List;
 

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogElement.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogElement.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.List;
 

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogHeader.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogHeader.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogImage.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogImage.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogSection.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogSection.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogStyleRule.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogStyleRule.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.HashMap;
 import java.util.List;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogTOC.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogTOC.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogTable.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogTable.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogText.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/fe9/ChangelogText.java
@@ -1,4 +1,4 @@
-package util.recordkeeper;
+package util.recordkeeper.fe9;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Contains a fix for Issue #178 to move bosses in GBA FE to their own section, by creating a subcategory "Characters - Bosses", which is pretty much the same thing FE4 does.

Additionally I moved the FE9 ChangeLog related things into their own package (recordkeeper.fe9) and refactored the GBA + FE4 Record Keeper into more of a Builder style like the FE9 one.

I personally prefer the readability as a builder, but if you disagree then I could remove those and only keep the change to the 
gba/loader/CharacterDataLoader.java

since that's the only thing needed for the defect