### PR TITLE
Feature Suggestion: Import / Export settings Buttons

### DIFF
--- a/Universal FE Randomizer/src/ui/importexport/AbstractImportExportListener.java
+++ b/Universal FE Randomizer/src/ui/importexport/AbstractImportExportListener.java
@@ -1,0 +1,79 @@
+package ui.importexport;
+
+import fedata.general.FEBase;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+import ui.MainView;
+import ui.general.MessageModal;
+
+/**
+ * Abstract Base class for the import and export Listeners which contains the
+ * common functionality between teh two, such as most validations, and the file selection flow
+ */
+public abstract class AbstractImportExportListener implements Listener {
+    protected Shell mainShell;
+    protected MainView mainView;
+    protected FEBase.GameType type;
+    protected String selectedFile;
+
+    public AbstractImportExportListener(Shell mainShell, MainView mainView, FEBase.GameType type) {
+        this.mainShell = mainShell;
+        this.mainView = mainView;
+        this.type = type;
+    }
+
+    public abstract void handleEvent(Event event);
+
+
+    /**
+     * Shows an error Modal to the user with the given Format String
+     */
+    protected void showError(String errorMessage, Object... args) {
+        new MessageModal(mainShell, "Error", String.format("Import failed with error: %n" + errorMessage, args)).show();
+    }
+
+    /**
+     * Opens the file dialog with the given style, and sets the {@link #selectedFile} with the result of the dialog selection.
+     */
+    protected void performFileSelection(int process) {
+        FileDialog openDialog = new FileDialog(mainShell, process);
+        openDialog.setFilterExtensions(new String[]{"*.json"});
+        openDialog.setFilterNames(new String[]{"*.json"});
+        selectedFile = openDialog.open();
+    }
+
+    /**
+     * Defines what should happen if the selected file already exists
+     */
+    protected abstract boolean validateFileExistence();
+
+    /**
+     * Validates that the user actually selected a File
+     */
+    protected boolean isValidFileSelection() {
+        if (selectedFile == null || selectedFile.length() == 0) {
+            // nothing selected
+            return false;
+        }
+
+        return validateFileExistence();
+    }
+
+    /**
+     * Validates if the File the user had selected a valid Json file for the import / export.
+     * For this Purpose that just means that the file name ends on .json
+     * <p>
+     * If it doesn't then show an error to the user, and they'll have to try again.
+     */
+    protected boolean isJsonFile() {
+        if (!selectedFile.endsWith(".json")) {
+            // Case that the user selected something that is not a json file.
+            showError("The import/export only works with JSON files. %n Make sure that the file you want to import/export ends on .json");
+            return false;
+        }
+        return true;
+    }
+}

--- a/Universal FE Randomizer/src/ui/importexport/ExportSettingsListener.java
+++ b/Universal FE Randomizer/src/ui/importexport/ExportSettingsListener.java
@@ -1,0 +1,64 @@
+package ui.importexport;
+
+import com.google.gson.Gson;
+import fedata.general.FEBase.GameType;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+import ui.MainView;
+import ui.general.MessageModal;
+import util.DebugPrinter;
+import util.OptionRecorder;
+
+import java.io.*;
+
+/**
+ * Button listener for Importing a Bundle Json file.
+ */
+public class ExportSettingsListener extends AbstractImportExportListener {
+
+    public ExportSettingsListener(Shell mainShell, MainView mainView, GameType type) {
+        super(mainShell, mainView, type);
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        // Let user select where to save the file
+        performFileSelection(SWT.SAVE);
+
+        // Validate the selection
+        if (!isValidFileSelection() || !isJsonFile()) {
+            return;
+        }
+
+        // Make sure that the currently selected options are saved.
+        mainView.triggerOptionSave(type);
+
+        // Write the OptionBundle of the current game into a new File
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(selectedFile));) {
+            OptionRecorder.Bundle bundle = OptionRecorder.getBundle(type);
+            Gson gson = new Gson();
+            String jsonString = gson.toJson(bundle);
+            writer.write(jsonString);
+        } catch (IOException e) {
+            showError(e.getMessage());
+        }
+    }
+
+    @Override
+    protected boolean validateFileExistence() {
+        File file = new File(selectedFile);
+        if (file.exists()) {
+            MessageModal confirm = new MessageModal(mainShell, "Confirm", "The Selected file already exists, should it be overriden?");
+            confirm.addButton("Yes", () -> confirm.hide()); // if yes do nothing
+            confirm.addButton("No", () -> {
+                selectedFile = null;
+                confirm.hide();
+            });
+            confirm.show();
+        }
+        return selectedFile != null;
+    }
+}

--- a/Universal FE Randomizer/src/ui/importexport/ImportSettingsListener.java
+++ b/Universal FE Randomizer/src/ui/importexport/ImportSettingsListener.java
@@ -1,0 +1,106 @@
+package ui.importexport;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import fedata.general.FEBase.GameType;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Shell;
+import random.exc.UnsupportedGameException;
+import ui.MainView;
+import util.OptionRecorder;
+import util.OptionRecorder.Bundle;
+import util.OptionRecorder.FE4OptionBundle;
+import util.OptionRecorder.FE9OptionBundle;
+import util.OptionRecorder.GBAOptionBundle;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Button listener for Importing a Bundle Json file.
+ */
+public class ImportSettingsListener extends AbstractImportExportListener {
+
+    public ImportSettingsListener(Shell mainShell, MainView mainView, GameType type) {
+        super(mainShell, mainView, type);
+    }
+
+    public void handleEvent(Event event) {
+        // Let the user select a Json file
+        performFileSelection(SWT.OPEN);
+
+        // Validate the selection
+        if (!isValidFileSelection() || !isJsonFile()) {
+            return;
+        }
+
+        try {
+            // Start reading the file line by line, and try figuring
+            // out what game the File is for, assuming it is a valid Export.
+            BufferedReader reader = new BufferedReader(new FileReader(selectedFile));
+            String line;
+            StringBuilder fileContent = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                fileContent.append(line);
+            }
+
+            // Parse the selected file into a Base Bundle, since that contains the GameType
+            Gson gson = new Gson();
+            Bundle baseBundle;
+            try {
+                if (fileContent.length() == 0) {
+                   throw new JsonSyntaxException("Empty files get successfully parsed to a Bundle, don't allow that");
+                }
+                baseBundle = gson.fromJson(fileContent.toString(), Bundle.class);
+            } catch (JsonSyntaxException e) {
+                showError("The Selected Json file does not contain a valid Bundle.%n Please check the selected file.");
+                return;
+            }
+
+            // Validate the GameType of the Bundle against the currently loaded one.
+            if (!baseBundle.type.equals(type)) {
+                showError("The Selected Settings are not valid for the currently loaded gameType. %n Expected %s was %s", type, baseBundle.type);
+                return;
+            }
+
+            // Depending on the GameType of the Base Bundle, select the Final class to parse the bundle to.
+            Class clazz;
+            switch (baseBundle.type) {
+                case FE6: case FE7: case FE8: clazz = GBAOptionBundle.class; break;
+                case FE4: clazz = FE4OptionBundle.class; break;
+                case FE9: clazz = FE9OptionBundle.class; break;
+                default: throw new UnsupportedGameException();
+            }
+
+            // Parse the Bundle into the game of the correct GameType
+            Object bundle = gson.fromJson(fileContent.toString(), clazz);
+
+            // Update the Bundle in the OptionRecorder
+            switch(type) {
+                case FE4: OptionRecorder.options.fe4 = (FE4OptionBundle) bundle; break;
+                case FE6: OptionRecorder.options.fe6 = (GBAOptionBundle) bundle; break;
+                case FE7: OptionRecorder.options.fe7 = (GBAOptionBundle) bundle; break;
+                case FE8: OptionRecorder.options.fe8 = (GBAOptionBundle) bundle; break;
+                case FE9: OptionRecorder.options.fe9 = (FE9OptionBundle) bundle; break;
+            }
+
+            // Make the mainview reload the selected options
+            mainView.preloadOptions(type);
+        } catch (IOException | UnsupportedGameException e) {
+            showError(e.getMessage());
+        }
+    }
+
+    @Override
+    protected boolean validateFileExistence() {
+        if (!new File(selectedFile).exists()) {
+            showError("File couldn't be found.");
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -5,6 +5,7 @@ import java.util.prefs.Preferences;
 import com.google.gson.Gson;
 
 import fedata.general.FEBase;
+import fedata.general.FEBase.GameType;
 import ui.fe4.FE4ClassOptions;
 import ui.fe4.FE4EnemyBuffOptions;
 import ui.fe4.FE4PromotionOptions;
@@ -37,8 +38,14 @@ public class OptionRecorder {
 		public GBAOptionBundle fe8;
 		public FE9OptionBundle fe9;
 	}
-	
-	public static class GBAOptionBundle {
+
+	public static class Bundle {
+		public String seed;
+		public Integer version;
+		public GameType type;
+	}
+
+	public static class GBAOptionBundle extends Bundle {
 		public GrowthOptions growths;
 		public BaseOptions bases;
 		public ClassOptions classes;
@@ -49,11 +56,9 @@ public class OptionRecorder {
 		public RecruitmentOptions recruitmentOptions;
 		public ItemAssignmentOptions itemAssignmentOptions;
 		public CharacterShufflingOptions characterShufflingOptions;
-		public String seed;
-		public Integer version;
 	}
 	
-	public static class FE4OptionBundle {
+	public static class FE4OptionBundle extends Bundle  {
 		public GrowthOptions growths;
 		public BaseOptions bases;
 		public HolyBloodOptions holyBlood;
@@ -62,11 +67,12 @@ public class OptionRecorder {
 		public FE4PromotionOptions promo;
 		public FE4EnemyBuffOptions enemyBuff;
 		public MiscellaneousOptions misc;
-		public String seed;
-		public Integer version;
+		public FE4OptionBundle() {
+			this.type = GameType.FE4;
+		}
 	}
 	
-	public static class FE9OptionBundle {
+	public static class FE9OptionBundle extends Bundle  {
 		public GrowthOptions growths;
 		public BaseOptions bases;
 		public FE9SkillsOptions skills;
@@ -75,8 +81,9 @@ public class OptionRecorder {
 		public FE9ClassOptions classes;
 		public WeaponOptions weapons;
 		public MiscellaneousOptions misc;
-		public String seed;
-		public Integer version;
+		public FE9OptionBundle() {
+			this.type = GameType.FE9;
+		}
 	}
 	
 	public static AllOptions options = loadOptions();
@@ -205,7 +212,7 @@ public class OptionRecorder {
 		return null;
 	}
 	
-	private static void saveOptions(AllOptions options) {
+	public static void saveOptions(AllOptions options) {
 		Gson gson = new Gson();
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		
@@ -270,8 +277,8 @@ public class OptionRecorder {
 		saveOptions(options);
 	}
 	
-	public static void recordGBAFEOptions(FEBase.GameType gameType, GrowthOptions growths, BaseOptions bases, ClassOptions classes, WeaponOptions weapons,
-			OtherCharacterOptions other, EnemyOptions enemies, MiscellaneousOptions otherOptions, RecruitmentOptions recruitment, ItemAssignmentOptions itemAssignment, CharacterShufflingOptions shufflingOptions, String seed) {
+	public static void recordGBAFEOptions(GameType gameType, GrowthOptions growths, BaseOptions bases, ClassOptions classes, WeaponOptions weapons,
+										  OtherCharacterOptions other, EnemyOptions enemies, MiscellaneousOptions otherOptions, RecruitmentOptions recruitment, ItemAssignmentOptions itemAssignment, CharacterShufflingOptions shufflingOptions, String seed) {
 		GBAOptionBundle bundle = new GBAOptionBundle();
 		bundle.growths = growths;
 		bundle.bases = bases;
@@ -285,7 +292,7 @@ public class OptionRecorder {
 		bundle.seed = seed;
 		bundle.version = GBAOptionBundleVersion;
 		bundle.characterShufflingOptions = shufflingOptions;
-		
+		bundle.type = gameType;
 		switch (gameType) {
 		case FE6:
 			options.fe6 = bundle;
@@ -301,6 +308,28 @@ public class OptionRecorder {
 		}
 		
 		saveOptions(options);
+	}
+
+	public static GBAOptionBundle getGBABundle(GameType type) {
+		switch (type) {
+			case FE6: return options.fe6;
+			case FE7: return options.fe7;
+			case FE8: return options.fe8;
+			default:
+				throw new UnsupportedOperationException(type.name() +" is not a valid GBA GameType");
+		}
+	}
+
+	public static Bundle getBundle(GameType type) {
+		switch (type) {
+			case FE4: return options.fe4;
+			case FE6: return options.fe6;
+			case FE7: return options.fe7;
+			case FE8: return options.fe8;
+			case FE9: return options.fe9;
+			default:
+				throw new UnsupportedOperationException(type.name() + " is not a valid GBA GameType");
+		}
 	}
 
 }

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -310,16 +310,6 @@ public class OptionRecorder {
 		saveOptions(options);
 	}
 
-	public static GBAOptionBundle getGBABundle(GameType type) {
-		switch (type) {
-			case FE6: return options.fe6;
-			case FE7: return options.fe7;
-			case FE8: return options.fe8;
-			default:
-				throw new UnsupportedOperationException(type.name() +" is not a valid GBA GameType");
-		}
-	}
-
 	public static Bundle getBundle(GameType type) {
 		switch (type) {
 			case FE4: return options.fe4;


### PR DESCRIPTION
Currently Yune only has the ability to save the last used Option Selections per game, which can be annoying if you swap between multiple settings everynow and then.

Additionally this can also be useful for development, f.e. like having a preset for different things one want to test.

This adds two buttons in the GUI, which allow the user to export their current settings to a Json File, or to import a previously imported Json File.
![grafik](https://github.com/lushen124/Universal-FE-Randomizer/assets/41942612/b8566a6d-12ed-4a36-b25a-c824c8890b4d)

Also adds a Bundle class which all the Bundles (GBAOptionBundle, FE4OptionBundle, FE9OptionBundle) extend. This base Bundle contains a GameType, which is used for validating if the Bundle is of the same type as the currently loaded game.