### PR TITLE
Updated code to use a universal Size so we remain cross-platform.

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/FE6PortraitFormat.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/FE6PortraitFormat.java
@@ -7,7 +7,8 @@ import java.util.Optional;
 
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.internal.win32.SIZE;
+
+import util.Size;
 
 /**
  * Class providing the Format of the FE6 Portraits for insertion <br>
@@ -43,23 +44,19 @@ public class FE6PortraitFormat extends PortraitFormat {
 	}
 
 	@Override
-	public SIZE getMainPortraitSize() {
-		SIZE size = new SIZE();
-		size.cx = 32;
-		size.cy = 5;
+	public Size getMainPortraitSize() {
+		Size size = new Size(32, 5);
 		return size;
 	}
 
 	@Override
-	public SIZE getMiniPortraitSize() {
-		SIZE size = new SIZE();
-		size.cx = 4;
-		size.cy = 4;
+	public Size getMiniPortraitSize() {
+		Size size = new Size(4, 4);
 		return size;
 	}
 
 	@Override
-	public SIZE getMouthChunksSize() {
+	public Size getMouthChunksSize() {
 		return null;
 	}
 

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/FE7PortraitFormat.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/FE7PortraitFormat.java
@@ -7,7 +7,8 @@ import java.util.Optional;
 
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.internal.win32.SIZE;
+
+import util.Size;
 
 /**
  * Class providing the Format of the FE6 Portraits for insertion
@@ -49,26 +50,20 @@ public class FE7PortraitFormat extends PortraitFormat {
 	}
 
 	@Override
-	public SIZE getMainPortraitSize() {
-		SIZE size = new SIZE();
-		size.cx = 32;
-		size.cy = 4;
+	public Size getMainPortraitSize() {
+		Size size = new Size(32, 4);
 		return size;
 	}
 
 	@Override
-	public SIZE getMiniPortraitSize() {
-		SIZE size = new SIZE();
-		size.cx = 4;
-		size.cy = 4;
+	public Size getMiniPortraitSize() {
+		Size size = new Size(4, 4);
 		return size;
 	}
 
 	@Override
-	public SIZE getMouthChunksSize() {
-		SIZE size = new SIZE();
-		size.cx = 4;
-		size.cy = 12;
+	public Size getMouthChunksSize() {
+		Size size = new Size(4, 12);
 		return size;
 	}
 

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/FE8PortraitFormat.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/FE8PortraitFormat.java
@@ -7,7 +7,8 @@ import java.util.Optional;
 
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.internal.win32.SIZE;
+
+import util.Size;
 
 /**
  * Class providing the Format of the FE6 Portraits for insertion
@@ -49,26 +50,20 @@ public class FE8PortraitFormat extends PortraitFormat {
 	}
 
 	@Override
-	public SIZE getMainPortraitSize() {
-		SIZE size = new SIZE();
-		size.cx = 32;
-		size.cy = 4;
+	public Size getMainPortraitSize() {
+		Size size = new Size(32, 4);
 		return size;
 	}
 
 	@Override
-	public SIZE getMiniPortraitSize() {
-		SIZE size = new SIZE();
-		size.cx = 4;
-		size.cy = 4;
+	public Size getMiniPortraitSize() {
+		Size size = new Size(4, 4);
 		return size;
 	}
 
 	@Override
-	public SIZE getMouthChunksSize() {
-		SIZE size = new SIZE();
-		size.cx = 4;
-		size.cy = 12;
+	public Size getMouthChunksSize() {
+		Size size = new Size(4, 12);
 		return size;
 	}
 

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/PortraitFormat.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/PortraitFormat.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import fedata.general.FEBase;
-import org.eclipse.swt.internal.win32.SIZE;
+import util.Size;
 
 /**
  * Abstract base class for the GBA FE Portrait Formats
@@ -59,17 +59,17 @@ public abstract class PortraitFormat {
 	/**
 	 * Returns the size of the Main Portrait in Chunks
 	 */
-	public abstract SIZE getMainPortraitSize();
+	public abstract Size getMainPortraitSize();
 
 	/**
 	 * Returns the size of the Mini Portrait in Chunks
 	 */
-	public abstract SIZE getMiniPortraitSize();
+	public abstract Size getMiniPortraitSize();
 
 	/**
 	 * Returns the size of the Mouth Frames in Chunks
 	 */
-	public abstract SIZE getMouthChunksSize();
+	public abstract Size getMouthChunksSize();
 	
 	/**
 	 * Returns an optional of a byte array contianing the bytes that should be prefixed before all main Portraits 

--- a/Universal FE Randomizer/src/util/GBAImageCodec.java
+++ b/Universal FE Randomizer/src/util/GBAImageCodec.java
@@ -14,7 +14,6 @@ import javax.imageio.ImageIO;
 
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.internal.win32.SIZE;
 
 import application.Main;
 import fedata.gba.general.PaletteColor;
@@ -110,7 +109,7 @@ public class GBAImageCodec {
 	 * that passes an empty optional, indicating that there is no prefix
 	 */
 	public static byte[] getGBAPortraitGraphicsDataForImage(String name, PaletteColor[] palette,
-			List<PortraitChunkInfo> chunks, SIZE size) throws IOException {
+			List<PortraitChunkInfo> chunks, Size size) throws IOException {
 		return getGBAPortraitGraphicsDataForImage(name, palette, chunks, size, Optional.empty());
 	}
 
@@ -129,7 +128,7 @@ public class GBAImageCodec {
 	 *                the output, if any
 	 */
 	public static byte[] getGBAPortraitGraphicsDataForImage(String name, PaletteColor[] palette,
-			List<PortraitChunkInfo> chunks, SIZE size, Optional<byte[]> prefix) throws IOException {
+			List<PortraitChunkInfo> chunks, Size size, Optional<byte[]> prefix) throws IOException {
 		if (palette == null || name == null || chunks == null || chunks.isEmpty()) {
 			throw new IllegalArgumentException(
 					String.format("One of the arguments is invalid: palette %s, name %s, chunks %s, add %s, size %s",
@@ -160,7 +159,7 @@ public class GBAImageCodec {
 		 * Create a new Buffered image with the size of the given size. And create the
 		 * Graphics2D object so we can write into the BufferedImage
 		 */
-		BufferedImage destImage = new BufferedImage(size.cx * 8, size.cy * 8, BufferedImage.TYPE_INT_ARGB);
+		BufferedImage destImage = new BufferedImage(size.width * 8, size.height * 8, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D graphics = destImage.createGraphics();
 
 		/*

--- a/Universal FE Randomizer/src/util/Size.java
+++ b/Universal FE Randomizer/src/util/Size.java
@@ -1,0 +1,11 @@
+package util;
+
+public class Size {
+	int width;
+	int height;
+	
+	public Size(int width, int height) {
+		this.width = width;
+		this.height = height;
+	}
+}


### PR DESCRIPTION
Some of the Image Codec code was relying on a Windows-specific size structure. We want to keep Yune cross-platform, so we can't use anything that is locked to Windows. We just create a simple `Size` class that holds an integer width and height, since that seems to be all we need it to hold.