### PR TITLE
[GBAFE] Terrain Bonus Randomizer

### DIFF
--- a/Universal FE Randomizer/src/fedata/TerrainTable.java
+++ b/Universal FE Randomizer/src/fedata/TerrainTable.java
@@ -1,0 +1,126 @@
+package fedata;
+
+import fedata.gba.AbstractGBAData;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Represents a Terrain Table, each Terrain table applies to a subset of classes in the game (or all),
+ * and describes the properties of it relating to all tiles.
+ * <p>
+ * Each Terrain Table relates to a TerrainTableType and there can be multiple tables for one TerrainTableType.
+ */
+public class TerrainTable extends AbstractGBAData {
+    public enum TerrainTableType {
+
+        /**
+         * Table containing the default Movement costs for the classes using this given table.
+         * Valid values are technically 1-254, 255 means it is untraversable.
+         */
+        MOVEMENT(1, 255, 255, true),
+        /**
+         * Table containing the default Movement costs for the classes using this given table.
+         *          * Valid values are technically 1-254, 255 means it is untraversable.
+         */
+        MOVEMENT_RAIN(1, 255, 255, true),
+        /**
+         * Table containing the default Movement costs for the classes using this given table.
+         * Valid values are technically 1-254, 255 means it is untraversable.
+         */
+        MOVEMENT_SNOW(1, 255, 255, true),
+
+        /**
+         * The number of additional defense points the unit gets from standing on this tile
+         */
+        AVOID(0, 255, 0, false),
+        /**
+         * The number of additional defense points the unit gets from standing on this tile
+         */
+        DEF(0, 255, 0, false),
+        /**
+         * The number of additional resistence points the unit gets from standing on this tile
+         */
+        RES(0, 255, 0, false),
+        /**
+         * The number of hitpoints that are restored by standing on this tile in Percent
+         */
+        HEALING(0, 100, 0, true),
+        /**
+         * Decides if negative status effects on the unit are cleared when standing on this tile. 0 = No, 1 = Yes
+         */
+        STATUS_RECOVERY(0, 1, 0, true),
+        /**
+         * INFO_DISPLAY decides if the attributes of a tile should be displayed in the GUI or not,
+         * but apparently is also used for Berserk AI? Doesn't seem like something that makes sense to.
+         */
+        /*INFO_DISPLAY*/;
+
+
+        public int min;
+        public int max;
+        public int disabledValue;
+        public boolean applicableToFliers;
+        public boolean isToggle;
+
+        TerrainTableType(int min, int max, int disabledValue, boolean applicableToFliers) {
+            this.min = min;
+            this.max = max;
+            this.disabledValue = disabledValue;
+            this.applicableToFliers = applicableToFliers;
+            this.isToggle = max - min == 1;
+        }
+
+        public static final List<TerrainTableType> CLASS_BOUND = Collections.unmodifiableList(Arrays.asList(MOVEMENT, MOVEMENT_RAIN, MOVEMENT_SNOW, AVOID, DEF, RES));
+        public static final List<TerrainTableType> UNIVERSAL = Collections.unmodifiableList(Arrays.asList(HEALING, STATUS_RECOVERY));
+        public static final List<TerrainTableType> MOVEMENT_TABLES = Collections.unmodifiableList(Arrays.asList(MOVEMENT, MOVEMENT_RAIN, MOVEMENT_SNOW));
+
+        public boolean isDisabled(int value) {
+            return this.disabledValue == value;
+        }
+        public boolean isMin(int value) {
+            return this.min == value;
+        }
+
+        public boolean isSafe(int value) {
+            return this.isDisabled(value) && !isMovementTable() || (this.isMin(value) && isMovementTable());
+        }
+
+        public boolean mayNotChange(int value) {
+            return this.isMovementTable() && isDisabled(value);
+        }
+
+        public boolean isMovementTable() {
+            switch (this) {
+                case MOVEMENT:
+                case MOVEMENT_RAIN:
+                case MOVEMENT_SNOW:
+                    return true;
+                default:
+                    return false;
+
+            }
+        }
+
+        public boolean isUniversal() {
+            return UNIVERSAL.contains(this);
+        }
+    }
+
+    public final TerrainTableType tableType;
+
+    public TerrainTable(long offset, byte[] data, TerrainTableType type) {
+        super(data, offset);
+        this.tableType = type;
+    }
+
+    public void setAtIndex(int index, int newValue) {
+        if (index == 0) {
+            // The first value in all terrain tables may not be changed
+            return;
+        }
+        data[index] = asByte(newValue);
+    }
+}

--- a/Universal FE Randomizer/src/fedata/gba/AbstractGBAData.java
+++ b/Universal FE Randomizer/src/fedata/gba/AbstractGBAData.java
@@ -1,6 +1,7 @@
 package fedata.gba;
 
 import fedata.general.FEModifiableData;
+import util.FileReadHelper;
 
 import java.util.Arrays;
 
@@ -69,7 +70,7 @@ public abstract class AbstractGBAData implements FEModifiableData {
 	}
 
 	protected long readPointerFromData(int startingIndex) {
-		return data[startingIndex] << 24 | data[startingIndex+1] << 16 | data[startingIndex+2] << 8 | data[startingIndex+3];
+		return FileReadHelper.wordValue(new byte[] {data[startingIndex], data[startingIndex+1],data[startingIndex+2],data[startingIndex+3]}, true);
 	}
 
 	public static int asInt(byte b) {

--- a/Universal FE Randomizer/src/fedata/gba/AbstractGBAData.java
+++ b/Universal FE Randomizer/src/fedata/gba/AbstractGBAData.java
@@ -2,6 +2,8 @@ package fedata.gba;
 
 import fedata.general.FEModifiableData;
 
+import java.util.Arrays;
+
 public abstract class AbstractGBAData implements FEModifiableData {
 	protected byte[] originalData;
 	protected byte[] data;
@@ -16,7 +18,7 @@ public abstract class AbstractGBAData implements FEModifiableData {
 	}
 
 	public AbstractGBAData(byte[] data, long originalOffset) {
-		this.originalData = data;
+		this.originalData = Arrays.copyOf(data, data.length);
 		this.data = data;
 		this.originalOffset = originalOffset;
 	}
@@ -39,6 +41,10 @@ public abstract class AbstractGBAData implements FEModifiableData {
 
 	public byte[] getData() {
 		return data;
+	}
+
+	public int dataAtIndex(int index) {
+		return asInt(data[index]);
 	}
 
 	public void markModified() {
@@ -66,10 +72,14 @@ public abstract class AbstractGBAData implements FEModifiableData {
 		return data[startingIndex] << 24 | data[startingIndex+1] << 16 | data[startingIndex+2] << 8 | data[startingIndex+3];
 	}
 
-	protected int asInt(byte b) {
+	public static int asInt(byte b) {
 		return b & 0xFF;
 	}
-	protected byte asByte(int i) {
+	public static byte asByte(int i) {
 		return (byte) (i & 0xFF);
+	}
+
+	public byte[] copyOriginalData() {
+		return Arrays.copyOf(originalData, originalData.length);
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/AbstractGBAData.java
+++ b/Universal FE Randomizer/src/fedata/gba/AbstractGBAData.java
@@ -12,6 +12,15 @@ public abstract class AbstractGBAData implements FEModifiableData {
 	protected Boolean wasModified = false;
 	protected Boolean hasChanges = false;
 
+	public AbstractGBAData() {
+	}
+
+	public AbstractGBAData(byte[] data, long originalOffset) {
+		this.originalData = data;
+		this.data = data;
+		this.originalOffset = originalOffset;
+	}
+
 	public void resetData() {
 		data = originalData;
 		wasModified = false;
@@ -51,5 +60,16 @@ public abstract class AbstractGBAData implements FEModifiableData {
 	public void overrideAddress(long newAddress) {
 		addressOverride = newAddress;
 		wasModified = true;
+	}
+
+	protected long readPointerFromData(int startingIndex) {
+		return data[startingIndex] << 24 | data[startingIndex+1] << 16 | data[startingIndex+2] << 8 | data[startingIndex+3];
+	}
+
+	protected int asInt(byte b) {
+		return b & 0xFF;
+	}
+	protected byte asByte(int i) {
+		return (byte) (i & 0xFF);
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEChapterUnitData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEChapterUnitData.java
@@ -4,6 +4,13 @@ import java.util.ArrayList;
 
 public abstract class GBAFEChapterUnitData extends AbstractGBAData {
 
+	public GBAFEChapterUnitData() {
+	}
+
+	public GBAFEChapterUnitData(byte[] data, long originalOffset) {
+		super(data, originalOffset);
+	}
+
 	public int getCharacterNumber() {
 		return data[0] & 0xFF;
 	}

--- a/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFECharacterData.java
@@ -11,7 +11,15 @@ import fedata.general.FEPrintableData;
 import util.WhyDoesJavaNotHaveThese;
 
 public abstract class GBAFECharacterData extends AbstractGBAData implements FELockableData, FEPrintableData {
-	
+
+	public GBAFECharacterData() {
+	}
+
+	public GBAFECharacterData(byte[] data, long originalOffset, boolean isClassRestricted) {
+		super(data, originalOffset);
+		this.isClassRestricted = isClassRestricted;
+	}
+
 	protected Boolean isClassRestricted = false;
 	protected Boolean isReadOnly = false;
 	protected String debugString = "Uninitialized";

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
@@ -1,10 +1,8 @@
 package fedata.gba;
 
-import java.util.Arrays;
 import java.util.Comparator;
 
-import fedata.TerrainTable;
-import fedata.TerrainTable.TerrainTableType;
+import fedata.gba.general.TerrainTable.TerrainTableType;
 import fedata.gba.fe7.FE7Data;
 import fedata.gba.general.WeaponRank;
 import fedata.gba.general.WeaponType;

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
@@ -3,6 +3,8 @@ package fedata.gba;
 import java.util.Arrays;
 import java.util.Comparator;
 
+import fedata.TerrainTable;
+import fedata.TerrainTable.TerrainTableType;
 import fedata.gba.fe7.FE7Data;
 import fedata.gba.general.WeaponRank;
 import fedata.gba.general.WeaponType;
@@ -20,6 +22,13 @@ public abstract class GBAFEClassData extends AbstractGBAData implements FEPrinta
 			return Integer.compare(arg0.getID(), arg1.getID());
 		}
 	};
+
+	public GBAFEClassData() {
+	}
+
+	public GBAFEClassData(byte[] data, long originalOffset) {
+		super(data, originalOffset);
+	}
 	
 	// Info
 	
@@ -454,5 +463,40 @@ public abstract class GBAFEClassData extends AbstractGBAData implements FEPrinta
 		data[42] &= 0xFE;
 		data[43] &= 0x0F;
 		wasModified = true;
+	}
+
+	public long getMoveCostPointer() {
+		return readPointerFromData(0x38);
+	}
+	public long getRainMoveCostPointer() {
+		return readPointerFromData(0x3C);
+	}
+
+	public long getSnowMoveCostPointer() {
+		return readPointerFromData(0x40);
+	}
+
+	public long getTerrainAvoidPointer() {
+		return readPointerFromData(0x44);
+	}
+
+	public long getTerrainDefPointer() {
+		return readPointerFromData(0x48);
+	}
+
+	public long getTerrainResPointer() {
+		return readPointerFromData(0x4C);
+	}
+
+	public long getTerrainPointerByType(TerrainTableType type) {
+		switch (type) {
+			case MOVEMENT: return getMoveCostPointer();
+			case MOVEMENT_RAIN: return getRainMoveCostPointer();
+			case MOVEMENT_SNOW: return getSnowMoveCostPointer();
+			case AVOID: return getTerrainAvoidPointer();
+			case DEF: return getTerrainDefPointer();
+			case RES: return getTerrainResPointer();
+		}
+		return 0;
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6ChapterUnit.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6ChapterUnit.java
@@ -4,10 +4,7 @@ import fedata.gba.GBAFEChapterUnitData;
 
 public class FE6ChapterUnit extends GBAFEChapterUnitData {
 	public FE6ChapterUnit(byte[] data, long originalOffset) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 	}
 
 	@Override

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Character.java
@@ -7,11 +7,7 @@ import fedata.gba.GBAFECharacterData;
 public class FE6Character extends GBAFECharacterData {
 	
 	public FE6Character(byte[] data, long originalOffset, Boolean isClassRestricted) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
-		this.isClassRestricted = isClassRestricted;
+		super(data, originalOffset, isClassRestricted);
 	}
 	
 	public GBAFECharacterData createCopy(boolean useOriginalData) {

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Class.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Class.java
@@ -30,10 +30,7 @@ public class FE6Class extends GBAFEClassData {
 	}
 
 	public FE6Class(byte[] data, long originalOffset, GBAFEClassData demotedClass) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 
 		if (demotedClass != null) {
 			promoHP = getBaseHP() - demotedClass.getBaseHP();

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7ChapterUnit.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7ChapterUnit.java
@@ -5,10 +5,7 @@ import fedata.gba.GBAFEChapterUnitData;
 public class FE7ChapterUnit extends GBAFEChapterUnitData {
 
 	public FE7ChapterUnit(byte[] data, long originalOffset) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 	}
 
 	@Override

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Character.java
@@ -8,11 +8,7 @@ import fedata.gba.GBAFECharacterData;
 
 public class FE7Character extends GBAFECharacterData {
 	public FE7Character(byte[] data, long originalOffset, Boolean isClassRestricted) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
-		this.isClassRestricted = isClassRestricted;
+		super(data, originalOffset, isClassRestricted);
 	}
 	
 	public GBAFECharacterData createCopy(boolean useOriginalData) {

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Class.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Class.java
@@ -14,10 +14,7 @@ public class FE7Class extends GBAFEClassData {
 	}
 
 	public FE7Class(byte[] data, long originalOffset) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 	}
 	
 

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8ChapterUnit.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8ChapterUnit.java
@@ -10,10 +10,7 @@ public class FE8ChapterUnit extends GBAFEChapterUnitData {
 	List<FE8ChapterUnitMoveData> movements = new ArrayList<>();
 	
 	public FE8ChapterUnit(byte[] data, long originalOffset) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 	}
 	
 	@Override

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8ChapterUnitMoveData.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8ChapterUnitMoveData.java
@@ -17,9 +17,7 @@ public class FE8ChapterUnitMoveData extends AbstractGBAData {
 	
 	
 	public FE8ChapterUnitMoveData(long originalOffset, byte[] data) {
-		this.data = data;
-		this.originalData = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 	}
 	
 	public int getPostMoveX() {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Character.java
@@ -6,11 +6,7 @@ import fedata.gba.GBAFECharacterData;
 
 public class FE8Character extends GBAFECharacterData {
 	public FE8Character(byte[] data, long originalOffset, Boolean isClassRestricted) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
-		this.isClassRestricted = isClassRestricted;
+		super(data, originalOffset, isClassRestricted);
 	}
 
 	public GBAFECharacterData createCopy(boolean useOriginalData) {

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Class.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Class.java
@@ -16,10 +16,7 @@ public class FE8Class extends GBAFEClassData {
 	}
 	
 	public FE8Class(byte[] data, long originalOffset) {
-		super();
-		this.originalData = data;
-		this.data = data;
-		this.originalOffset = originalOffset;
+		super(data, originalOffset);
 	}
 
 

--- a/Universal FE Randomizer/src/fedata/gba/general/TerrainTable.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/TerrainTable.java
@@ -20,38 +20,38 @@ public class TerrainTable extends AbstractGBAData {
          * Table containing the default Movement costs for the classes using this given table.
          * Valid values are technically 1-254, 255 means it is untraversable.
          */
-        MOVEMENT(1, 255, 255, true),
+        MOVEMENT(1, 255, 255, true, "Movement"),
         /**
          * Table containing the default Movement costs for the classes using this given table.
-         *          * Valid values are technically 1-254, 255 means it is untraversable.
+         * * Valid values are technically 1-254, 255 means it is untraversable.
          */
-        MOVEMENT_RAIN(1, 255, 255, true),
+        MOVEMENT_RAIN(1, 255, 255, true, "Rain Movement"),
         /**
          * Table containing the default Movement costs for the classes using this given table.
          * Valid values are technically 1-254, 255 means it is untraversable.
          */
-        MOVEMENT_SNOW(1, 255, 255, true),
+        MOVEMENT_SNOW(1, 255, 255, true, "Snow Movement"),
 
         /**
          * The number of additional avoid points the unit gets from standing on this tile
          */
-        AVOID(0, 255, 0, false),
+        AVOID(0, 255, 0, false, "Avoid"),
         /**
          * The number of additional defense points the unit gets from standing on this tile
          */
-        DEF(0, 255, 0, false),
+        DEF(0, 255, 0, false, "Defense"),
         /**
          * The number of additional resistence points the unit gets from standing on this tile
          */
-        RES(0, 255, 0, false),
+        RES(0, 255, 0, false, "Resistence"),
         /**
          * The number of hitpoints that are restored by standing on this tile in Percent
          */
-        HEALING(0, 100, 0, true),
+        HEALING(0, 100, 0, true, "Healing"),
         /**
          * Decides if negative status effects on the unit are cleared when standing on this tile. 0 = No, 1 = Yes
          */
-        STATUS_RECOVERY(0, 1, 0, true),
+        STATUS_RECOVERY(0, 1, 0, true, "Status Recovery"),
         /**
          * INFO_DISPLAY decides if the attributes of a tile should be displayed in the GUI or not,
          * but apparently is also used for Berserk AI? Doesn't seem like something that makes sense to change.
@@ -64,46 +64,69 @@ public class TerrainTable extends AbstractGBAData {
         public int disabledValue;
         public boolean applicableToFliers;
         public boolean isToggle;
+        public String displayString;
 
-        TerrainTableType(int min, int max, int disabledValue, boolean applicableToFliers) {
+        TerrainTableType(int min, int max, int disabledValue, boolean applicableToFliers, String displayString) {
             this.min = min;
             this.max = max;
             this.disabledValue = disabledValue;
             this.applicableToFliers = applicableToFliers;
             this.isToggle = max - min == 1;
+            this.displayString = displayString;
         }
 
+        /** List containing all table types that are defined for each class */
         public static final List<TerrainTableType> CLASS_BOUND = Collections.unmodifiableList(Arrays.asList(MOVEMENT, MOVEMENT_RAIN, MOVEMENT_SNOW, AVOID, DEF, RES));
+
+        /** List containing all table types that are not defined for each class */
         public static final List<TerrainTableType> UNIVERSAL = Collections.unmodifiableList(Arrays.asList(HEALING, STATUS_RECOVERY));
+
+        /** List containing all movement tables */
         public static final List<TerrainTableType> MOVEMENT_TABLES = Collections.unmodifiableList(Arrays.asList(MOVEMENT, MOVEMENT_RAIN, MOVEMENT_SNOW));
 
+        /**
+         * returns true if the given value means it is disabled for the current table type. i.e. healing of 0 means there is no healing.
+         */
         public boolean isDisabled(int value) {
             return this.disabledValue == value;
         }
+
+        /**
+         * Returns true if the given value is the minimum for this table type.
+         * Currently the only difference to {@link #isDisabled(int)} is for movement tables, where the disabled value is 255.
+         */
         public boolean isMin(int value) {
             return this.min == value;
         }
 
+        /**
+         * Returns true if the given value is a "Safe" value for this table type.
+         *
+         * This method is intended to identify thing such as plains.
+         * A plain has no avoid / defense / default movement value etc.
+         */
         public boolean isSafe(int value) {
             return this.isDisabled(value) && !isMovementTable() || (this.isMin(value) && isMovementTable());
         }
 
+        /**
+         * Returns true if the the given value shouldn't change for this TableType.
+         * The only example currently are walls in Movement tables.
+         */
         public boolean mayNotChange(int value) {
             return this.isMovementTable() && isDisabled(value);
         }
 
+        /**
+         * Returns true if this TerrainTableType is a movement table
+         */
         public boolean isMovementTable() {
-            switch (this) {
-                case MOVEMENT:
-                case MOVEMENT_RAIN:
-                case MOVEMENT_SNOW:
-                    return true;
-                default:
-                    return false;
-
-            }
+            return MOVEMENT_TABLES.contains(this);
         }
 
+        /**
+         * Returns true if this TerrainTableType is a universally defined table
+         */
         public boolean isUniversal() {
             return UNIVERSAL.contains(this);
         }
@@ -122,5 +145,6 @@ public class TerrainTable extends AbstractGBAData {
             return;
         }
         data[index] = asByte(newValue);
+        wasModified = true;
     }
 }

--- a/Universal FE Randomizer/src/fedata/gba/general/TerrainTable.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/TerrainTable.java
@@ -1,4 +1,4 @@
-package fedata;
+package fedata.gba.general;
 
 import fedata.gba.AbstractGBAData;
 
@@ -33,7 +33,7 @@ public class TerrainTable extends AbstractGBAData {
         MOVEMENT_SNOW(1, 255, 255, true),
 
         /**
-         * The number of additional defense points the unit gets from standing on this tile
+         * The number of additional avoid points the unit gets from standing on this tile
          */
         AVOID(0, 255, 0, false),
         /**
@@ -54,7 +54,7 @@ public class TerrainTable extends AbstractGBAData {
         STATUS_RECOVERY(0, 1, 0, true),
         /**
          * INFO_DISPLAY decides if the attributes of a tile should be displayed in the GUI or not,
-         * but apparently is also used for Berserk AI? Doesn't seem like something that makes sense to.
+         * but apparently is also used for Berserk AI? Doesn't seem like something that makes sense to change.
          */
         /*INFO_DISPLAY*/;
 

--- a/Universal FE Randomizer/src/random/gba/loader/ClassDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ClassDataLoader.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import fedata.gba.GBAFEClassData;
-import fedata.gba.fe8.FE8Data;
 import fedata.gba.general.GBAFEClass;
 import fedata.gba.general.GBAFEClassProvider;
 import fedata.gba.general.WeaponType;
@@ -74,6 +73,10 @@ public class ClassDataLoader {
 		provider.prepareForClassRandomization(classMap);
 		
 		lastClassID = provider.numberOfClasses();
+	}
+
+	public Map<Integer, GBAFEClassData> getClassMap() {
+		return classMap;
 	}
 	
 	public GBAFEClassData createLordClassBasedOnClass(GBAFEClassData referenceClass) {

--- a/Universal FE Randomizer/src/random/gba/loader/TerrainDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/TerrainDataLoader.java
@@ -1,0 +1,113 @@
+package random.gba.loader;
+
+import fedata.TerrainTable;
+import fedata.TerrainTable.TerrainTableType;
+import fedata.gba.AbstractGBAData;
+import fedata.gba.GBAFEClassData;
+import fedata.general.FEBase.GameType;
+import io.FileHandler;
+import util.FileReadHelper;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ *
+ */
+public class TerrainDataLoader {
+
+    GameType gameType;
+
+    private Map<TerrainTableType, List<TerrainTable>> terrainDataMap = new HashMap<>();
+    private Map<Long, Boolean> pointerUsedByFliers = new HashMap<>();
+    public int dataLengthBytes;
+
+    /**
+     * Construtor for unit tests
+     */
+    public TerrainDataLoader(GameType gameType, Map<TerrainTableType, List<TerrainTable>> dataMap, Map<Long, Boolean> pointerUsedByFliers, int dataLengthBytes) {
+        this.gameType = gameType;
+        this.terrainDataMap = dataMap;
+        this.pointerUsedByFliers = pointerUsedByFliers;
+        this.dataLengthBytes = dataLengthBytes;
+    }
+
+    public TerrainDataLoader(GameType type, ClassDataLoader classData, FileHandler handler) {
+        this.gameType = type;
+        Collection<GBAFEClassData> allClasses = classData.getClassMap().values();
+        dataLengthBytes = terrainDataLengthInBytes();
+        for (TerrainTableType tableType : TerrainTableType.CLASS_BOUND) {
+            List<TerrainTable> terrainDataOfType = allClasses.stream()
+                    .map(e -> e.getTerrainPointerByType(tableType)) // Map each class to it's pointer for the current type
+                    .distinct()// Filter out duplicates
+                    .peek(pointer -> pointerUsedByFliers.put(pointer, isPointerUsedByFliers(classData, allClasses, tableType, pointer)))
+                    .filter(pointer -> { // Filter out fliers if the Table Type isn't applicable to them (DEF, RES, AVOID)
+                        // If it's applicable to fliers, we can keep all entries regardless
+                        if (tableType.applicableToFliers) {
+                            return true;
+                        }
+                        // If it's not applicable to fliers, check if the current pointer is used by any flier, if so then remove them
+                        return Boolean.FALSE.equals(pointerUsedByFliers.get(pointer));
+                    })
+                    .map(pointer -> FileReadHelper.readAddress(handler, pointer))
+                    .map(offset -> new TerrainTable(offset, handler.readBytesAtOffset(offset, dataLengthBytes), tableType))// Create a TerrainData object for the current Pointer
+                    .collect(Collectors.toList()); // Collect them to a list
+            terrainDataMap.put(tableType, terrainDataOfType);
+        }
+        for (TerrainTableType tableType : TerrainTableType.UNIVERSAL) {
+            long offset = staticPointerByTypeAndGame(tableType);
+            TerrainTable terrainDataOfType = new TerrainTable(offset, handler.readBytesAtOffset(offset, dataLengthBytes), tableType);
+            terrainDataMap.put(tableType, Arrays.asList(terrainDataOfType));
+        }
+    }
+
+    /**
+     * Returns true if any of the classes is a flying class and matches the given pointer
+     */
+    private static boolean isPointerUsedByFliers(ClassDataLoader classData, Collection<GBAFEClassData> allClasses, TerrainTableType tableType, Long pointer) {
+        return allClasses.stream()
+                .filter(c -> classData.isFlying(c.getID()))
+                .anyMatch(c -> c.getTerrainPointerByType(tableType) == pointer);
+    }
+
+    /**
+     * Returns all the terrain tables for the given TerrainTableType.
+     * For example: Returns all the Movement Tables (Foot, Horse, Knight etc.) if the given TerrainTableType is MOVEMENT
+     */
+    public List<TerrainTable> getTerrainTablesOfType(TerrainTableType type) {
+        return terrainDataMap.get(type);
+    }
+
+    /**
+     * Returns true if during the generation of the TerrainTables we recognized that the given pointer is used by fliers.
+     * This can be used to filter out tables that apply to fliers from randomization.
+     * An example use case is that in vanilla DEF / RES / Avoid don't apply to fliers.
+     */
+    public boolean isUsedByFliers(long pointer) {
+        return pointerUsedByFliers.get(pointer);
+    }
+
+    public List<TerrainTable> getMovementCostsForNonFliers() {
+        return terrainDataMap.get(TerrainTableType.MOVEMENT).stream().filter(data -> !pointerUsedByFliers.get(data.getAddressOffset())).collect(Collectors.toList());
+    }
+
+    private int terrainDataLengthInBytes() {
+        if (GameType.FE8.equals(gameType) || GameType.FE7.equals(gameType)) {
+            return 0x41;
+        } else {
+            // FE6
+            return 0x33;
+        }
+    }
+
+    private long staticPointerByTypeAndGame(TerrainTableType tableType) {
+        if (GameType.FE8.equals(gameType)) {
+            return TerrainTableType.HEALING.equals(tableType) ? 0x80C744 : 0x80C785;
+        } else if (GameType.FE7.equals(gameType)) {
+            return TerrainTableType.HEALING.equals(tableType) ? 0xBE47C4 : 0xBE4805;
+        } else {
+            // FE6
+            return TerrainTableType.HEALING.equals(tableType) ? 0x60CBA9 : 0x60CBDC;
+        }
+    }
+}

--- a/Universal FE Randomizer/src/random/gba/loader/TerrainDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/TerrainDataLoader.java
@@ -1,8 +1,7 @@
 package random.gba.loader;
 
-import fedata.TerrainTable;
-import fedata.TerrainTable.TerrainTableType;
-import fedata.gba.AbstractGBAData;
+import fedata.gba.general.TerrainTable;
+import fedata.gba.general.TerrainTable.TerrainTableType;
 import fedata.gba.GBAFEClassData;
 import fedata.general.FEBase.GameType;
 import io.FileHandler;
@@ -81,9 +80,12 @@ public class TerrainDataLoader {
     /**
      * Returns true if during the generation of the TerrainTables we recognized that the given pointer is used by fliers.
      * This can be used to filter out tables that apply to fliers from randomization.
-     * An example use case is that in vanilla DEF / RES / Avoid don't apply to fliers.
+     * An example use case is that in vanilla DEF / RES / Avoid don't apply to fliers, but they still have tables for them.
      */
-    public boolean isUsedByFliers(long pointer) {
+    public boolean isUsedByFliers(Long pointer) {
+        if (!pointerUsedByFliers.containsKey(pointer)) {
+            throw new IllegalArgumentException(String.format("All the tables must have been mapped to if they are being used by fliers or not! But Pointer %d wasn't", pointer));
+        }
         return pointerUsedByFliers.get(pointer);
     }
 

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -104,7 +104,7 @@ public class GBARandomizer extends Randomizer {
 	public GBARandomizer(String sourcePath, String targetPath, FEBase.GameType gameType, DiffCompiler diffs, 
 			GrowthOptions growths, BaseOptions bases, ClassOptions classes, WeaponOptions weapons,
 			OtherCharacterOptions other, EnemyOptions enemies, MiscellaneousOptions otherOptions,
-			RecruitmentOptions recruit, ItemAssignmentOptions itemAssign, CharacterShufflingOptions shufflingOptions, String seed) {
+			RecruitmentOptions recruit, ItemAssignmentOptions itemAssign, CharacterShufflingOptions shufflingOptions, TerrainOptions terrainOptions, String seed) {
 		super();
 		this.sourcePath = sourcePath;
 		this.targetPath = targetPath;
@@ -122,6 +122,7 @@ public class GBARandomizer extends Randomizer {
 		recruitOptions = recruit;
 		itemAssignmentOptions = itemAssign;
 		this.shufflingOptions = shufflingOptions;
+		this.terrainOptions = terrainOptions;
 		if (itemAssignmentOptions == null) { itemAssignmentOptions = new ItemAssignmentOptions(WeaponReplacementPolicy.ANY_USABLE, ShopAdjustment.NO_CHANGE, false, false); }
 		
 		this.gameType = gameType;
@@ -218,6 +219,8 @@ public class GBARandomizer extends Randomizer {
 		updateProgress(0.70);
 		try { randomizeOtherThingsIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing miscellaneous settings.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; } // i.e. Miscellaneous options.
 		updateProgress(0.75);
+		try { randomizeTerrainIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing terrain bonuses.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; } // i.e. Miscellaneous options.
+		updateProgress(0.77);
 		try { randomizeGrowthsIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing growths.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
 		updateProgress(0.90);
 		try { makeFinalAdjustments(seed); } catch (Exception e) { notifyError("Encountered error while making final adjustments.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
@@ -230,7 +233,8 @@ public class GBARandomizer extends Randomizer {
 		paletteData.compileDiffs(diffCompiler);
 		textData.commitChanges(freeSpace, diffCompiler);
 		portraitData.compileDiffs(diffCompiler);
-		
+		terrainData.compileDiffs(diffCompiler);
+
 		if (gameType == GameType.FE8) {
 			fe8_paletteMapper.commitChanges(diffCompiler);
 			fe8_promotionManager.compileDiffs(diffCompiler);
@@ -351,6 +355,9 @@ public class GBARandomizer extends Randomizer {
 		updateStatusString("Loading Palette Data...");
 		updateProgress(0.30);
 		paletteData = new PaletteLoader(FEBase.GameType.FE7, handler, charData, classData);
+		updateStatusString("Loading Palette Data...");
+		updateProgress(0.31);
+		terrainData = new TerrainDataLoader(FEBase.GameType.FE7, classData, handler);
 		
 		handler.clearAppliedDiffs();
 	}
@@ -386,7 +393,9 @@ public class GBARandomizer extends Randomizer {
 		updateStatusString("Loading Palette Data...");
 		updateProgress(0.30);
 		paletteData = new PaletteLoader(FEBase.GameType.FE6, handler, charData, classData);
-		
+		updateStatusString("Loading Palette Data...");
+		updateProgress(0.31);
+		terrainData = new TerrainDataLoader(FEBase.GameType.FE6, classData, handler);
 		handler.clearAppliedDiffs();
 	}
 	
@@ -424,6 +433,9 @@ public class GBARandomizer extends Randomizer {
 		updateStatusString("Loading Palette Data...");
 		updateProgress(0.30);
 		paletteData = new PaletteLoader(FEBase.GameType.FE8, handler, charData, classData);
+		updateStatusString("Loading Palette Data...");
+		updateProgress(0.31);
+		terrainData = new TerrainDataLoader(FEBase.GameType.FE8, classData, handler);
 		
 		updateStatusString("Loading Summoner Module...");
 		updateProgress(0.35);

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -30,41 +30,21 @@ import fedata.gba.fe8.FE8SpellAnimationCollection;
 import fedata.gba.fe8.FE8SummonerModule;
 import fedata.gba.general.GBAFEChapterMetadataChapter;
 import fedata.gba.general.GBAFEChapterMetadataData;
-import fedata.gba.general.GBAFEClass;
-import fedata.gba.general.WeaponRank;
 import fedata.gba.general.WeaponType;
 import fedata.general.FEBase;
 import fedata.general.FEBase.GameType;
 import io.DiffApplicator;
 import io.FileHandler;
 import io.UPSPatcher;
-import io.UPSPatcherStatusListener;
-import random.gba.loader.ChapterLoader;
-import random.gba.loader.CharacterDataLoader;
-import random.gba.loader.ClassDataLoader;
-import random.gba.loader.ItemDataLoader;
-import random.gba.loader.PaletteLoader;
-import random.gba.loader.PortraitDataLoader;
-import random.gba.loader.TextLoader;
+import random.gba.loader.*;
 import random.gba.randomizer.shuffling.CharacterShuffler;
 import random.gba.loader.ItemDataLoader.AdditionalData;
 import random.general.Randomizer;
-import ui.model.BaseOptions;
-import ui.model.CharacterShufflingOptions;
+import ui.model.*;
 import ui.model.CharacterShufflingOptions.ShuffleLevelingMode;
-import ui.model.ClassOptions;
-import ui.model.EnemyOptions;
-import ui.model.GrowthOptions;
-import ui.model.ItemAssignmentOptions;
-import ui.model.MiscellaneousOptions;
-import ui.model.MiscellaneousOptions.ExperienceRate;
-import ui.model.OtherCharacterOptions;
-import ui.model.RecruitmentOptions;
-import ui.model.WeaponOptions;
 import ui.model.EnemyOptions.BossStatMode;
 import ui.model.ItemAssignmentOptions.ShopAdjustment;
 import ui.model.ItemAssignmentOptions.WeaponReplacementPolicy;
-import util.DebugPrinter;
 import util.Diff;
 import util.DiffCompiler;
 import util.FileReadHelper;
@@ -94,6 +74,7 @@ public class GBARandomizer extends Randomizer {
 	private RecruitmentOptions recruitOptions;
 	private ItemAssignmentOptions itemAssignmentOptions;
 	private CharacterShufflingOptions shufflingOptions;
+	private TerrainOptions terrainOptions;
 	
 	private CharacterDataLoader charData;
 	private ClassDataLoader classData;
@@ -102,6 +83,7 @@ public class GBARandomizer extends Randomizer {
 	private PaletteLoader paletteData;
 	private TextLoader textData;
 	private PortraitDataLoader portraitData;
+	private TerrainDataLoader terrainData;
 	
 	private boolean needsPaletteFix;
 	private Map<GBAFECharacterData, GBAFECharacterData> characterMap; // valid with random recruitment. Maps slots to reference character.
@@ -461,7 +443,13 @@ public class GBARandomizer extends Randomizer {
 			CharacterShuffler.shuffleCharacters(gameType, charData, textData, rng, handler, portraitData, freeSpace, chapterData, classData, shufflingOptions, itemAssignmentOptions, itemData);
 		}
 	}
-	
+	public void randomizeTerrainIfNecessary(String seed) {
+		if (terrainOptions != null) {
+			Random rng = new Random(SeedGenerator.generateSeedValue(seed, TerrainRandomizer.rngSalt));
+			new TerrainRandomizer(rng, terrainData, terrainOptions).randomize();
+		}
+	}
+
 	private void randomizeGrowthsIfNecessary(String seed) {
 		if (growths != null) {
 			Random rng = new Random(SeedGenerator.generateSeedValue(seed, GrowthsRandomizer.rngSalt));

--- a/Universal FE Randomizer/src/random/gba/randomizer/TerrainRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/TerrainRandomizer.java
@@ -1,0 +1,168 @@
+package random.gba.randomizer;
+
+import fedata.TerrainTable;
+import fedata.TerrainTable.TerrainTableType;
+import random.gba.loader.TerrainDataLoader;
+import ui.model.MinMaxOption;
+import ui.model.TerrainOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public class TerrainRandomizer {
+
+    public static int rngSalt = 564894;
+
+    private final Random rng;
+    private final TerrainDataLoader terrainData;
+    private final TerrainOptions options;
+    private final List<Integer> untraversableTiles = new ArrayList<>();
+    private final List<Integer> excludedTiles = new ArrayList<>();
+    private final List<Integer> flierOnlyTiles = new ArrayList<>();
+    private final List<Integer> safeTiles = new ArrayList<>();
+    private final int numberTiles;
+
+    public TerrainRandomizer(Random rng, TerrainDataLoader terrainData, TerrainOptions options) {
+        this.rng = rng;
+        this.terrainData = terrainData;
+        this.options = options;
+
+        // All tables in a game have the same number of entries, so this is fine
+        numberTiles = terrainData.dataLengthBytes;
+
+        determineUntraversableTiles();
+        determineSafeTiles();
+        determineFlierOnlyTiles();
+
+        for (int i = 1; i < terrainData.dataLengthBytes - 1; i++) {
+            if (flierOnlyTiles.contains(i) || untraversableTiles.contains(i)) {
+                excludedTiles.add(i);
+                continue;
+            }
+            if (rng.nextInt(100) > options.effectChance) {
+                excludedTiles.add(i);
+            }
+        }
+    }
+
+    public void randomize() {
+        if (options.randomizeMovementCost) {
+            handleTables(TerrainTableType.MOVEMENT, options.movementCostRange, true);
+            handleTables(TerrainTableType.MOVEMENT_RAIN, options.movementCostRange, true);
+            handleTables(TerrainTableType.MOVEMENT_SNOW, options.movementCostRange, true);
+        }
+
+
+        if (options.randomizeHealing) {
+            handleTables(TerrainTableType.HEALING, options.healingRange, false, options.healingChance);
+        }
+
+        if (options.randomizeStatusRecovery) {
+            handleTables(TerrainTableType.STATUS_RECOVERY, new MinMaxOption(0, 1), false, options.statusRestoreChance);
+        }
+
+        if (options.randomizeAvoid) {
+            handleTables(TerrainTableType.AVOID, options.avoidRange, true, options.avoidChance);
+        }
+
+        if (options.randomizeDef) {
+            handleTables(TerrainTableType.DEF, options.defRange, true, options.defChance);
+        }
+
+        if (options.randomizeRes) {
+            handleTables(TerrainTableType.RES, options.resRange, true, options.resChance);
+        }
+    }
+
+    /**
+     * Determines all the tiles which are only usable by Fliers
+     */
+    private void determineFlierOnlyTiles() {
+        List<TerrainTable> nonFlierMovementTables = terrainData.getTerrainTablesOfType(TerrainTableType.MOVEMENT).stream()
+                .filter(table -> !terrainData.isUsedByFliers(table.getAddressOffset()))
+                .collect(Collectors.toList());
+
+        for (int i = 1; i < numberTiles; i++) {
+            boolean isFlierOnly = true;
+
+            for (TerrainTable table : nonFlierMovementTables) {
+                isFlierOnly &= table.tableType.isDisabled(table.getData()[i]);
+            }
+
+            if (isFlierOnly) {
+                this.flierOnlyTiles.add(i);
+            }
+        }
+    }
+
+    /**
+     * Determines the indicies of all Tiles that have no effect among: Avoid, Def, Res, Healing, or Status Recovery.
+     */
+    private void determineSafeTiles() {
+        List<TerrainTable> tables = new ArrayList<>();
+        tables.addAll(terrainData.getTerrainTablesOfType(TerrainTableType.AVOID));
+        tables.addAll(terrainData.getTerrainTablesOfType(TerrainTableType.DEF));
+        tables.addAll(terrainData.getTerrainTablesOfType(TerrainTableType.RES));
+        tables.addAll(terrainData.getTerrainTablesOfType(TerrainTableType.HEALING));
+        tables.addAll(terrainData.getTerrainTablesOfType(TerrainTableType.STATUS_RECOVERY));
+        tables.removeIf(table -> terrainData.isUsedByFliers(table.getAddressOffset()) && !table.tableType.isUniversal());
+
+        for (int i = 1; i < numberTiles; i++) {
+            boolean hasEffect = false;
+            for (TerrainTable table : tables) {
+                hasEffect |= table.tableType.isDisabled(table.getData()[i]);
+            }
+            if (!hasEffect) {
+                this.safeTiles.add(i);
+            }
+        }
+
+    }
+
+    private void determineUntraversableTiles() {
+        List<TerrainTable> moveTables = terrainData.getTerrainTablesOfType(TerrainTableType.MOVEMENT);
+        for (int i = 1; i < numberTiles; i++) {
+            boolean isUntraversable = true;
+
+            for (TerrainTable table : moveTables) {
+                isUntraversable &= table.tableType.isDisabled(table.getData()[i]);
+            }
+
+            if (isUntraversable) {
+                this.untraversableTiles.add(i);
+            }
+        }
+    }
+
+    public void handleTables(TerrainTableType tableType, MinMaxOption minMax, boolean excludeFliers) {
+        handleTables(tableType, minMax, excludeFliers, -1);
+    }
+
+    public void handleTables(TerrainTableType tableType, MinMaxOption minMax, boolean excludeFliers, int chance) {
+        List<TerrainTable> avoidTable = terrainData.getTerrainTablesOfType(tableType);
+        for (TerrainTable tt : avoidTable) {
+            // if the current Step is not applicable to fliers, then skip any table used by flier classes
+            if (excludeFliers && terrainData.isUsedByFliers(tt.getAddressOffset())) {
+                continue;
+            }
+            for (int i = 1; i < tt.getData().length; i++) {
+                int oldValue = tt.getData()[i];
+                if (untraversableTiles.contains(i) // never randomize completely untraversable Tiles
+                        || (options.keepSafeTiles && safeTiles.contains(i)) // If the user chose, keep things such as roads / plains safe
+                        || excludedTiles.contains(i) // Wether this tile was randomized to not have a change, skip it
+                        || tableType.mayNotChange(oldValue) // Exclude all Untraversable Tiles
+                ) {
+                    continue;
+                }
+
+                if (chance == -1 || rng.nextInt(100) < chance) {
+                    int newValue = rng.nextInt(minMax.maxValue - minMax.minValue) + minMax.minValue;
+                    tt.setAtIndex(i, newValue);
+                }
+            }
+        }
+    }
+
+}

--- a/Universal FE Randomizer/src/random/gba/randomizer/TerrainRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/TerrainRandomizer.java
@@ -5,11 +5,14 @@ import fedata.gba.general.TerrainTable.TerrainTableType;
 import random.gba.loader.TerrainDataLoader;
 import ui.model.MinMaxOption;
 import ui.model.TerrainOptions;
+import util.DebugPrinter;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
+
+import static util.DebugPrinter.Key.GBA_TERRAIN_RANDOMIZER;
 
 public class TerrainRandomizer {
 
@@ -168,11 +171,11 @@ public class TerrainRandomizer {
                         newValue = rng.nextInt(minMax.maxValue - minMax.minValue) + minMax.minValue;
                     }
                     table.setAtIndex(i, newValue);
-                    System.out.println("Table "+table.getAddressOffset()+" index"+i+" oldValue "+oldValue+" newValue"+newValue);
+                    DebugPrinter.log(GBA_TERRAIN_RANDOMIZER,"Table "+table.getAddressOffset()+" index"+i+" oldValue "+oldValue+" newValue "+newValue);
                 }
             }
             if (table.wasModified()) {
-                System.out.println("Modified table: " + table.getAddressOffset()+ ", for type " + tableType);
+                DebugPrinter.log(GBA_TERRAIN_RANDOMIZER,"Modified table: " + table.getAddressOffset()+ ", for type " + tableType);
             }
         }
     }

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/CharacterShuffler.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/CharacterShuffler.java
@@ -71,7 +71,7 @@ public class CharacterShuffler {
 			}
 			for (GBAFECharacterData slot : characterPool) {
 				// Determine if the current character should be replaced
-				if (options.getChance() < rng.nextInt(1, 100)) {
+				if (options.getChance() < rng.nextInt(100)) {
 					continue;
 				}
 

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/GBACrossGameData.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/GBACrossGameData.java
@@ -1,10 +1,6 @@
 package random.gba.randomizer.shuffling;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import fedata.gba.GBAFEStatDto;
 import fedata.gba.fe6.FE6Data;
@@ -38,8 +34,8 @@ public class GBACrossGameData {
 	public int mouthY;
 
 	public GBACrossGameData(String name, String portraitPath, String description1, String description2,
-			String paletteString, GBAFEClass characterClass, int level, GBAFEStatDto bases, GBAFEStatDto growths,
-			int[] weaponRanks, int constitution, byte[] facialFeatureCoordinates) {
+							String paletteString, GBAFEClass characterClass, int level, GBAFEStatDto bases, GBAFEStatDto growths,
+							int[] weaponRanks, int constitution, byte[] facialFeatureCoordinates) {
 		this.name = name;
 		this.portraitPath = portraitPath;
 		this.description1 = description1;
@@ -100,7 +96,13 @@ public class GBACrossGameData {
 		// try to find a fitting replacement if the origin class could be found
 		if (classOpt.isPresent()) {
 			GBAFEClass classToSub = classOpt.get();
-			GBAFEClass substituteClass = classMap.get(classToSub).get(targetGame);
+			Map<GameType, GBAFEClass> classMapping = classMap.get(classToSub);
+			if (classMapping == null) {
+				DebugPrinter.log(DebugPrinter.Key.GBA_CHARACTER_SHUFFLING,
+						String.format("Found no class mapping for class %s in game %s.", classToSub.name(), targetGame));
+				return FE6Data.CharacterClass.NONE;
+			}
+			GBAFEClass substituteClass = classMapping.get(targetGame);
 			if (substituteClass != null) {
 				return substituteClass;
 			} else {
@@ -114,7 +116,7 @@ public class GBACrossGameData {
 
 	/**
 	 * Double check exceptional cases after Naive search.
-	 * 
+	 *
 	 * F.e. FE8 has a bard class, but that one has no animations and as such isn't
 	 * usable (since it apparently might freeze), make sure not to give that one out
 	 * and instead give out Dancer in the fixed mapping.
@@ -123,11 +125,11 @@ public class GBACrossGameData {
 		GBAFEClass chosenClass = classOpt.get();
 		if (provider instanceof FE8Data) {
 			return (Arrays.asList(FE8Data.CharacterClass.BARD, // Lack of Magic Animations?
-					// These following female classes are too much of a pain to make work.
-					// They have the same animation as the male one anyway, don't have Promo Bonuses
-					// either.
-					FE8Data.CharacterClass.WYVERN_RIDER_F, FE8Data.CharacterClass.WYVERN_LORD_F,
-					FE8Data.CharacterClass.HERO_F, FE8Data.CharacterClass.SHAMAN_F, FE8Data.CharacterClass.DRUID_F)
+							// These following female classes are too much of a pain to make work.
+							// They have the same animation as the male one anyway, don't have Promo Bonuses
+							// either.
+							FE8Data.CharacterClass.WYVERN_RIDER_F, FE8Data.CharacterClass.WYVERN_LORD_F,
+							FE8Data.CharacterClass.HERO_F, FE8Data.CharacterClass.SHAMAN_F, FE8Data.CharacterClass.DRUID_F)
 					.contains(chosenClass));
 		} else if (provider instanceof FE7Data) {
 			return (Arrays.asList(FE7Data.CharacterClass.CAVALIER_F, // Not a useable class
@@ -207,6 +209,7 @@ public class GBACrossGameData {
 		addEntry(GameType.FE6, FE6Data.CharacterClass.PRIEST, FE7Data.CharacterClass.CLERIC, FE8Data.CharacterClass.PRIEST);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.TROUBADOUR, FE7Data.CharacterClass.TROUBADOUR, FE8Data.CharacterClass.TROUBADOUR);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.SAGE, FE7Data.CharacterClass.SAGE, FE8Data.CharacterClass.SAGE);
+		addEntry(GameType.FE6, FE6Data.CharacterClass.MANAKETE_F, FE7Data.CharacterClass.DANCER, FE8Data.CharacterClass.MANAKETE_F);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.SNIPER, FE7Data.CharacterClass.SNIPER, FE8Data.CharacterClass.SNIPER);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.ARCHER_F, FE7Data.CharacterClass.ARCHER_F, FE8Data.CharacterClass.ARCHER_F);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.SHAMAN, FE7Data.CharacterClass.SHAMAN, FE8Data.CharacterClass.SHAMAN);
@@ -231,7 +234,7 @@ public class GBACrossGameData {
 		addEntry(GameType.FE6, FE6Data.CharacterClass.HERO_F, FE7Data.CharacterClass.HERO, FE8Data.CharacterClass.HERO);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.KING, FE7Data.CharacterClass.GENERAL, FE8Data.CharacterClass.GENERAL);
 		addEntry(GameType.FE6, FE6Data.CharacterClass.WYVERN_KNIGHT, FE7Data.CharacterClass.WYVERNLORD, FE8Data.CharacterClass.WYVERN_LORD);
-		
+
 		// FE7 Classes -> FE6 / FE8
 		addEntry(GameType.FE7, FE7Data.CharacterClass.LORD_LYN, FE6Data.CharacterClass.MYRMIDON_F, FE8Data.CharacterClass.MYRMIDON);
 		addEntry(GameType.FE7, FE7Data.CharacterClass.LORD_HECTOR, FE6Data.CharacterClass.KNIGHT, FE8Data.CharacterClass.KNIGHT);
@@ -270,7 +273,7 @@ public class GBACrossGameData {
 		addEntry(GameType.FE7, FE7Data.CharacterClass.WARRIOR, FE6Data.CharacterClass.WARRIOR, FE8Data.CharacterClass.WARRIOR);
 		addEntry(GameType.FE7, FE7Data.CharacterClass.WYVERNLORD_F, FE6Data.CharacterClass.WYVERN_KNIGHT_F, FE8Data.CharacterClass.WYVERN_LORD);
 		addEntry(GameType.FE7, FE7Data.CharacterClass.HERO, FE6Data.CharacterClass.HERO, FE8Data.CharacterClass.HERO);
-		
+
 		// FE8 Classes -> FE6 / FE7
 		addEntry(GameType.FE8, FE8Data.CharacterClass.FIGHTER, FE6Data.CharacterClass.FIGHTER, FE7Data.CharacterClass.FIGHTER);
 		addEntry(GameType.FE8, FE8Data.CharacterClass.TRAINEE, FE6Data.CharacterClass.FIGHTER, FE7Data.CharacterClass.FIGHTER);
@@ -302,34 +305,40 @@ public class GBACrossGameData {
 		addEntry(GameType.FE8, FE8Data.CharacterClass.ROGUE, FE6Data.CharacterClass.SWORDMASTER, FE7Data.CharacterClass.ASSASSIN);
 	}
 
-	
-	private static Map<GameType, List<GameType>> sourceGameMap = 
-			Map.of(
-					GameType.FE6, Arrays.asList(GameType.FE7, GameType.FE8), 
-					GameType.FE7, Arrays.asList(GameType.FE6, GameType.FE8), 
-					GameType.FE8, Arrays.asList(GameType.FE6, GameType.FE7)
-			); 
+
+	private static Map<GameType, List<GameType>> sourceGameMap = buildSourceGameMap();
+
+	private static Map<GameType, List<GameType>> buildSourceGameMap() {
+		Map<GameType, List<GameType>> map = new HashMap<>();
+		map.put(GameType.FE6, Arrays.asList(GameType.FE7, GameType.FE8));
+		map.put(GameType.FE7, Arrays.asList(GameType.FE6, GameType.FE8));
+		map.put(GameType.FE8, Arrays.asList(GameType.FE6, GameType.FE7));
+		return Collections.unmodifiableMap(map);
+	}
 	//@formatter:on
 
 	/**
 	 * Add an entry to the class map. the parameters must ensure that the passed to
 	 * parameters are in game order, as we will infer the target game based on the
 	 * position (using the sourceGameMap).
-	 * 
+	 *
 	 * @param sourceGame The game (of FE6,7,8) that the source class is from.
 	 * @param source     the source class to put as a key in the map
-	 * 
+	 *
 	 * @param to1        the replacement class in the first other game (f.e. if the
 	 *                   source class is FE6, this MUST be the FE7 equivalent or if
 	 *                   Source is FE7 then this is FE6)
-	 * 
+	 *
 	 * @param to2        the replacement class in the second other game (f.e. if the
 	 *                   source class is FE6, this MUST be the FE8 equivalent or if
 	 *                   Source is FE8 then this is FE7)
 	 */
 	private static void addEntry(GameType sourceGame, GBAFEClass source, GBAFEClass to1, GBAFEClass to2) {
 		List<GameType> sourceGames = sourceGameMap.get(sourceGame);
-		classMap.put(source, Map.of(sourceGames.get(0), to1, sourceGames.get(1), to2));
+		Map<GameType, GBAFEClass> inner = new HashMap<>();
+		inner.put(sourceGames.get(0), to1);
+		inner.put(sourceGames.get(1), to2);
+		classMap.put(source, Collections.unmodifiableMap(inner));
 	}
 
 }

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/GBAFEPortraitData.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/data/GBAFEPortraitData.java
@@ -14,9 +14,7 @@ public class GBAFEPortraitData extends AbstractGBAData {
 	private byte[] newPalette;
 
 	public GBAFEPortraitData(byte[] originalData, long offset, int faceId, boolean separateMouthFrames) {
-		this.data = originalData;
-		this.originalData = originalData;
-		this.originalOffset = offset;
+		super(originalData, offset);
 		this.faceId = faceId;
 		this.separateMouthFrames = separateMouthFrames;
 	}

--- a/Universal FE Randomizer/src/ui/CharacterShufflingView.java
+++ b/Universal FE Randomizer/src/ui/CharacterShufflingView.java
@@ -226,7 +226,7 @@ public class CharacterShufflingView extends Composite {
 					StringBuilder sb = new StringBuilder();
 					for (String file : chosenFiles) {
 						includedShuffles.add(currentFolder + "/"+ file);
-						if (!sb.isEmpty()){
+						if (sb.length() != 0){
 							sb.append(",");
 						}
 						sb.append(file);

--- a/Universal FE Randomizer/src/ui/MainView.java
+++ b/Universal FE Randomizer/src/ui/MainView.java
@@ -133,7 +133,8 @@ public class MainView implements FileFlowDelegate {
 	private RecruitmentView recruitView;
 	private ItemAssignmentView itemAssignmentView;
 	private CharacterShufflingView characterShufflingView;
-	
+	private TerrainView terrainView;
+
 	// FE4
 	private SkillsView skillsView;
 	private HolyBloodView holyBloodView;
@@ -474,6 +475,7 @@ public class MainView implements FileFlowDelegate {
 				recruitView.setRecruitmentOptions(bundle.recruitmentOptions);
 				characterShufflingView.setShufflingOptions(bundle.characterShufflingOptions, type);
 				itemAssignmentView.setItemAssignmentOptions(bundle.itemAssignmentOptions);
+				terrainView.setTerrainOptions(bundle.terrainOptions);
 			}
 		} else if (type == GameType.FE9 && OptionRecorder.options.fe9 != null) {
 			FE9OptionBundle bundle = OptionRecorder.options.fe9;
@@ -784,11 +786,21 @@ public class MainView implements FileFlowDelegate {
 			itemAssignData.left = new FormAttachment(characterShufflingView, 0, SWT.LEFT);
 			itemAssignData.right = new FormAttachment(characterShufflingView, 0, SWT.RIGHT);
 			itemAssignmentView.setLayoutData(itemAssignData);
-			  
+
+			terrainView = new TerrainView(container, SWT.NONE, type);
+			terrainView.setSize(200, 200);
+			terrainView.setVisible(false);
+
+			FormData terrainViewData = new FormData();
+			terrainViewData.top = new FormAttachment(itemAssignmentView, 5);
+			terrainViewData.left = new FormAttachment(itemAssignmentView, 0, SWT.LEFT);
+			terrainViewData.right = new FormAttachment(itemAssignmentView, 0, SWT.RIGHT);
+			terrainView.setLayoutData(terrainViewData);
+
 			FormData randomizeData = new FormData();
-			randomizeData.top = new FormAttachment(itemAssignmentView, 5);
-			randomizeData.left = new FormAttachment(itemAssignmentView, 0, SWT.LEFT);
-			randomizeData.right = new FormAttachment(itemAssignmentView, 0, SWT.RIGHT);
+			randomizeData.top = new FormAttachment(terrainView, 5);
+			randomizeData.left = new FormAttachment(terrainView, 0, SWT.LEFT);
+			randomizeData.right = new FormAttachment(terrainView, 0, SWT.RIGHT);
 			randomizeData.bottom = new FormAttachment(100, -10);
 			randomizeButton.setLayoutData(randomizeData);
 		}
@@ -983,6 +995,7 @@ public class MainView implements FileFlowDelegate {
 			recruitView.setVisible(true);
 			itemAssignmentView.setVisible(true);
 			characterShufflingView.setVisible(true);
+			terrainView.setVisible(true);
 		}
 
 		
@@ -1062,6 +1075,7 @@ public class MainView implements FileFlowDelegate {
 								recruitView.getRecruitmentOptions(),
 								itemAssignmentView.getAssignmentOptions(),
 								characterShufflingView.getShufflingOptions(),
+								terrainView.getTerrainOptions(),
 								seedField.getText());
 						
 						OptionRecorder.recordGBAFEOptions(type, 
@@ -1075,6 +1089,7 @@ public class MainView implements FileFlowDelegate {
 								recruitView.getRecruitmentOptions(),
 								itemAssignmentView.getAssignmentOptions(),
 								characterShufflingView.getShufflingOptions(),
+								terrainView.getTerrainOptions(),
 								seedField.getText());
 					} else if (type.isSFC()) {
 						if (type == GameType.FE4) {

--- a/Universal FE Randomizer/src/ui/TerrainView.java
+++ b/Universal FE Randomizer/src/ui/TerrainView.java
@@ -1,0 +1,246 @@
+package ui;
+
+import fedata.gba.general.TerrainTable;
+import fedata.general.FEBase.GameType;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.*;
+import ui.general.MinMaxControl;
+import ui.model.TerrainOptions;
+
+import java.util.*;
+
+import static fedata.gba.general.TerrainTable.TerrainTableType.*;
+
+public class TerrainView extends Composite {
+
+    private Group container;
+
+    private Button enableButton;
+    private Label effectChanceLabel;
+    private Spinner effectChanceSpinner;
+    private Button keepSafeTiles;
+
+    private Map<TerrainTable.TerrainTableType, Button> enabledMap = new HashMap<>();
+    private Map<TerrainTable.TerrainTableType, MinMaxControl> rangeMap = new HashMap<>();
+    private Map<TerrainTable.TerrainTableType, Spinner> spinnerMap = new HashMap<>();
+    private Map<TerrainTable.TerrainTableType, Label> spinnerLabelMap = new HashMap<>();
+
+
+    public TerrainView(Composite parent, int style, GameType type) {
+        super(parent, style);
+
+        FillLayout layout = new FillLayout();
+        setLayout(layout);
+
+        container = new Group(this, SWT.NONE);
+        container.setText("Terrain Bonuses");
+        container.setToolTipText("Randomizes Terrain Bonuses.");
+
+        FormLayout groupMargins = new FormLayout();
+        groupMargins.marginLeft = 5;
+        groupMargins.marginTop = 5;
+        groupMargins.marginBottom = 5;
+        groupMargins.marginRight = 5;
+        container.setLayout(groupMargins);
+
+
+        enableButton = new Button(container, SWT.CHECK);
+        enableButton.setText("Enable Randomization");
+
+        effectChanceSpinner = new Spinner(container, SWT.NONE);
+        FormData formData = new FormData();
+        formData.top = new FormAttachment(enableButton, 5);
+        formData.right = new FormAttachment(100, -5);
+        effectChanceSpinner.setLayoutData(formData);
+        effectChanceSpinner.setEnabled(false);
+        effectChanceSpinner.setMinimum(0);
+        effectChanceSpinner.setMaximum(100);
+        effectChanceSpinner.setSelection(0);
+        effectChanceSpinner.setIncrement(1);
+
+        effectChanceLabel = new Label(container, SWT.NONE);
+        effectChanceLabel.setText("Effect chance: ");
+        effectChanceLabel.setToolTipText("The chance that a tile will get any kind of effect.");
+        formData = new FormData();
+        formData.top = new FormAttachment(effectChanceSpinner, 0, SWT.TOP);
+        formData.right = new FormAttachment(effectChanceSpinner, 0);
+        effectChanceLabel.setLayoutData(formData);
+        effectChanceLabel.setEnabled(false);
+
+        keepSafeTiles = new Button(container, SWT.CHECK);
+        keepSafeTiles.setText("Keep safe tiles");
+        formData = new FormData();
+        formData.left = new FormAttachment(enableButton, 10, SWT.LEFT);
+        formData.top = new FormAttachment(effectChanceSpinner, 5);
+        keepSafeTiles.setLayoutData(formData);
+        keepSafeTiles.setEnabled(false);
+
+
+        Control previousControl = keepSafeTiles;
+        for (TerrainTable.TerrainTableType terrainType : Arrays.asList(AVOID, DEF, RES, HEALING, STATUS_RECOVERY)) {
+            Composite group = createCompositeForTerrainType(container, terrainType);
+
+            formData = new FormData();
+            formData.left = new FormAttachment(container, 10);
+            formData.top = new FormAttachment(previousControl, 5);
+            formData.right = new FormAttachment(100, -5);
+            group.setLayoutData(formData);
+            previousControl = group;
+        }
+
+        enableButton.addListener(SWT.Selection, event -> {
+            for (Control button : enabledMap.values()) {
+                button.setEnabled(enableButton.getSelection());
+            }
+            for (Control button : spinnerMap.values()) {
+                button.setEnabled(enableButton.getSelection());
+            }
+            for (Control button : spinnerLabelMap.values()) {
+                button.setEnabled(enableButton.getSelection());
+            }
+            for (Control button : rangeMap.values()) {
+                button.setEnabled(enableButton.getSelection());
+            }
+            keepSafeTiles.setEnabled(enableButton.getSelection());
+            effectChanceLabel.setEnabled(enableButton.getSelection());
+            effectChanceSpinner.setEnabled(enableButton.getSelection());
+        });
+    }
+
+    private Composite createCompositeForTerrainType(Composite container, TerrainTable.TerrainTableType terrainTableType) {
+        Composite group = new Composite(container, SWT.NONE);
+        group.setLayout(new FormLayout());
+
+        Button typeEnabledButton = new Button(group, SWT.CHECK);
+        typeEnabledButton.setEnabled(false);
+        typeEnabledButton.setText("Randomize " + terrainTableType.displayString);
+        enabledMap.put(terrainTableType, typeEnabledButton);
+
+        Spinner chanceSpinner = new Spinner(group, SWT.NONE);
+        chanceSpinner.setMinimum(0);
+        chanceSpinner.setIncrement(5);
+        chanceSpinner.setSelection(0);
+        chanceSpinner.setMaximum(100);
+        spinnerMap.put(terrainTableType, chanceSpinner);
+
+        FormData formData = new FormData();
+        formData.right = new FormAttachment(100, -5);
+        formData.top = new FormAttachment(typeEnabledButton, 5);
+        chanceSpinner.setLayoutData(formData);
+        chanceSpinner.setEnabled(false);
+
+        Label chanceLabel = new Label(group, SWT.NONE);
+        chanceLabel.setText("Chance: ");
+        chanceLabel.setEnabled(false);
+        formData = new FormData();
+        formData.right = new FormAttachment(chanceSpinner, 0, SWT.LEFT);
+        formData.top = new FormAttachment(typeEnabledButton, 5);
+        chanceLabel.setLayoutData(formData);
+        spinnerLabelMap.put(terrainTableType, chanceLabel);
+
+        if (!terrainTableType.isToggle) {
+            MinMaxControl rangeControl = new MinMaxControl(group, SWT.NONE, "Min:", "Max:");
+            rangeControl.getMinSpinner().setSelection(terrainTableType.min);
+            rangeControl.getMinSpinner().setMinimum(terrainTableType.min);
+            rangeControl.getMinSpinner().setMaximum(terrainTableType.max - 1);
+            rangeControl.getMinSpinner().setIncrement(1);
+            rangeControl.setEnabled(false);
+
+            rangeControl.getMaxSpinner().setSelection(terrainTableType.min + 1);
+            rangeControl.getMaxSpinner().setMinimum(terrainTableType.min + 1);
+            rangeControl.getMaxSpinner().setMaximum(terrainTableType.max);
+            rangeControl.getMaxSpinner().setIncrement(1);
+            rangeControl.setEnabled(false);
+            rangeMap.put(terrainTableType, rangeControl);
+            formData = new FormData();
+            formData.right = new FormAttachment(100, 0);
+            formData.top = new FormAttachment(chanceSpinner, 5);
+            rangeControl.setLayoutData(formData);
+        }
+
+        typeEnabledButton.addListener(SWT.Selection, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                for (Control child : group.getChildren()) {
+                    if (child != typeEnabledButton) {
+                        child.setEnabled(typeEnabledButton.getSelection());
+                    }
+                }
+            }
+        });
+
+        return group;
+    }
+
+    public TerrainOptions getTerrainOptions() {
+        TerrainOptions options = new TerrainOptions();
+        if (!enableButton.getSelection()) {
+            return options;
+        }
+
+        options.enabled = true;
+        options.effectChance = effectChanceSpinner.getSelection();
+
+        options.randomizeDef = enabledMap.get(DEF).getSelection();
+        options.randomizeRes = enabledMap.get(RES).getSelection();
+        options.randomizeAvoid = enabledMap.get(AVOID).getSelection();
+        options.randomizeHealing = enabledMap.get(HEALING).getSelection();
+        options.randomizeStatusRecovery = enabledMap.get(STATUS_RECOVERY).getSelection();
+
+        options.defChance = spinnerMap.get(DEF).getSelection();
+        options.resChance = spinnerMap.get(RES).getSelection();
+        options.avoidChance = spinnerMap.get(AVOID).getSelection();
+        options.healingChance = spinnerMap.get(HEALING).getSelection();
+        options.statusRestoreChance = spinnerMap.get(STATUS_RECOVERY).getSelection();
+
+        options.defRange = rangeMap.get(DEF).getMinMaxOption();
+        options.resRange = rangeMap.get(RES).getMinMaxOption();
+        options.avoidRange = rangeMap.get(AVOID).getMinMaxOption();
+        options.healingRange = rangeMap.get(HEALING).getMinMaxOption();
+
+        return options;
+    }
+
+    public void setTerrainOptions(TerrainOptions options) {
+        if (options == null) {
+            enableButton.setSelection(false);
+        } else {
+            enableButton.setSelection(true);
+            keepSafeTiles.setEnabled(true);
+            keepSafeTiles.setSelection(options.keepSafeTiles);
+
+            effectChanceLabel.setEnabled(true);
+            effectChanceSpinner.setEnabled(true);
+            effectChanceSpinner.setSelection(options.effectChance);
+
+            enabledMap.values().forEach(b -> b.setEnabled(true));
+            enabledMap.get(DEF).setSelection(options.randomizeDef);
+            enabledMap.get(RES).setSelection(options.randomizeRes);
+            enabledMap.get(AVOID).setSelection(options.randomizeAvoid);
+            enabledMap.get(HEALING).setSelection(options.randomizeHealing);
+            enabledMap.get(STATUS_RECOVERY).setSelection(options.randomizeStatusRecovery);
+
+            rangeMap.entrySet().forEach(e -> e.getValue().setEnabled(enabledMap.get(e.getKey()).getSelection()));
+            rangeMap.get(DEF).getMinSpinner().setSelection(options.defRange.minValue);
+            rangeMap.get(DEF).getMaxSpinner().setSelection(options.defRange.maxValue);
+            rangeMap.get(RES).getMinSpinner().setSelection(options.resRange.minValue);
+            rangeMap.get(RES).getMaxSpinner().setSelection(options.resRange.maxValue);
+            rangeMap.get(AVOID).getMinSpinner().setSelection(options.avoidRange.minValue);
+            rangeMap.get(AVOID).getMaxSpinner().setSelection(options.avoidRange.maxValue);
+            rangeMap.get(HEALING).getMinSpinner().setSelection(options.healingRange.minValue);
+            rangeMap.get(HEALING).getMaxSpinner().setSelection(options.healingRange.maxValue);
+
+            spinnerMap.entrySet().forEach(e -> e.getValue().setEnabled(enabledMap.get(e.getKey()).getSelection()));
+            spinnerLabelMap.entrySet().forEach(e -> e.getValue().setEnabled(enabledMap.get(e.getKey()).getSelection()));
+            spinnerMap.get(DEF).setSelection(options.defChance);
+            spinnerMap.get(RES).setSelection(options.resChance);
+            spinnerMap.get(AVOID).setSelection(options.avoidChance);
+            spinnerMap.get(HEALING).setSelection(options.healingChance);
+            spinnerMap.get(STATUS_RECOVERY).setSelection(options.statusRestoreChance);
+        }
+    }
+}

--- a/Universal FE Randomizer/src/ui/model/TerrainOptions.java
+++ b/Universal FE Randomizer/src/ui/model/TerrainOptions.java
@@ -5,50 +5,55 @@ public class TerrainOptions {
     /*
      * Healing Related Settings
      */
-    public final boolean randomizeHealing;
-    public final int healingChance;
-    public final MinMaxOption healingRange;
+    public boolean randomizeHealing = false;
+    public int healingChance = 0;
+    public MinMaxOption healingRange = null;
 
     /*
      * Status recovery Related Settings
      */
-    public final boolean randomizeStatusRecovery;
-    public final int statusRestoreChance;
+    public boolean randomizeStatusRecovery = false;
+    public int statusRestoreChance = 0;
 
     /*
      * avoid Related Settings
      */
-    public final boolean randomizeAvoid;
-    public final MinMaxOption avoidRange;
-    public final int avoidChance;
+    public boolean randomizeAvoid = false;
+    public MinMaxOption avoidRange = null;
+    public int avoidChance = 0;
 
     /*
      * Defense Related Settings
      */
-    public final boolean randomizeDef;
-    public final MinMaxOption defRange;
-    public final int defChance;
+    public boolean randomizeDef = false;
+    public MinMaxOption defRange = null;
+    public int defChance = 0;
     /*
      * Resistence Related Settings
      */
-    public final boolean randomizeRes;
-    public final MinMaxOption resRange;
-    public final int resChance;
+    public boolean randomizeRes = false;
+    public MinMaxOption resRange = null;
+    public int resChance = 0;
     /*
      * Movement Related Settings
      */
-    public final boolean randomizeMovementCost;
-    public final MinMaxOption movementCostRange;
+    public boolean randomizeMovementCost = false;
+    public MinMaxOption movementCostRange = null;
 
     /*
      * Flag to keep tiles that didn't use to have effects safe
      */
-    public final boolean keepSafeTiles;
+    public boolean keepSafeTiles = false;
 
     /*
      * Chance for a tile to get some kind of effect, otherwise it stays as it is in vanilla
      */
-    public final int effectChance;
+    public int effectChance = 0;
+
+    // Constructor for Tests
+    public TerrainOptions() {
+
+    }
 
     public TerrainOptions(boolean randomizeHealing, int healingChance, MinMaxOption healingRange,
                           boolean randomizeStatusRecovery, int statusRestoreChance,

--- a/Universal FE Randomizer/src/ui/model/TerrainOptions.java
+++ b/Universal FE Randomizer/src/ui/model/TerrainOptions.java
@@ -1,0 +1,79 @@
+package ui.model;
+
+public class TerrainOptions {
+
+    /*
+     * Healing Related Settings
+     */
+    public final boolean randomizeHealing;
+    public final int healingChance;
+    public final MinMaxOption healingRange;
+
+    /*
+     * Status recovery Related Settings
+     */
+    public final boolean randomizeStatusRecovery;
+    public final int statusRestoreChance;
+
+    /*
+     * avoid Related Settings
+     */
+    public final boolean randomizeAvoid;
+    public final MinMaxOption avoidRange;
+    public final int avoidChance;
+
+    /*
+     * Defense Related Settings
+     */
+    public final boolean randomizeDef;
+    public final MinMaxOption defRange;
+    public final int defChance;
+    /*
+     * Resistence Related Settings
+     */
+    public final boolean randomizeRes;
+    public final MinMaxOption resRange;
+    public final int resChance;
+    /*
+     * Movement Related Settings
+     */
+    public final boolean randomizeMovementCost;
+    public final MinMaxOption movementCostRange;
+
+    /*
+     * Flag to keep tiles that didn't use to have effects safe
+     */
+    public final boolean keepSafeTiles;
+
+    /*
+     * Chance for a tile to get some kind of effect, otherwise it stays as it is in vanilla
+     */
+    public final int effectChance;
+
+    public TerrainOptions(boolean randomizeHealing, int healingChance, MinMaxOption healingRange,
+                          boolean randomizeStatusRecovery, int statusRestoreChance,
+                          boolean randomizeAvoid, MinMaxOption avoidRange, int avoidChance,
+                          boolean randomizeDef, MinMaxOption defRange, int defChance,
+                          boolean randomizeRes, MinMaxOption resRange, int resChance,
+                          boolean randomizeMovementCost, MinMaxOption movementCostRange,
+                          boolean keepSafeTiles, int effectChance) {
+        this.randomizeHealing = randomizeHealing;
+        this.healingChance = healingChance;
+        this.healingRange = healingRange;
+        this.randomizeStatusRecovery = randomizeStatusRecovery;
+        this.statusRestoreChance = statusRestoreChance;
+        this.randomizeAvoid = randomizeAvoid;
+        this.avoidRange = avoidRange;
+        this.avoidChance = avoidChance;
+        this.randomizeDef = randomizeDef;
+        this.defRange = defRange;
+        this.defChance = defChance;
+        this.randomizeRes = randomizeRes;
+        this.resRange = resRange;
+        this.resChance = resChance;
+        this.randomizeMovementCost = randomizeMovementCost;
+        this.movementCostRange = movementCostRange;
+        this.keepSafeTiles = keepSafeTiles;
+        this.effectChance = effectChance;
+    }
+}

--- a/Universal FE Randomizer/src/ui/model/TerrainOptions.java
+++ b/Universal FE Randomizer/src/ui/model/TerrainOptions.java
@@ -37,8 +37,8 @@ public class TerrainOptions {
     /*
      * Movement Related Settings
      */
-    public boolean randomizeMovementCost = false;
-    public MinMaxOption movementCostRange = null;
+    public final boolean randomizeMovementCost = false;
+    public final MinMaxOption movementCostRange = null;
 
     /*
      * Flag to keep tiles that didn't use to have effects safe
@@ -50,18 +50,23 @@ public class TerrainOptions {
      */
     public int effectChance = 0;
 
+    public boolean enabled = false;
+
     // Constructor for Tests
     public TerrainOptions() {
 
     }
 
-    public TerrainOptions(boolean randomizeHealing, int healingChance, MinMaxOption healingRange,
+    /**
+     * Constructor for usage from the GUI.
+     */
+    public TerrainOptions(boolean enabled, boolean randomizeHealing, int healingChance, MinMaxOption healingRange,
                           boolean randomizeStatusRecovery, int statusRestoreChance,
                           boolean randomizeAvoid, MinMaxOption avoidRange, int avoidChance,
                           boolean randomizeDef, MinMaxOption defRange, int defChance,
                           boolean randomizeRes, MinMaxOption resRange, int resChance,
-                          boolean randomizeMovementCost, MinMaxOption movementCostRange,
                           boolean keepSafeTiles, int effectChance) {
+        this.enabled = enabled;
         this.randomizeHealing = randomizeHealing;
         this.healingChance = healingChance;
         this.healingRange = healingRange;
@@ -76,8 +81,6 @@ public class TerrainOptions {
         this.randomizeRes = randomizeRes;
         this.resRange = resRange;
         this.resChance = resChance;
-        this.randomizeMovementCost = randomizeMovementCost;
-        this.movementCostRange = movementCostRange;
         this.keepSafeTiles = keepSafeTiles;
         this.effectChance = effectChance;
     }

--- a/Universal FE Randomizer/src/util/DebugPrinter.java
+++ b/Universal FE Randomizer/src/util/DebugPrinter.java
@@ -21,6 +21,7 @@ public class DebugPrinter {
 		FE9_CHAPTER_LOADER("FE9 Chapter Loader"), FE9_ARMY_LOADER("FE9 Army Loader"), FE9_RANDOM_CLASSES("FE9 Class Randomization"),
 		FE9_CHAPTER_SCRIPT("FE9 Chapter Script"), FE9_CHAPTER_STRINGS("FE9 Chapter Strings"), DBX_HANDLER("DBX Handler"),
 		FE9_DATA_FILE_HANDLER_V2("FE9 Data File Handler V2"), GBA_CHARACTER_SHUFFLING("GBA Character Shuffling"),
+		GBA_TERRAIN_RANDOMIZER("GBA Terrain Randomizer"),
 		
 		MISC("MISC");
 		

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -12,24 +12,13 @@ import ui.fe4.HolyBloodOptions;
 import ui.fe4.SkillsOptions;
 import ui.fe9.FE9ClassOptions;
 import ui.fe9.FE9SkillsOptions;
-import ui.model.BaseOptions;
-import ui.model.CharacterShufflingOptions;
-import ui.model.ClassOptions;
-import ui.model.EnemyOptions;
-import ui.model.FE9EnemyBuffOptions;
-import ui.model.FE9OtherCharacterOptions;
-import ui.model.GrowthOptions;
-import ui.model.ItemAssignmentOptions;
-import ui.model.MiscellaneousOptions;
-import ui.model.OtherCharacterOptions;
-import ui.model.RecruitmentOptions;
-import ui.model.WeaponOptions;
+import ui.model.*;
 
 public class OptionRecorder {
 	private static final Integer FE4OptionBundleVersion = 5;
-	private static final Integer GBAOptionBundleVersion = 14;
+	private static final Integer GBAOptionBundleVersion = 15;
 	private static final Integer FE9OptionBundleVersion = 12;
-	
+
 	public static class AllOptions {
 		public FE4OptionBundle fe4;
 		public GBAOptionBundle fe6;
@@ -37,7 +26,7 @@ public class OptionRecorder {
 		public GBAOptionBundle fe8;
 		public FE9OptionBundle fe9;
 	}
-	
+
 	public static class GBAOptionBundle {
 		public GrowthOptions growths;
 		public BaseOptions bases;
@@ -49,10 +38,11 @@ public class OptionRecorder {
 		public RecruitmentOptions recruitmentOptions;
 		public ItemAssignmentOptions itemAssignmentOptions;
 		public CharacterShufflingOptions characterShufflingOptions;
+		public TerrainOptions terrainOptions;
 		public String seed;
 		public Integer version;
 	}
-	
+
 	public static class FE4OptionBundle {
 		public GrowthOptions growths;
 		public BaseOptions bases;
@@ -65,7 +55,7 @@ public class OptionRecorder {
 		public String seed;
 		public Integer version;
 	}
-	
+
 	public static class FE9OptionBundle {
 		public GrowthOptions growths;
 		public BaseOptions bases;
@@ -78,17 +68,17 @@ public class OptionRecorder {
 		public String seed;
 		public Integer version;
 	}
-	
+
 	public static AllOptions options = loadOptions();
-	
+
 	private static final String SettingsKey = "saved_settings";
-	
+
 	private static final String FE4Suffix = "_fe4";
 	private static final String FE6Suffix = "_fe6";
 	private static final String FE7Suffix = "_fe7";
 	private static final String FE8Suffix = "_fe8";
 	private static final String FE9Suffix = "_fe9";
-	
+
 	private static AllOptions loadOptions() {
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		String jsonString = prefs.get(SettingsKey, null);
@@ -101,11 +91,11 @@ public class OptionRecorder {
 			if (loadedOptions.fe7 != null && GBAOptionBundleVersion != loadedOptions.fe7.version) { loadedOptions.fe7 = null; }
 			if (loadedOptions.fe8 != null && GBAOptionBundleVersion != loadedOptions.fe8.version) { loadedOptions.fe8 = null; }
 			if (loadedOptions.fe9 != null && FE9OptionBundleVersion != loadedOptions.fe9.version) { loadedOptions.fe9 = null; }
-			
+
 			// Migrate to pieced JSON.
 			prefs.remove(SettingsKey);
 			saveOptions(loadedOptions);
-			
+
 			return loadedOptions;
 		} else {
 			AllOptions options = new AllOptions();
@@ -117,7 +107,7 @@ public class OptionRecorder {
 			return options;
 		}
 	}
-	
+
 	private static FE4OptionBundle loadFE4Options() {
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		String jsonString = prefs.get(SettingsKey + FE4Suffix, null);
@@ -132,16 +122,16 @@ public class OptionRecorder {
 			}
 			return FE4OptionBundleVersion != loadedOptions.version ? null : loadedOptions;
 		}
-		
+
 		return null;
 	}
-	
+
 	private static GBAOptionBundle loadFE6Options() {
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		String jsonString = prefs.get(SettingsKey + FE6Suffix, null);
 		if (jsonString != null) {
 			Gson gson = new Gson();
-			
+
 			GBAOptionBundle loadedOptions;
 			try {
 				loadedOptions = gson.fromJson(jsonString, GBAOptionBundle.class);
@@ -150,10 +140,10 @@ public class OptionRecorder {
 			}
 			return GBAOptionBundleVersion != loadedOptions.version ? null : loadedOptions;
 		}
-		
+
 		return null;
 	}
-	
+
 	private static GBAOptionBundle loadFE7Options() {
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		String jsonString = prefs.get(SettingsKey + FE7Suffix, null);
@@ -167,10 +157,10 @@ public class OptionRecorder {
 			}
 			return GBAOptionBundleVersion != loadedOptions.version ? null : loadedOptions;
 		}
-		
+
 		return null;
 	}
-	
+
 	private static GBAOptionBundle loadFE8Options() {
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		String jsonString = prefs.get(SettingsKey + FE8Suffix, null);
@@ -184,10 +174,10 @@ public class OptionRecorder {
 			}
 			return GBAOptionBundleVersion != loadedOptions.version ? null : loadedOptions;
 		}
-		
+
 		return null;
 	}
-	
+
 	private static FE9OptionBundle loadFE9Options() {
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
 		String jsonString = prefs.get(SettingsKey + FE9Suffix, null);
@@ -201,14 +191,14 @@ public class OptionRecorder {
 			}
 			return FE9OptionBundleVersion != loadedOptions.version ? null : loadedOptions;
 		}
-		
+
 		return null;
 	}
-	
+
 	private static void saveOptions(AllOptions options) {
 		Gson gson = new Gson();
 		Preferences prefs = Preferences.userRoot().node(OptionRecorder.class.getName());
-		
+
 		if (options.fe4 != null) {
 			String fe4String = gson.toJson(options.fe4);
 			prefs.put(SettingsKey + FE4Suffix, fe4String);
@@ -230,7 +220,7 @@ public class OptionRecorder {
 			prefs.put(SettingsKey + FE9Suffix, fe9String);
 		}
 	}
-	
+
 	public static void recordFE9Options(GrowthOptions growthOptions, BaseOptions baseOptions, FE9SkillsOptions skillOptions,
 			FE9OtherCharacterOptions otherOptions, FE9EnemyBuffOptions buffOptions, FE9ClassOptions classOptions, WeaponOptions weaponOptions,
 			MiscellaneousOptions miscOptions, String seed) {
@@ -245,13 +235,13 @@ public class OptionRecorder {
 		bundle.misc = miscOptions;
 		bundle.seed = seed;
 		bundle.version = FE9OptionBundleVersion;
-		
+
 		options.fe9 = bundle;
-		
+
 		saveOptions(options);
 	}
-	
-	public static void recordFE4Options(GrowthOptions growthOptions, BaseOptions basesOptions, HolyBloodOptions bloodOptions, SkillsOptions skillOptions, 
+
+	public static void recordFE4Options(GrowthOptions growthOptions, BaseOptions basesOptions, HolyBloodOptions bloodOptions, SkillsOptions skillOptions,
 			FE4ClassOptions classOptions, FE4PromotionOptions promoOptions, FE4EnemyBuffOptions buffOptions, MiscellaneousOptions miscOptions, String seed) {
 		FE4OptionBundle bundle = new FE4OptionBundle();
 		bundle.growths = growthOptions;
@@ -264,14 +254,14 @@ public class OptionRecorder {
 		bundle.misc = miscOptions;
 		bundle.seed = seed;
 		bundle.version = FE4OptionBundleVersion;
-		
+
 		options.fe4 = bundle;
-		
+
 		saveOptions(options);
 	}
-	
+
 	public static void recordGBAFEOptions(FEBase.GameType gameType, GrowthOptions growths, BaseOptions bases, ClassOptions classes, WeaponOptions weapons,
-			OtherCharacterOptions other, EnemyOptions enemies, MiscellaneousOptions otherOptions, RecruitmentOptions recruitment, ItemAssignmentOptions itemAssignment, CharacterShufflingOptions shufflingOptions, String seed) {
+			OtherCharacterOptions other, EnemyOptions enemies, MiscellaneousOptions otherOptions, RecruitmentOptions recruitment, ItemAssignmentOptions itemAssignment, CharacterShufflingOptions shufflingOptions, TerrainOptions terrainOptions, String seed) {
 		GBAOptionBundle bundle = new GBAOptionBundle();
 		bundle.growths = growths;
 		bundle.bases = bases;
@@ -282,10 +272,11 @@ public class OptionRecorder {
 		bundle.otherOptions = otherOptions;
 		bundle.recruitmentOptions = recruitment;
 		bundle.itemAssignmentOptions = itemAssignment;
+        bundle.terrainOptions = terrainOptions;
 		bundle.seed = seed;
 		bundle.version = GBAOptionBundleVersion;
 		bundle.characterShufflingOptions = shufflingOptions;
-		
+
 		switch (gameType) {
 		case FE6:
 			options.fe6 = bundle;
@@ -299,7 +290,7 @@ public class OptionRecorder {
 		default:
 			return;
 		}
-		
+
 		saveOptions(options);
 	}
 

--- a/Universal FE Randomizer/test/random/gba/randomizer/TerrainRandomizerTest.java
+++ b/Universal FE Randomizer/test/random/gba/randomizer/TerrainRandomizerTest.java
@@ -1,0 +1,46 @@
+package random.gba.randomizer;
+
+import fedata.TerrainTable;
+import fedata.TerrainTable.TerrainTableType;
+import fedata.general.FEBase;
+import org.junit.jupiter.api.BeforeEach;
+import random.gba.loader.TerrainDataLoader;
+
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class TerrainRandomizerTest {
+
+    TerrainDataLoader dataLoader;
+
+    @BeforeEach
+    public void before() {
+        Map<TerrainTableType, List<TerrainTable>> map = new HashMap<>();
+        List<TerrainTable> movementTables = new ArrayList<>();
+        // Hypothetical Infantry table
+        movementTables.add(new TerrainTable(1, new byte[]{1, 2, (byte) 255, 1, (byte) 255}, TerrainTableType.MOVEMENT));
+        // Hypothehical Flier table
+        movementTables.add(new TerrainTable(2, new byte[]{1, 1, (byte) 255, 1, 1}, TerrainTableType.MOVEMENT));
+        map.put(TerrainTableType.MOVEMENT, movementTables);
+        movementTables = new ArrayList<>();
+        // Hypothetical Infantry table
+        movementTables.add(new TerrainTable(3, new byte[]{1, 4, (byte) 255, 2, 4, (byte) 255}, TerrainTableType.MOVEMENT_RAIN));
+        // Hypothehical Flier table
+        movementTables.add(new TerrainTable(4, new byte[]{1, 2, (byte) 255, 2, 2, (byte) 2}, TerrainTableType.MOVEMENT_RAIN));
+
+        movementTables = new ArrayList<>();
+        // Hypothetical Infantry table
+        movementTables.add(new TerrainTable(5, new byte[]{1, 4, (byte) 255, 2, 4, (byte) 255}, TerrainTableType.MOVEMENT_RAIN));
+        // Hypothehical Flier table
+        movementTables.add(new TerrainTable(6, new byte[]{1, 2, (byte) 255, 2, 2, (byte) 2}, TerrainTableType.MOVEMENT_RAIN));
+
+        dataLoader = new TerrainDataLoader(FEBase.GameType.FE8, null, null, 5);
+    }
+
+
+}

--- a/Universal FE Randomizer/test/random/gba/randomizer/TerrainRandomizerTest.java
+++ b/Universal FE Randomizer/test/random/gba/randomizer/TerrainRandomizerTest.java
@@ -1,45 +1,284 @@
 package random.gba.randomizer;
 
-import fedata.TerrainTable;
-import fedata.TerrainTable.TerrainTableType;
+import fedata.gba.AbstractGBAData;
+import fedata.gba.general.TerrainTable;
+import fedata.gba.general.TerrainTable.TerrainTableType;
 import fedata.general.FEBase;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import random.gba.loader.TerrainDataLoader;
+import ui.model.MinMaxOption;
+import ui.model.TerrainOptions;
 
-import java.sql.Array;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockito.Mockito.mock;
 
 public class TerrainRandomizerTest {
 
     TerrainDataLoader dataLoader;
+    Random rng;
+
+    private final byte B255 = (byte) (255 & 0xFF);
+    private static final int[] RANDOMIZED_TILES = new int[] {1, 2, 4, 5};
+    private static final int[] NON_SAFE_TILES = new int[] {1};
+    private static final int[] SAFE_TILES = new int[] {4, 5};
+    private boolean keepSafeTiles = false;
 
     @BeforeEach
     public void before() {
-        Map<TerrainTableType, List<TerrainTable>> map = new HashMap<>();
-        List<TerrainTable> movementTables = new ArrayList<>();
-        // Hypothetical Infantry table
-        movementTables.add(new TerrainTable(1, new byte[]{1, 2, (byte) 255, 1, (byte) 255}, TerrainTableType.MOVEMENT));
-        // Hypothehical Flier table
-        movementTables.add(new TerrainTable(2, new byte[]{1, 1, (byte) 255, 1, 1}, TerrainTableType.MOVEMENT));
-        map.put(TerrainTableType.MOVEMENT, movementTables);
-        movementTables = new ArrayList<>();
-        // Hypothetical Infantry table
-        movementTables.add(new TerrainTable(3, new byte[]{1, 4, (byte) 255, 2, 4, (byte) 255}, TerrainTableType.MOVEMENT_RAIN));
-        // Hypothehical Flier table
-        movementTables.add(new TerrainTable(4, new byte[]{1, 2, (byte) 255, 2, 2, (byte) 2}, TerrainTableType.MOVEMENT_RAIN));
+        Map<TerrainTableType, List<TerrainTable>> dataMap = new HashMap<>();
+        List<TerrainTable> tables = new ArrayList<>();
+        // Regular Movement for Infantry + Flier
+        tables.add(new TerrainTable(1, new byte[]{B255, 1, 2, B255, 1, 2, B255}, TerrainTableType.MOVEMENT));
+        tables.add(new TerrainTable(2, new byte[]{B255, 1, 1, B255, 1, 1, 1}, TerrainTableType.MOVEMENT));
+        dataMap.put(TerrainTableType.MOVEMENT, tables);
 
-        movementTables = new ArrayList<>();
-        // Hypothetical Infantry table
-        movementTables.add(new TerrainTable(5, new byte[]{1, 4, (byte) 255, 2, 4, (byte) 255}, TerrainTableType.MOVEMENT_RAIN));
-        // Hypothehical Flier table
-        movementTables.add(new TerrainTable(6, new byte[]{1, 2, (byte) 255, 2, 2, (byte) 2}, TerrainTableType.MOVEMENT_RAIN));
+        // Rain Movement for Infantry + Flier
+        tables = new ArrayList<>();
+        tables.add(new TerrainTable(3, new byte[]{B255, 1, 4, B255, 2, 4, B255}, TerrainTableType.MOVEMENT_RAIN));
+        tables.add(new TerrainTable(4, new byte[]{B255, 1, 2, B255, 2, 2, 2}, TerrainTableType.MOVEMENT_RAIN));
+        dataMap.put(TerrainTableType.MOVEMENT_RAIN, tables);
 
-        dataLoader = new TerrainDataLoader(FEBase.GameType.FE8, null, null, 5);
+        // Snow Movement for Infantry + Flier
+        tables = new ArrayList<>();
+        tables.add(new TerrainTable(5, new byte[]{B255, 1, 4, B255, 2, 4, B255}, TerrainTableType.MOVEMENT_SNOW));
+        tables.add(new TerrainTable(6, new byte[]{B255, 1, 2, B255, 2, 2, (byte) 2}, TerrainTableType.MOVEMENT_SNOW));
+        dataMap.put(TerrainTableType.MOVEMENT_SNOW, tables);
+
+        // Healing and Status recovery, these ar universal
+        dataMap.put(TerrainTableType.HEALING, Arrays.asList(new TerrainTable(7, new byte[]{B255, 20, 0, 0, 0, 0, 0}, TerrainTableType.HEALING)));
+        dataMap.put(TerrainTableType.STATUS_RECOVERY, Arrays.asList(new TerrainTable(8, new byte[]{B255, 1, 0, 0, 0, 0, 0}, TerrainTableType.HEALING)));
+
+        // Defense for Infantry + Flier
+        tables = new ArrayList<>();
+        tables.add(new TerrainTable(9, new byte[]{B255, 2, 1, 0, 0, 0, 0}, TerrainTableType.DEF));
+        tables.add(new TerrainTable(10, new byte[]{B255, 0, 0, 0, 0, 0, 0}, TerrainTableType.DEF));
+        dataMap.put(TerrainTableType.DEF, tables);
+
+        // Defense for Infantry + Flier
+        tables = new ArrayList<>();
+        tables.add(new TerrainTable(11, new byte[]{B255, 5, 0, 0, 0, 0, 0}, TerrainTableType.RES));
+        tables.add(new TerrainTable(12, new byte[]{B255, 0, 0, 0, 0, 0, 0}, TerrainTableType.RES));
+        dataMap.put(TerrainTableType.RES, tables);
+
+        // Avoid for Infantry + Flier
+        tables = new ArrayList<>();
+        tables.add(new TerrainTable(13, new byte[]{B255, 50, 20, 0, 0, 0, 0}, TerrainTableType.AVOID));
+        tables.add(new TerrainTable(14, new byte[]{B255, 0, 0, 0, 0, 0, 0}, TerrainTableType.AVOID));
+        dataMap.put(TerrainTableType.AVOID, tables);
+
+        Map<Long, Boolean> applicableToFlier = new HashMap<>();
+        applicableToFlier.put(1L, false);
+        applicableToFlier.put(2L, true);
+        applicableToFlier.put(3L, false);
+        applicableToFlier.put(4L, true);
+        applicableToFlier.put(5L, false);
+        applicableToFlier.put(6L, true);
+        applicableToFlier.put(7L, true);
+        applicableToFlier.put(8L, true);
+        applicableToFlier.put(9L, false);
+        applicableToFlier.put(10L, true);
+        applicableToFlier.put(11L, false);
+        applicableToFlier.put(12L, true);
+        applicableToFlier.put(12L, false);
+        applicableToFlier.put(12L, true);
+        applicableToFlier.put(13L, false);
+        applicableToFlier.put(14L, true);
+
+        dataLoader = new TerrainDataLoader(FEBase.GameType.FE8, dataMap, applicableToFlier, 7);
+
+
+        rng = new Random(123456789);
+        burnRNs(4);
+    }
+
+    @Test
+    public void testKeepingSafeTiles() {
+        MinMaxOption minMax = new MinMaxOption(1, 3);
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeDef = true;
+        terrainOptions.defChance = 100;
+        terrainOptions.defRange = minMax;
+        terrainOptions.keepSafeTiles = true;
+        this.keepSafeTiles = true;
+
+        TerrainTable table = dataLoader.getTerrainTablesOfType(TerrainTableType.DEF).get(0);
+        byte[] expected = table.copyOriginalData();
+        prepareExpectedValues(expected, minMax);
+
+        new TerrainRandomizer(rng, dataLoader, terrainOptions).randomize();
+        validateStep(TerrainTableType.DEF, expected, minMax);
+    }
+
+    @Test
+    public void testStatusRecovery() {
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeStatusRecovery = true;
+        terrainOptions.statusRestoreChance = 100;
+
+        new TerrainRandomizer(rng, dataLoader, terrainOptions).randomize();
+        validateStep(TerrainTableType.STATUS_RECOVERY, new byte[]{B255, 1, 1, 0, 1, 1, 0}, null);
+    }
+
+    @Test
+    public void testHealing() {
+        MinMaxOption minMax = new MinMaxOption(10, 50);
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeHealing = true;
+        terrainOptions.healingChance = 100;
+        terrainOptions.healingRange = minMax;
+
+        TerrainTable healing = dataLoader.getTerrainTablesOfType(TerrainTableType.HEALING).get(0);
+        byte[] originalData = Arrays.copyOf(healing.getData(), healing.getData().length);
+
+        byte[] expected = Arrays.copyOf(originalData, originalData.length);
+        prepareExpectedValues(expected, minMax);
+
+
+        new TerrainRandomizer(new Random(123456789), dataLoader, terrainOptions).randomize();
+
+        validateStep(TerrainTableType.HEALING, expected, minMax);
+    }
+    @Test
+    public void testAvoid() {
+        MinMaxOption minMax = new MinMaxOption(10, 50);
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeAvoid = true;
+        terrainOptions.avoidChance = 100;
+        terrainOptions.avoidRange = minMax;
+
+        TerrainTable healing = dataLoader.getTerrainTablesOfType(TerrainTableType.AVOID).get(0);
+
+        byte[] expected = healing.copyOriginalData();
+        prepareExpectedValues(expected, minMax);
+
+
+        new TerrainRandomizer(new Random(123456789), dataLoader, terrainOptions).randomize();
+
+        validateStep(TerrainTableType.AVOID, expected, minMax);
+    }
+    @Test
+    public void testDefense() {
+        MinMaxOption minMax = new MinMaxOption(1, 4);
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeDef = true;
+        terrainOptions.defChance = 100;
+        terrainOptions.defRange = minMax;
+
+        TerrainTable healing = dataLoader.getTerrainTablesOfType(TerrainTableType.DEF).get(0);
+
+        byte[] expected = healing.copyOriginalData();
+        prepareExpectedValues(expected, minMax);
+
+
+        new TerrainRandomizer(new Random(123456789), dataLoader, terrainOptions).randomize();
+
+        validateStep(TerrainTableType.DEF, expected, minMax);
+    }
+    @Test
+    public void testResistance() {
+        MinMaxOption minMax = new MinMaxOption(3, 5);
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeRes = true;
+        terrainOptions.resChance = 100;
+        terrainOptions.resRange = minMax;
+
+        TerrainTable healing = dataLoader.getTerrainTablesOfType(TerrainTableType.RES).get(0);
+
+        byte[] expected = healing.copyOriginalData();
+        prepareExpectedValues(expected, minMax);
+
+
+        new TerrainRandomizer(new Random(123456789), dataLoader, terrainOptions).randomize();
+
+        validateStep(TerrainTableType.RES, expected, minMax);
+    }
+    @Test
+    public void testMinMaxEqual() {
+        MinMaxOption minMax = new MinMaxOption(5, 5);
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.effectChance = 100;
+        terrainOptions.randomizeDef = true;
+        terrainOptions.defChance = 100;
+        terrainOptions.defRange = minMax;
+
+        TerrainTable healing = dataLoader.getTerrainTablesOfType(TerrainTableType.DEF).get(0);
+
+        byte[] expected = healing.copyOriginalData();
+        prepareExpectedValues(expected, minMax);
+
+
+        new TerrainRandomizer(new Random(123456789), dataLoader, terrainOptions).randomize();
+
+        validateStep(TerrainTableType.DEF, expected, minMax);
+    }
+
+    public void validateStep(TerrainTableType tableType, byte[] expected, MinMaxOption minMax) {
+        validateStep(tableType, expected, minMax, 0);
+    }
+
+    public void validateStep(TerrainTableType tableType, byte[] expected, MinMaxOption minMax, int tableNumber) {
+        TerrainTable table = dataLoader.getTerrainTablesOfType(tableType).get(tableNumber);
+//        Assertions.assertNotEquals(healing.getData(), healing.getOriginalDataCopy());
+        Assertions.assertArrayEquals(expected, table.getData());
+
+        int[] tiles = this.keepSafeTiles ? NON_SAFE_TILES : RANDOMIZED_TILES;
+
+        if (minMax != null) {
+            for (int tile : tiles) {
+                int data = table.dataAtIndex(tile);
+                Assertions.assertTrue(minMax.maxValue >= data && minMax.minValue <= data, "Value outside of range");
+            }
+        }
+
+    }
+
+    public void burnRNs(int number) {
+        for (int i = 0; i < number; i++) {
+            rng.nextInt();
+        }
+    }
+
+    public void prepareExpectedValues(byte[] targetArray, MinMaxOption minMax) {
+        // Discard one RN and then save the next one 4 times each.
+        // The first RN is the check if the tile gets the healing effect.
+        // The Second RN is the healing value it gains
+        int[] tiles = this.keepSafeTiles ? NON_SAFE_TILES : RANDOMIZED_TILES;
+        for (int i : tiles) {
+            int chanceNumber = rng.nextInt(); // Discard one value used for the chance
+            int variance = minMax.maxValue - minMax.minValue;
+            int newValue = (variance != 0 ? rng.nextInt(minMax.maxValue - minMax.minValue) : 0) + minMax.minValue;
+            targetArray[i] = AbstractGBAData.asByte(newValue);
+        }
+    }
+
+
+    TerrainOptions getFullOptions() {
+        TerrainOptions terrainOptions = new TerrainOptions();
+        terrainOptions.randomizeDef = true;
+        terrainOptions.defChance = 20;
+        terrainOptions.defRange = new MinMaxOption(1, 3);
+        terrainOptions.randomizeRes = true;
+        terrainOptions.resChance = 10;
+        terrainOptions.resRange = new MinMaxOption(3, 5);
+        terrainOptions.randomizeAvoid = true;
+        terrainOptions.avoidRange = new MinMaxOption(10, 50);
+        terrainOptions.healingChance = 10;
+        terrainOptions.healingRange = new MinMaxOption(10, 30);
+        terrainOptions.randomizeHealing = true;
+        terrainOptions.randomizeStatusRecovery = true;
+        terrainOptions.statusRestoreChance = 10;
+        terrainOptions.effectChance = 100;
+
+        return terrainOptions;
     }
 
 


### PR DESCRIPTION
This is a bit of a cursed setting, but it wasn't too difficult to implement so here we go :D

Adds the ability to randomize the Terrain Bonuses, i.e. Avoid / Def / Res / Healing / Status recovery. Also an option to keep basic tiles like plains (i.e. ones that in vanilla have no effects) the same as they usually are.

![grafik](https://github.com/lushen124/Universal-FE-Randomizer/assets/41942612/089e7c7d-ccb8-4a44-b900-2b72749ea91e)


Most of the backend groundwork for Movecost Randomization is also laid, I just thought it would be absolutely not enjoyable so I didn't make it accessible for now. Might be wrong ofcourse.