### PR TITLE
Fix Random Recruitment Prfs always being Unbreakable

### DIFF
--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -1305,7 +1305,7 @@ public class GBARandomizer extends Randomizer {
 		}
 		
 		if ((classes != null && classes.createPrfs) || (recruitOptions != null && recruitOptions.createPrfs)) {
-			boolean unbreakablePrfs = ((classes != null && classes.unbreakablePrfs) || (recruitOptions != null && recruitOptions.createPrfs));
+			boolean unbreakablePrfs = ((classes != null && classes.unbreakablePrfs) || (recruitOptions != null && recruitOptions.unbreakablePrfs));
 
 			// Create new PRF weapons.
 			if (gameType == GameType.FE6) {


### PR DESCRIPTION
Small fix because when you selected to create a Prf during Randomized Recruitment the prf is always unbreakable, even if you select for it not to be

