### PR TITLE
[Issue #356] Fixed growth randomization not working.

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/GrowthsRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GrowthsRandomizer.java
@@ -12,8 +12,17 @@ public class GrowthsRandomizer {
 	
 	public static void randomizeGrowthsByRedistribution(int variance, int min, int max, boolean adjustHP, CharacterDataLoader charactersData, Random rng) {
 		GBAFECharacterData[] allPlayableCharacters = charactersData.playableCharacters();
+		
+		// Commit anything outstanding first.
+		// In case any other randomization step modified characters, because we
+		// need to start from a clean slate.
+		charactersData.commit();
+		
 		for (GBAFECharacterData character : allPlayableCharacters) {
 			
+			// Do not modify anything that was already modified.
+			// This is here because some characters are linked (for example, FE7 Lyn has two variants: Tutorial and Not Tutorial).
+			// If we generate growths for one, we apply it to all linked characters at the end of this loop.
 			if (character.wasModified()) {
 				continue;
 			}
@@ -118,6 +127,9 @@ public class GrowthsRandomizer {
 	
 	public static void randomizeGrowthsByRandomDelta(int maxDelta, int min, int max, boolean adjustHP, CharacterDataLoader charactersData, Random rng) {
 		GBAFECharacterData[] allPlayableCharacters = charactersData.playableCharacters();
+		
+		charactersData.commit();
+		
 		for (GBAFECharacterData character : allPlayableCharacters) {
 			
 			if (character.wasModified()) {
@@ -191,6 +203,9 @@ public class GrowthsRandomizer {
 	
 	public static void fullyRandomizeGrowthsWithRange(int minGrowth, int maxGrowth, boolean adjustHP, CharacterDataLoader charactersData, Random rng) {
 		GBAFECharacterData[] allPlayableCharacters = charactersData.playableCharacters();
+		
+		charactersData.commit();
+		
 		for (GBAFECharacterData character : allPlayableCharacters) {
 			
 			if (character.wasModified()) {


### PR DESCRIPTION
Fixed an issue (#356) where growths may not be randomized in some randomization setting combinations.

Growth randomization specifically has a special case where it generates growths only once for linked characters so that characters that have multiple versions (for example, FE7's tutorial version of Lyn and her non-tutorial counterpart) all share the same growths. This check is done by skipping over any character that is already modified. The assumption is that, coming into this randomization function, all previous work was already committed on the characters, which may not be the case, depending on the combination of settings given by the user. This simply forces character data to commit anything outstanding before starting, so that everything starts off as "not modified".