### PR TITLE
[Issue #360] Fixed FE8 animation assignment issue

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8SpellAnimationCollection.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8SpellAnimationCollection.java
@@ -276,7 +276,7 @@ public class FE8SpellAnimationCollection implements GBAFESpellAnimationCollectio
 		// Then another 0.
 		entryBytes.appendByte((byte)0);
 		// Then the animation value.
-		entryBytes.appendBytes(WhyDoesJavaNotHaveThese.byteArrayFromLongValue(animation.value, false, 2));
+		entryBytes.appendBytes(WhyDoesJavaNotHaveThese.byteArrayFromLongValue(animation.value, true, 2));
 		// Then two 0s.
 		entryBytes.appendByte((byte)0);
 		entryBytes.appendByte((byte)0);


### PR DESCRIPTION
#360 - Fixed an issue where FE8 spell animations were not being set with little endian, causing us to write some weird (and obviously incorrect) animation values when assigning animations to weapons.