### PR TITLE
Added Shop Randomization option

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFEItemData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEItemData.java
@@ -55,6 +55,9 @@ public interface GBAFEItemData extends FEModifiableData, FEPrintableData {
 	public int getMinRange();
 	public int getMaxRange();
 	
+	public int getCostPerUse();
+	public void setCostPerUse(int cost);
+	
 	public WeaponRank getWeaponRank();
 	
 	public boolean hasWeaponEffect();

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -107,6 +107,7 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public static final GBAFEStatboostProvider statboostProvider = sharedInstance;
 	public static final GBAFEShufflingDataProvider shufflingDataProvider = sharedInstance;
 	public static final GBAFETextProvider textProvider = sharedInstance;
+	public static final GBAFEShopProvider shopProvider = sharedInstance;
 	
 	public enum CharacterAndClassAbility1Mask {
 		USE_MOUNTED_AID(0x1), CANTO(0x2), STEAL(0x4), USE_LOCKPICKS(0x8),
@@ -990,6 +991,7 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 				HALBERD, TOMAHAWK, POISON_BOW, KILLER_BOW, BRAVE_BOW, SHORT_BOW, LONGBOW, THUNDER, AIRCALIBUR, BOLTING, PURGE, NOSFERATU, ECLIPSE, PHYSIC, FORTIFY, RESTORE, WARP, RESCUE, TORCH_STAFF, HAMMERNE, UNLOCK, BARRIER,
 				SILENCE, SLEEP, BERSERK, HOLY_MAIDEN));
 		public static Set<Item> promoSet = new HashSet<Item>(Arrays.asList());
+		public static Set<Item> legendaryWeapons = new HashSet<Item>(Arrays.asList(DURANDAL, MALTET, ARMADS, MURGLEIS, FORBLAZE, APOCALYPSE, HOLY_MAIDEN, AUREOLA));
 		
 		public static Set<Item> playerOnlySet = new HashSet<Item>(Arrays.asList(TORCH_STAFF, UNLOCK, RESTORE, HAMMERNE, BARRIER, RESCUE, WARP, TINA_STAFF));
 		
@@ -1008,6 +1010,8 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		public static Set<Item> allBasicWeapons = new HashSet<Item>(Arrays.asList(IRON_SWORD, IRON_LANCE, IRON_AXE, IRON_BOW, FIRE, LIGHTNING, FLUX));
 		public static Set<Item> allSteelWeapons = new HashSet<Item>(Arrays.asList(STEEL_SWORD, STEEL_LANCE, STEEL_AXE, STEEL_BOW, THUNDER));
 		public static Set<Item> allBasicThrownWeapons = new HashSet<Item>(Arrays.asList(JAVELIN, HAND_AXE));
+		
+		public static Set<Item> vendorItems = new HashSet<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY, VULNERARY, PURE_WATER, ANTITOXIN, TORCH));
 		
 		public static Set<Item> basicItemsOfType(WeaponType type) {
 			Set<Item> set = new HashSet<Item>();
@@ -1688,8 +1692,53 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			case CHAPTER_23_VENDOR_2:
 				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_23_VENDOR_1, CHAPTER_23_VENDOR_2));
 			default:
-				return null;
+				return new HashSet<GBAFEShop>(Arrays.asList(this));
 			}
+		}
+		
+		public GameStage getGameStage() {
+			switch (this) {
+			case CHAPTER_2_VENDOR:
+			case CHAPTER_2_ARMORY:
+			case CHAPTER_4_VENDOR:
+			case CHAPTER_4_ARMORY:
+			case CHAPTER_5_VENDOR:
+			case CHAPTER_7_VENDOR:
+			case CHAPTER_7_ARMORY_1:
+			case CHAPTER_7_ARMORY_2:
+				return GameStage.EARLY;
+			case CHAPTER_9_ARMORY:
+			case CHAPTER_9_VENDOR:
+			case CHAPTER_10B_ARMORY:
+			case CHAPTER_11A_ARMORY:
+			case CHAPTER_11A_VENDOR:
+			case CHAPTER_11B_VENDOR:
+			case CHAPTER_13_ARMORY:
+			case CHAPTER_13_VENDOR:
+			case CHAPTER_14_ARMORY:
+			case CHAPTER_14_VENDOR:
+			case CHAPTER_15_VENDOR:
+			case CHAPTER_16_SECRET:
+				return GameStage.MID;
+			case CHAPTER_17A_ARMORY:
+			case CHAPTER_17B_ARMORY:
+			case CHAPTER_18B_ARMORY:
+			case CHAPTER_18B_VENDOR:
+			case CHAPTER_19A_VENDOR:
+			case CHAPTER_19B_ARMORY:
+			case CHAPTER_19B_VENDOR:
+			case CHAPTER_20A_ARMORY:
+			case CHAPTER_20A_VENDOR:
+			case CHAPTER_21_ARMORY:
+			case CHAPTER_21_SECRET:
+			case CHAPTER_21_VENDOR:
+			case CHAPTER_23_ARMORY_2:
+			case CHAPTER_23_ARMORY_1:
+			case CHAPTER_23_VENDOR_1:
+			case CHAPTER_23_VENDOR_2:
+				return GameStage.LATE;
+			}
+			return GameStage.LATE;
 		}
 		
 		public long getPointerOffset() {
@@ -2615,6 +2664,10 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		return new HashSet<GBAFEItem>(equalRankWeapons);
 	}
 	
+	public Set<GBAFEItem> weaponsOfRank(WeaponRank rank) {
+		return new HashSet<GBAFEItem>(Item.weaponsOfRank(rank));
+	}
+	
 	public Set<GBAFEItem> healingStaves(WeaponRank maxRank) {
 		Set<Item> staves = Item.allHealingStaves;
 		return new HashSet<GBAFEItem>(staves);
@@ -2890,6 +2943,46 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	
 	public Set<GBAFEItem> rareDrops() {
 		return new HashSet<GBAFEItem>(Item.rareDrops);
+	}
+	
+	public Set<GBAFEItem> vendorItems(boolean rare) {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>(Item.vendorItems);
+		if (rare) {
+			items.add(Item.ELIXIR);
+		}
+		
+		return items;
+	}
+	
+	public Set<GBAFEItem> secretItems() {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>();
+		items.addAll(Item.allPromotionItems);
+		items.addAll(Item.reaverSet);
+		items.addAll(Item.braveSet);
+		items.addAll(Item.killerSet);
+		items.addAll(Item.allSiegeTomes);
+		
+		items.add(Item.ELIXIR);
+		items.add(Item.PHYSIC);
+		items.add(Item.RESCUE);
+		items.add(Item.FORTIFY);
+		
+		items.add(Item.RAPIER);
+		items.add(Item.WO_DAO);
+		items.add(Item.LIGHT_BRAND);
+		return items;
+	}
+	public Set<GBAFEItem> rareSecretItems() {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>();
+		items.addAll(Item.allStatBoosters);
+		items.add(Item.HAMMERNE);
+		items.add(Item.WARP);
+		items.add(Item.RUNE_SWORD);
+		return items;
+	}
+	
+	public Set<GBAFEItem> disallowedWeaponsInShops() {
+		return new HashSet<GBAFEItem>(Item.legendaryWeapons);
 	}
 
 	public String statBoostStringForWeapon(GBAFEItem weapon) {
@@ -3170,4 +3263,10 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public Set<GBAFEShop> allSecretShops() {
 		return new HashSet<GBAFEShop>(Shops.allSecretShops());
 	}
+	
+	public List<GBAFEShop> orderedShops() {
+		return new ArrayList<GBAFEShop>(Arrays.asList(Shops.values()));
+	}
+	
+	public Boolean isMapShop(GBAFEShop shop) { return false; }
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -16,8 +16,22 @@ import fedata.gba.GBAFECharacterData.Affinity;
 import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
-import fedata.gba.fe8.FE8Data.CharacterClass;
 import fedata.gba.general.*;
+import fedata.gba.general.CharacterNudge;
+import fedata.gba.general.GBAFEChapterMetadataChapter;
+import fedata.gba.general.GBAFECharacter;
+import fedata.gba.general.GBAFECharacterProvider;
+import fedata.gba.general.GBAFEClass;
+import fedata.gba.general.GBAFEClassProvider;
+import fedata.gba.general.GBAFEItem;
+import fedata.gba.general.GBAFEItemProvider;
+import fedata.gba.general.GBAFEPromotionItem;
+import fedata.gba.general.GBAFEShop;
+import fedata.gba.general.GBAFEShopProvider;
+import fedata.gba.general.PaletteColor;
+import fedata.gba.general.PaletteInfo;
+import fedata.gba.general.WeaponRank;
+import fedata.gba.general.WeaponType;
 import random.gba.loader.ItemDataLoader.AdditionalData;
 import random.gba.randomizer.shuffling.GBAFEShufflingDataProvider;
 import random.gba.randomizer.shuffling.data.FE6PortraitData;
@@ -25,7 +39,7 @@ import random.gba.randomizer.shuffling.data.GBAFEPortraitData;
 import util.AddressRange;
 import util.WhyDoesJavaNotHaveThese;
 
-public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAFEItemProvider, GBAFEShufflingDataProvider, GBAFETextProvider, GBAFEStatboostProvider {
+public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAFEItemProvider, GBAFEShufflingDataProvider, GBAFETextProvider, GBAFEStatboostProvider, GBAFEShopProvider {
 	public static final String FriendlyName = "ファイアーエムブレム　封印の剣";
 	public static final String GameCode = "AFEJ";
 
@@ -1600,6 +1614,93 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		}
 	}
 	
+	public enum Shops implements GBAFEShop {
+		
+		CHAPTER_2_VENDOR(0x6677F8L, 0x66A81CL),
+		CHAPTER_2_ARMORY(0x667804L, 0x66A820L),
+		CHAPTER_4_VENDOR(0x667A3CL, 0x66A82AL),
+		CHAPTER_4_ARMORY(0x667A48L, 0x66A832L),
+		CHAPTER_5_VENDOR(0x667B4CL, 0x66A844L),
+		CHAPTER_7_VENDOR(0x667F40L, 0x66A86CL),
+		CHAPTER_7_ARMORY_1(0x667F28L, 0x66A84EL),
+		CHAPTER_7_ARMORY_2(0x667F34L, 0x66A85EL),
+		CHAPTER_9_VENDOR(0x6681F0L, 0x66A890L),
+		CHAPTER_9_ARMORY(0x6681E4L, 0x66A87CL),
+		CHAPTER_10B_ARMORY(0x6698B0L, 0x66AA4EL),
+		CHAPTER_11A_ARMORY(0x668554L, 0x66A8A0L),
+		CHAPTER_11A_VENDOR(0x668560L, 0x66A8B8L),
+		CHAPTER_11B_VENDOR(0x6699FCL, 0x66AA64L),
+		CHAPTER_13_ARMORY(0x66881CL, 0x66A8CAL),
+		CHAPTER_13_VENDOR(0x668828L, 0x66A8E0L),
+		CHAPTER_14_ARMORY(0x668950L, 0x66A8F8L),
+		CHAPTER_14_VENDOR(0x66895CL, 0x66A904L),
+		CHAPTER_15_VENDOR(0x668AB4L, 0x66A918L),
+		CHAPTER_16_SECRET(0x668C3CL, 0x66A92AL),
+		CHAPTER_17A_ARMORY(0x668D4CL, 0x66A93AL),
+		CHAPTER_17B_ARMORY(0x669B18L, 0x66AA76L),
+		CHAPTER_18B_ARMORY(0x669BF8L, 0x66AA98L),
+		CHAPTER_18B_VENDOR(0x669C04L, 0x66AAB0L),
+		CHAPTER_19A_VENDOR(0x668FB4L, 0x66A956L),
+		CHAPTER_19B_ARMORY(0x669DE0L, 0x66AAC4L),
+		CHAPTER_19B_VENDOR(0x669DECL, 0x66AAE4L),
+		CHAPTER_20A_ARMORY(0x669100L, 0x66A96AL),
+		CHAPTER_20A_VENDOR(0x66910CL, 0x66A98AL),
+		CHAPTER_21_ARMORY(0x6692A0L, 0x66A99EL),
+		CHAPTER_21_VENDOR(0x6692ACL, 0x66A9B0L),
+		CHAPTER_21_SECRET(0x6692B8L, 0x66A9C8L),
+		CHAPTER_23_ARMORY_1(0x669544L, 0x66A9ECL),
+		CHAPTER_23_ARMORY_2(0x669550L, 0x66AA12L),
+		CHAPTER_23_VENDOR_1(0x66955CL, 0x66AA2AL),
+		CHAPTER_23_VENDOR_2(0x669568L, 0x66AA3CL)
+		;
+		
+		long pointerOffset;
+		long originalShopAddress;
+		
+		private Shops(final long pointerOffset, final long originalShopList) {
+			this.pointerOffset = pointerOffset;
+			this.originalShopAddress = originalShopList;
+		}
+		
+		public static Set<Shops> allVendors() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_2_VENDOR, CHAPTER_4_VENDOR, CHAPTER_5_VENDOR, CHAPTER_7_VENDOR, CHAPTER_9_VENDOR, CHAPTER_11A_VENDOR, CHAPTER_11B_VENDOR, CHAPTER_13_VENDOR, CHAPTER_14_VENDOR, CHAPTER_15_VENDOR,
+					CHAPTER_18B_VENDOR, CHAPTER_19A_VENDOR, CHAPTER_19B_VENDOR, CHAPTER_20A_VENDOR, CHAPTER_21_VENDOR, CHAPTER_23_VENDOR_1, CHAPTER_23_VENDOR_2));
+		}
+		
+		public static Set<Shops> allArmories() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_2_ARMORY, CHAPTER_4_ARMORY, CHAPTER_7_ARMORY_1, CHAPTER_7_ARMORY_2, CHAPTER_9_ARMORY, CHAPTER_10B_ARMORY, CHAPTER_11A_ARMORY, CHAPTER_13_ARMORY, CHAPTER_14_ARMORY, CHAPTER_17A_ARMORY,
+					CHAPTER_17B_ARMORY, CHAPTER_18B_ARMORY, CHAPTER_19B_ARMORY, CHAPTER_20A_ARMORY, CHAPTER_21_ARMORY, CHAPTER_23_ARMORY_1, CHAPTER_23_ARMORY_2));
+		}
+		
+		public static Set<Shops> allSecretShops() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_16_SECRET, CHAPTER_21_SECRET));
+		}
+		
+		public Set<GBAFEShop> groupedShops() {
+			switch(this) {
+			case CHAPTER_7_ARMORY_1:
+			case CHAPTER_7_ARMORY_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_7_ARMORY_1, CHAPTER_7_ARMORY_2));
+			case CHAPTER_23_ARMORY_1:
+			case CHAPTER_23_ARMORY_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_23_ARMORY_1, CHAPTER_23_ARMORY_2));
+			case CHAPTER_23_VENDOR_1:
+			case CHAPTER_23_VENDOR_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_23_VENDOR_1, CHAPTER_23_VENDOR_2));
+			default:
+				return null;
+			}
+		}
+		
+		public long getPointerOffset() {
+			return pointerOffset;
+		}
+		
+		public long getOriginalShopAddress() {
+			return originalShopAddress;
+		}
+	}
+	
 	public enum Palette {
 		
 		LORD_ROY(0x01, Character.ROY.ID, CharacterClass.LORD.ID, 0x7FC800),
@@ -3052,5 +3153,21 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	@Override
 	public int getNumberEntries() {
 		return 20;
+	}
+	
+	public Set<GBAFEShop> allShops() {
+		return new HashSet<GBAFEShop>(Arrays.asList(Shops.values()));
+	}
+	
+	public Set<GBAFEShop> allVendors() {
+		return new HashSet<GBAFEShop>(Shops.allVendors());
+	}
+	
+	public Set<GBAFEShop> allArmories() {
+		return new HashSet<GBAFEShop>(Shops.allArmories());
+	}
+	
+	public Set<GBAFEShop> allSecretShops() {
+		return new HashSet<GBAFEShop>(Shops.allSecretShops());
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Item.java
@@ -271,6 +271,17 @@ public class FE6Item implements GBAFEItemData {
 		wasModified = true;
 	}
 	
+	public int getCostPerUse() {
+		return WhyDoesJavaNotHaveThese.intValueFromByteSubarray(data, 26, 2, true);
+	}
+	
+	public void setCostPerUse(int costPerUse) {
+		byte[] costData = WhyDoesJavaNotHaveThese.byteArrayFromLongValue(costPerUse, true, 2);
+		data[26] = costData[0];
+		data[27] = costData[1];
+		wasModified = true;
+ 	}
+	
 	public void applyRandomEffect(WeightedDistributor<WeaponEffects> allowedEffects, ItemDataLoader itemData, TextLoader textData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
 		if (getType() == WeaponType.NOT_A_WEAPON) {
 			return;

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -16,15 +16,29 @@ import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
 import fedata.gba.GBAFECharacterData.Affinity;
-import fedata.gba.fe8.FE8Data.Character;
 import fedata.gba.general.*;
+import fedata.gba.fe6.FE6Data.Shops;
+import fedata.gba.general.GBAFEChapterMetadataChapter;
+import fedata.gba.general.GBAFECharacter;
+import fedata.gba.general.GBAFECharacterProvider;
+import fedata.gba.general.GBAFEClass;
+import fedata.gba.general.GBAFEClassProvider;
+import fedata.gba.general.GBAFEItem;
+import fedata.gba.general.GBAFEItemProvider;
+import fedata.gba.general.GBAFEPromotionItem;
+import fedata.gba.general.GBAFEShop;
+import fedata.gba.general.GBAFEShopProvider;
+import fedata.gba.general.PaletteColor;
+import fedata.gba.general.PaletteInfo;
+import fedata.gba.general.WeaponRank;
+import fedata.gba.general.WeaponType;
 import random.gba.loader.ItemDataLoader.AdditionalData;
 import random.gba.randomizer.shuffling.GBAFEShufflingDataProvider;
 import random.gba.randomizer.shuffling.data.GBAFEPortraitData;
 import util.AddressRange;
 import util.WhyDoesJavaNotHaveThese;
 
-public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAFEItemProvider, GBAFEShufflingDataProvider, GBAFETextProvider, GBAFEStatboostProvider {
+public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAFEItemProvider, GBAFEShufflingDataProvider, GBAFETextProvider, GBAFEStatboostProvider, GBAFEShopProvider {
 
 	public static final String FriendlyName = "Fire Emblem: Blazing Sword";
 	public static final String GameCode = "AE7E";
@@ -2042,6 +2056,132 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		}
 	}
 	
+	public enum Shops implements GBAFEShop {
+		
+		CHAPTER_3_ARMORY(0xCA8B98L, 0xCA6F3CL),
+		CHAPTER_5_ARMORY(0xCA0F38L, 0xCA6F42L),
+		CHAPTER_7_VENDOR(0xCA130CL, 0xCA6F4AL),
+		CHAPTER_8_ARMORY(0xCA1504L, 0xCA6F52L),
+		CHAPTER_10_ARMORY(0xCA187CL, 0xCA6F5CL),
+		CHAPTER_10_VENDOR(0xCA1888L, 0xCA6F66L),
+		CHAPTER_11_VENDOR(0xCA1958L, 0xCA6F72L),
+		CHAPTER_12_ARMORY(0xCA1B4CL, 0xCA6F76L),
+		CHAPTER_12_VENDOR(0xCA1B58L, 0xCA6F7AL),
+		CHAPTER_13_ARMORY(0xCA1D24L, 0xCA6F84L),
+		CHAPTER_13_VENDOR(0xCA1D30L, 0xCA6F8EL),
+		CHAPTER_14_ARMORY(0xCA218CL, 0xCA6F94L),
+		CHAPTER_14_VENDOR(0xCA2198L, 0xCA6F9EL),
+		CHAPTER_16_ARMORY_1(0xCA25C0L, 0xCA6FA6L),
+		CHAPTER_16_ARMORY_2(0xCA25CCL, 0xCA6FB4L),
+		CHAPTER_16_VENDOR(0xCA25D8L, 0xCA6FC2L),
+		CHAPTER_17X_VENDOR(0xCA2A24L, 0xCA6FCCL),
+		CHAPTER_18_ARMORY(0xCA2C64L, 0xCA6FD8L),
+		CHAPTER_18_VENDOR(0xCA2C70L, 0xCA6FEAL),
+		CHAPTER_20_SECRET_1(0xCA344CL, 0xCA6FFCL),
+		CHAPTER_20_SECRET_2(0xCA3458L, 0xCA700CL),
+		CHAPTER_21_ARMORY_1(0xCA374CL, 0xCA7022L),
+		CHAPTER_21_VENDOR_1(0xCA3764L, 0xCA703AL),
+		CHAPTER_21_ARMORY_2(0xCA3740L, 0xCA7018L),
+		CHAPTER_21_VENDOR_2(0xCA3758L, 0xCA7030L),
+		CHAPTER_22_SECRET(0xCA3764L, 0xCA703AL),
+		CHAPTER_24A_ARMORY_1(0xCA4214L, 0xCA7068L),
+		CHAPTER_24A_VENDOR_1(0xCA4220L, 0xCA7076L),
+		CHAPTER_24A_ARMORY_2(0xCA4208L, 0xCA7058L),
+		CHAPTER_24A_VENDOR_2(0xCA422CL, 0xCA7082L),
+		CHAPTER_24A_SECRET(0xCA4238L, 0xCA708CL),
+		CHAPTER_24B_ARMORY_1(0xCA4518L, 0xCA709AL),
+		CHAPTER_24B_VENDOR_1(0xCA4530L, 0xCA70B8L),
+		CHAPTER_24B_ARMORY_2(0xCA4524L, 0xCA70AAL),
+		CHAPTER_24B_VENDOR_2(0xCA453CL, 0xCA70C2L),
+		CHAPTER_24B_SECRET(0xCA4548L, 0xCA70CEL),
+		CHAPTER_25_ARMORY(0xCA471CL, 0xCA70DEL),
+		CHAPTER_25_VENDOR(0xCA4728L, 0xCA70E8L),
+		CHAPTER_26_ARMORY(0xCA4928L, 0xCA70F2L),
+		CHAPTER_26_VENDOR(0xCA4934L, 0xCA7100L),
+		CHAPTER_29_ARMORY(0xCA5A28L, 0xCA710CL),
+		CHAPTER_29_VENDOR(0xCA5A34L, 0xCA711EL),
+		CHAPTER_31_SECRET(0xCA5EA0L, 0xCA7130L),
+		CHAPTER_31X_ARMORY_1(0xCA601CL, 0xCA7168L),
+		CHAPTER_31X_VENDOR_1(0xCA6028L, 0xCA7176L),
+		CHAPTER_31X_VENDOR_2(0xCA6034L, 0xCA7186L),
+		CHAPTER_31X_ARMORY_2(0xCA5FF8L, 0xCA713CL),
+		CHAPTER_31X_ARMORY_3(0xCA6004L, 0xCA714AL),
+		CHAPTER_31X_ARMORY_4(0xCA6010L, 0xCA715AL),
+		CHAPTER_32_SECRET(0xCA63ACL, 0xCA7198L)
+		;
+		
+		long pointerOffset;
+		long originalShopAddress;
+		
+		private Shops(final long pointerOffset, final long originalShopList) {
+			this.pointerOffset = pointerOffset;
+			this.originalShopAddress = originalShopList;
+		}
+		
+		public static Set<Shops> allVendors() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_7_VENDOR, CHAPTER_10_VENDOR, CHAPTER_11_VENDOR, CHAPTER_12_VENDOR, CHAPTER_13_VENDOR, CHAPTER_14_VENDOR, CHAPTER_16_VENDOR, CHAPTER_17X_VENDOR, CHAPTER_18_VENDOR, CHAPTER_21_VENDOR_1,
+					CHAPTER_21_VENDOR_2, CHAPTER_24A_VENDOR_1, CHAPTER_24A_VENDOR_2, CHAPTER_24B_VENDOR_1, CHAPTER_24B_VENDOR_2, CHAPTER_25_VENDOR, CHAPTER_26_VENDOR, CHAPTER_29_VENDOR, CHAPTER_31X_VENDOR_1, CHAPTER_31X_VENDOR_2));
+		}
+		
+		public static Set<Shops> allArmories() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_3_ARMORY, CHAPTER_5_ARMORY, CHAPTER_8_ARMORY, CHAPTER_10_ARMORY, CHAPTER_12_ARMORY, CHAPTER_13_ARMORY, CHAPTER_14_ARMORY, CHAPTER_16_ARMORY_1, CHAPTER_16_ARMORY_2, CHAPTER_18_ARMORY,
+					CHAPTER_21_ARMORY_1, CHAPTER_21_ARMORY_2, CHAPTER_24A_ARMORY_1, CHAPTER_24A_ARMORY_2, CHAPTER_24B_ARMORY_1, CHAPTER_24B_ARMORY_2, CHAPTER_25_ARMORY, CHAPTER_26_ARMORY, CHAPTER_29_ARMORY, CHAPTER_31X_ARMORY_1, CHAPTER_31X_ARMORY_2,
+					CHAPTER_31X_ARMORY_3, CHAPTER_31X_ARMORY_4
+					));
+		}
+		
+		public static Set<Shops> allSecretShops() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_20_SECRET_1, CHAPTER_20_SECRET_2, CHAPTER_22_SECRET, CHAPTER_24A_SECRET, CHAPTER_24B_SECRET, CHAPTER_31_SECRET, CHAPTER_32_SECRET));
+		}
+		
+		public Set<GBAFEShop> groupedShops() {
+			switch (this) {
+			case CHAPTER_16_ARMORY_1:
+			case CHAPTER_16_ARMORY_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_16_ARMORY_1, CHAPTER_16_ARMORY_2));
+			case CHAPTER_20_SECRET_1:
+			case CHAPTER_20_SECRET_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_20_SECRET_1, CHAPTER_20_SECRET_2));
+			case CHAPTER_21_ARMORY_1:
+			case CHAPTER_21_ARMORY_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_21_ARMORY_1, CHAPTER_21_ARMORY_2));
+			case CHAPTER_21_VENDOR_1:
+			case CHAPTER_21_VENDOR_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_21_VENDOR_1, CHAPTER_21_VENDOR_2));
+			case CHAPTER_24A_ARMORY_1:
+			case CHAPTER_24A_ARMORY_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_24A_ARMORY_1, CHAPTER_24A_ARMORY_2));
+			case CHAPTER_24A_VENDOR_1:
+			case CHAPTER_24A_VENDOR_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_24A_VENDOR_1, CHAPTER_24A_VENDOR_2));
+			case CHAPTER_24B_ARMORY_1:
+			case CHAPTER_24B_ARMORY_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_24B_ARMORY_1, CHAPTER_24B_ARMORY_2));
+			case CHAPTER_24B_VENDOR_1:
+			case CHAPTER_24B_VENDOR_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_24B_VENDOR_1, CHAPTER_24B_VENDOR_2));
+			case CHAPTER_31X_ARMORY_1:
+			case CHAPTER_31X_ARMORY_2:
+			case CHAPTER_31X_ARMORY_3:
+			case CHAPTER_31X_ARMORY_4:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_31X_ARMORY_1, CHAPTER_31X_ARMORY_2, CHAPTER_31X_ARMORY_3, CHAPTER_31X_ARMORY_4));
+			case CHAPTER_31X_VENDOR_1:
+			case CHAPTER_31X_VENDOR_2:
+				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_31X_VENDOR_1, CHAPTER_31X_VENDOR_2));
+			default:
+				return null;
+			}
+		}
+		
+		public long getPointerOffset() {
+			return pointerOffset;
+		}
+		
+		public long getOriginalShopAddress() {
+			return originalShopAddress;
+		}
+	}
+	
 	public enum Palette {
 		
 		ARCHER_WIL(0x03, Character.WIL.ID, CharacterClass.ARCHER.ID, 0xFD90B4),
@@ -3637,5 +3777,21 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	@Override
 	public int getNumberEntries() {
 		return 16;
+	}
+	
+	public Set<GBAFEShop> allShops() {
+		return new HashSet<GBAFEShop>(Arrays.asList(Shops.values()));
+	}
+	
+	public Set<GBAFEShop> allVendors() {
+		return new HashSet<GBAFEShop>(Shops.allVendors());
+	}
+	
+	public Set<GBAFEShop> allArmories() {
+		return new HashSet<GBAFEShop>(Shops.allArmories());
+	}
+	
+	public Set<GBAFEShop> allSecretShops() {
+		return new HashSet<GBAFEShop>(Shops.allSecretShops());
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -158,6 +158,7 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public static final GBAFEStatboostProvider statboostProvider = sharedInstance;
 	public static final GBAFEShufflingDataProvider shufflingDataProvider = sharedInstance;
 	public static final GBAFETextProvider textProvider = sharedInstance;
+	public static final GBAFEShopProvider shopProvider = sharedInstance;
 	
 	public enum CharacterAndClassAbility1Mask {
 		USE_MOUNTED_AID(0x1), CANTO(0x2), STEAL(0x4), USE_LOCKPICKS(0x8),
@@ -1264,6 +1265,8 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		public static Set<Item> allSteelWeapons = new HashSet<Item>(Arrays.asList(STEEL_SWORD, STEEL_LANCE, STEEL_AXE, STEEL_BOW, THUNDER));
 		public static Set<Item> allBasicThrownWeapons = new HashSet<Item>(Arrays.asList(JAVELIN, HAND_AXE));
 		
+		public static Set<Item> vendorItems = new HashSet<Item>(Arrays.asList(CHEST_KEY, CHEST_KEY_5, DOOR_KEY, LOCKPICK, VULNERARY, PURE_WATER, ANTITOXIN, TORCH));
+		
 		public static Set<Item> basicItemsOfType(WeaponType type) {
 			Set<Item> set = new HashSet<Item>();
 			set.addAll(weaponsOfType(type));
@@ -2058,15 +2061,15 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	
 	public enum Shops implements GBAFEShop {
 		
-		CHAPTER_3_ARMORY(0xCA8B98L, 0xCA6F3CL),
+		CHAPTER_3_ARMORY(0xCA0B98L, 0xCA6F3CL),
 		CHAPTER_5_ARMORY(0xCA0F38L, 0xCA6F42L),
 		CHAPTER_7_VENDOR(0xCA130CL, 0xCA6F4AL),
 		CHAPTER_8_ARMORY(0xCA1504L, 0xCA6F52L),
 		CHAPTER_10_ARMORY(0xCA187CL, 0xCA6F5CL),
 		CHAPTER_10_VENDOR(0xCA1888L, 0xCA6F66L),
 		CHAPTER_11_VENDOR(0xCA1958L, 0xCA6F72L),
-		CHAPTER_12_ARMORY(0xCA1B4CL, 0xCA6F76L),
-		CHAPTER_12_VENDOR(0xCA1B58L, 0xCA6F7AL),
+		CHAPTER_12_VENDOR(0xCA1B4CL, 0xCA6F76L),
+		CHAPTER_12_ARMORY(0xCA1B58L, 0xCA6F7AL),
 		CHAPTER_13_ARMORY(0xCA1D24L, 0xCA6F84L),
 		CHAPTER_13_VENDOR(0xCA1D30L, 0xCA6F8EL),
 		CHAPTER_14_ARMORY(0xCA218CL, 0xCA6F94L),
@@ -2083,7 +2086,7 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		CHAPTER_21_VENDOR_1(0xCA3764L, 0xCA703AL),
 		CHAPTER_21_ARMORY_2(0xCA3740L, 0xCA7018L),
 		CHAPTER_21_VENDOR_2(0xCA3758L, 0xCA7030L),
-		CHAPTER_22_SECRET(0xCA3764L, 0xCA703AL),
+		CHAPTER_22_SECRET(0xCA3ABCL, 0xCA7048L),
 		CHAPTER_24A_ARMORY_1(0xCA4214L, 0xCA7068L),
 		CHAPTER_24A_VENDOR_1(0xCA4220L, 0xCA7076L),
 		CHAPTER_24A_ARMORY_2(0xCA4208L, 0xCA7058L),
@@ -2169,8 +2172,70 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			case CHAPTER_31X_VENDOR_2:
 				return new HashSet<GBAFEShop>(Arrays.asList(CHAPTER_31X_VENDOR_1, CHAPTER_31X_VENDOR_2));
 			default:
-				return null;
+				return new HashSet<GBAFEShop>(Arrays.asList(this));
 			}
+		}
+		
+		public GameStage getGameStage() {
+			switch (this) {
+			case CHAPTER_3_ARMORY:
+			case CHAPTER_5_ARMORY:
+				return GameStage.EARLY;
+			case CHAPTER_7_VENDOR:
+			case CHAPTER_8_ARMORY:
+			case CHAPTER_10_ARMORY:
+			case CHAPTER_10_VENDOR:
+				return GameStage.MID;
+			case CHAPTER_11_VENDOR:
+			case CHAPTER_12_VENDOR:
+			case CHAPTER_12_ARMORY:
+			case CHAPTER_13_ARMORY:
+			case CHAPTER_13_VENDOR:
+			case CHAPTER_14_ARMORY:
+			case CHAPTER_14_VENDOR:
+				return GameStage.EARLY;
+			case CHAPTER_16_ARMORY_1:
+			case CHAPTER_16_ARMORY_2:
+			case CHAPTER_16_VENDOR:
+			case CHAPTER_17X_VENDOR:
+			case CHAPTER_18_ARMORY:
+			case CHAPTER_18_VENDOR:
+			case CHAPTER_20_SECRET_1:
+			case CHAPTER_20_SECRET_2:
+			case CHAPTER_21_ARMORY_1:
+			case CHAPTER_21_VENDOR_1:
+			case CHAPTER_21_ARMORY_2:
+			case CHAPTER_21_VENDOR_2:
+			case CHAPTER_22_SECRET:
+				return GameStage.MID;
+			case CHAPTER_24A_ARMORY_1:
+			case CHAPTER_24A_VENDOR_1:
+			case CHAPTER_24A_ARMORY_2:
+			case CHAPTER_24A_VENDOR_2:
+			case CHAPTER_24A_SECRET:
+			case CHAPTER_24B_ARMORY_1:
+			case CHAPTER_24B_VENDOR_1:
+			case CHAPTER_24B_ARMORY_2:
+			case CHAPTER_24B_VENDOR_2:
+			case CHAPTER_24B_SECRET:
+			case CHAPTER_25_ARMORY:
+			case CHAPTER_25_VENDOR:
+			case CHAPTER_26_ARMORY:
+			case CHAPTER_26_VENDOR:
+			case CHAPTER_29_ARMORY:
+			case CHAPTER_29_VENDOR:
+			case CHAPTER_31_SECRET:
+			case CHAPTER_31X_ARMORY_1:
+			case CHAPTER_31X_VENDOR_1:
+			case CHAPTER_31X_VENDOR_2:
+			case CHAPTER_31X_ARMORY_2:
+			case CHAPTER_31X_ARMORY_3:
+			case CHAPTER_31X_ARMORY_4:
+			case CHAPTER_32_SECRET:
+				return GameStage.LATE;
+			}
+			
+			return GameStage.LATE;
 		}
 		
 		public long getPointerOffset() {
@@ -3188,6 +3253,10 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		return new HashSet<GBAFEItem>(equalRankWeapons);
 	}
 	
+	public Set<GBAFEItem> weaponsOfRank(WeaponRank rank) {
+		return new HashSet<GBAFEItem>(Item.weaponsOfRank(rank));
+	}
+	
 	public Set<GBAFEItem> healingStaves(WeaponRank maxRank) {
 		Set<Item> staves = Item.allHealingStaves;
 		return new HashSet<GBAFEItem>(staves);
@@ -3470,6 +3539,51 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	
 	public Set<GBAFEItem> rareDrops() {
 		return new HashSet<GBAFEItem>(Item.rareDrops);
+	}
+	
+	public Set<GBAFEItem> vendorItems(boolean rare) {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>(Item.vendorItems);
+		if (rare) {
+			items.add(Item.ELIXIR);
+			items.add(Item.MINE);
+			items.add(Item.LIGHT_RUNE);
+		}
+		
+		return items;
+	}
+	
+	public Set<GBAFEItem> secretItems() {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>();
+		items.addAll(Item.allPromotionItems);
+		items.addAll(Item.reaverSet);
+		items.addAll(Item.killerSet);
+		items.addAll(Item.braveSet);
+		items.addAll(Item.allSiegeTomes);
+		items.add(Item.ELIXIR);
+		items.add(Item.RESCUE);
+		items.add(Item.FORTIFY);
+		items.add(Item.PHYSIC);
+		items.add(Item.MANI_KATTI);
+		items.add(Item.RAPIER);
+		items.add(Item.WOLF_BEIL);
+		items.add(Item.WO_DAO);
+		items.add(Item.LIGHT_BRAND);
+		items.add(Item.WIND_SWORD);
+		return items;
+	}
+	public Set<GBAFEItem> rareSecretItems() {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>();
+		items.addAll(Item.allStatBoosters);
+		items.addAll(Item.allSRank);
+		items.addAll(Item.allDancingRings);
+		items.add(Item.HAMMERNE);
+		items.add(Item.WARP);
+		items.add(Item.RUNE_SWORD);
+		return items;
+	}
+	
+	public Set<GBAFEItem> disallowedWeaponsInShops() {
+		return new HashSet<GBAFEItem>();
 	}
 	
 	public String statBoostStringForWeapon(GBAFEItem weapon) {
@@ -3794,4 +3908,10 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public Set<GBAFEShop> allSecretShops() {
 		return new HashSet<GBAFEShop>(Shops.allSecretShops());
 	}
+	
+	public List<GBAFEShop> orderedShops() {
+		return new ArrayList<GBAFEShop>(Arrays.asList(Shops.values()));
+	}
+	
+	public Boolean isMapShop(GBAFEShop shop) { return false; }
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Item.java
@@ -205,6 +205,17 @@ public class FE7Item implements GBAFEItemData {
 	public int getMaxRange() {
 		return data[25] & 0x0F;
 	}
+	
+	public int getCostPerUse() {
+		return WhyDoesJavaNotHaveThese.intValueFromByteSubarray(data, 26, 2, true);
+	}
+	
+	public void setCostPerUse(int costPerUse) {
+		byte[] costData = WhyDoesJavaNotHaveThese.byteArrayFromLongValue(costPerUse, true, 2);
+		data[26] = costData[0];
+		data[27] = costData[1];
+		wasModified = true;
+ 	}
 
 	public WeaponRank getWeaponRank() {
 		int rank = data[28] & 0xFF;

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -135,6 +135,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public static final GBAFEStatboostProvider statboostProvider = sharedInstance;
 	public static final GBAFEShufflingDataProvider shufflingDataProvider = sharedInstance;
 	public static final GBAFETextProvider textProvider = sharedInstance;
+	public static final GBAFEShopProvider shopProvider = sharedInstance;
 	
 	public enum CharacterAndClassAbility1Mask {
 		USE_MOUNTED_AID(0x1), CANTO(0x2), STEAL(0x4), USE_LOCKPICKS(0x8),
@@ -1233,6 +1234,9 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		public static Set<Item> allSteelWeapons = new HashSet<Item>(Arrays.asList(STEEL_SWORD, STEEL_LANCE, STEEL_AXE, STEEL_BOW, THUNDER));
 		public static Set<Item> allBasicThrownWeapons = new HashSet<Item>(Arrays.asList(JAVELIN, HAND_AXE));
 		
+		public static Set<Item> vendorItems = new HashSet<Item>(Arrays.asList(CHEST_KEY, DOOR_KEY, LOCKPICK, VULNERARY, PURE_WATER, ANTITOXIN, TORCH));
+		public static Set<Item> legendaryWeapons = new HashSet<Item>(Arrays.asList(AUDHULMA, VIDOFNIR, GARM, NIDHOGG, LATONA, EXCALIBUR, IVALDI, GLEIPNIR, NAGLFAR));
+		
 		public static Set<Item> basicItemsOfType(WeaponType type) {
 			Set<Item> set = new HashSet<Item>();
 			set.addAll(weaponsOfType(type));
@@ -2282,6 +2286,69 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					RAUSTEN_ARMORY, RAUSTEN_VENDOR, RAUSTEN_SECRET, SERAFEW_ARMORY, SERAFEW_VENDOR, TAIZEL_VENDOR));
 		}
 		
+		public static List<Shops> inOrderOfAppearance() {
+			return Arrays.asList(CHAPTER_2_ARMORY, IDE_ARMORY,
+					CHAPTER_5_ARMORY, CHAPTER_5_VENDOR, SERAFEW_ARMORY, SERAFEW_VENDOR,
+					CHAPTER_9A_ARMORY, CHAPTER_9A_VENDOR, PORT_KIRIS_ARMORY, PORT_KIRIS_VENDOR,
+					CHAPTER_10B_ARMORY, CHAPTER_10B_VENDOR, BETHROEN_ARMORY, BETHROEN_VENDOR,
+					CHAPTER_12A_VENDOR, CAER_PELYN_VENDOR,
+					CHAPTER_12B_VENDOR, TAIZEL_VENDOR,
+					CHAPTER_14A_SECRET, JEHANNA_SECRET,
+					CHAPTER_14B_SECRET, GRADO_SECRET,
+					CHAPTER_15A_VENDOR, CHAPTER_15B_VENDOR, JEHANNA_VENDOR,
+					CHAPTER_17A_ARMORY, CHAPTER_17B_ARMORY, CHAPTER_17A_VENDOR, CHAPTER_17B_VENDOR, NARUBE_RIVER_ARMORY, NARUBE_RIVER_VENDOR,
+					CHAPTER_19A_SECRET,
+					CHAPTER_19B_SECRET,
+					RAUSTEN_ARMORY,
+					RAUSTEN_VENDOR, RAUSTEN_SECRET);
+		}
+		
+		public GameStage getGameStage() {
+			switch (this) {
+			case CHAPTER_2_ARMORY:
+			case IDE_ARMORY:
+			case CHAPTER_5_ARMORY:
+			case CHAPTER_5_VENDOR:
+			case SERAFEW_ARMORY:
+			case SERAFEW_VENDOR:
+				return GameStage.EARLY;
+			case CHAPTER_9A_ARMORY:
+			case CHAPTER_9A_VENDOR:
+			case PORT_KIRIS_ARMORY:
+			case PORT_KIRIS_VENDOR:
+			case CHAPTER_10B_ARMORY:
+			case CHAPTER_10B_VENDOR:
+			case BETHROEN_ARMORY:
+			case BETHROEN_VENDOR:
+			case CHAPTER_12A_VENDOR:
+			case CAER_PELYN_VENDOR:
+			case CHAPTER_12B_VENDOR:
+			case TAIZEL_VENDOR:
+			case CHAPTER_14A_SECRET:
+			case JEHANNA_SECRET:
+			case CHAPTER_14B_SECRET:
+			case GRADO_SECRET:
+				return GameStage.MID;
+			case CHAPTER_15A_VENDOR:
+			case CHAPTER_15B_VENDOR:
+			case JEHANNA_VENDOR:
+			case CHAPTER_17A_ARMORY:
+			case CHAPTER_17B_ARMORY:
+			case CHAPTER_17A_VENDOR:
+			case CHAPTER_17B_VENDOR:
+			case NARUBE_RIVER_ARMORY:
+			case NARUBE_RIVER_VENDOR:
+			case CHAPTER_19A_SECRET:
+			case CHAPTER_19B_SECRET:
+			case RAUSTEN_ARMORY:
+			case RAUSTEN_VENDOR:
+			case RAUSTEN_SECRET:
+				return GameStage.LATE;
+			}
+			
+			return GameStage.LATE;
+		}
+		
 		public Set<GBAFEShop> groupedShops() {
 			switch (this) {
 			case BETHROEN_ARMORY:
@@ -2305,7 +2372,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 			case RAUSTEN_SECRET:
 				return new HashSet<GBAFEShop>(Arrays.asList(JEHANNA_SECRET, GRADO_SECRET, RAUSTEN_SECRET));
 			default:
-				return null;
+				return new HashSet<GBAFEShop>(Arrays.asList(this));
 			}
 		}
 		
@@ -3376,6 +3443,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		return new HashSet<GBAFEItem>(equalRankWeapons);
 	}
 	
+	public Set<GBAFEItem> weaponsOfRank(WeaponRank rank) {
+		return new HashSet<GBAFEItem>(Item.weaponsOfRank(rank));
+	}
+	
 	public Set<GBAFEItem> healingStaves(WeaponRank maxRank) {
 		Set<Item> staves = Item.allHealingStaves;
 		return new HashSet<GBAFEItem>(staves);
@@ -3714,6 +3785,49 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	
 	public Set<GBAFEItem> rareDrops() {
 		return new HashSet<GBAFEItem>(Item.rareDrops);
+	}
+	
+	public Set<GBAFEItem> vendorItems(boolean rare) {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>(Item.vendorItems);
+		if (rare) {
+			items.add(Item.ELIXIR);
+			items.add(Item.CHEST_KEY_5);
+		}
+		
+		return items;
+	}
+	
+	public Set<GBAFEItem> secretItems() {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>();
+		items.addAll(Item.allPromotionItems);
+		items.addAll(Item.killerSet);
+		items.addAll(Item.braveSet);
+		items.addAll(Item.reaverSet);
+		items.addAll(Item.allSiegeTomes);
+		items.add(Item.ELIXIR);
+		items.add(Item.RESCUE);
+		items.add(Item.FORTIFY);
+		items.add(Item.PHYSIC);
+		items.add(Item.RAPIER);
+		items.add(Item.REGINLEIF);
+		items.add(Item.WIND_SWORD);
+		items.add(Item.LIGHT_BRAND);
+		items.removeAll(Item.allMonsterWeapons);
+		return items;
+	}
+	
+	public Set<GBAFEItem> rareSecretItems() {
+		Set<GBAFEItem> items = new HashSet<GBAFEItem>();
+		items.addAll(Item.allStatBoosters);
+		items.add(Item.HAMMERNE);
+		items.add(Item.WARP);
+		items.add(Item.RUNE_SWORD);
+		items.removeAll(Item.allMonsterWeapons);
+		return items;
+	}
+	
+	public Set<GBAFEItem> disallowedWeaponsInShops() {
+		return new HashSet<GBAFEItem>(Item.legendaryWeapons);
 	}
 	
 	public String statBoostStringForWeapon(GBAFEItem weapon) {
@@ -4104,5 +4218,13 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	
 	public Set<GBAFEShop> allSecretShops() {
 		return new HashSet<GBAFEShop>(Shops.allSecretShops());
+	}
+	
+	public List<GBAFEShop> orderedShops() {
+		return new ArrayList<GBAFEShop>(Shops.inOrderOfAppearance());
+	}
+	
+	public Boolean isMapShop(GBAFEShop shop) {
+		return Shops.allMapShops().contains(shop);
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -17,13 +17,29 @@ import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
 import fedata.gba.general.*;
 import fedata.gba.GBAFECharacterData.Affinity;
+import fedata.gba.fe7.FE7Data.Shops;
+import fedata.gba.general.CharacterNudge;
+import fedata.gba.general.GBAFEChapterMetadataChapter;
+import fedata.gba.general.GBAFECharacter;
+import fedata.gba.general.GBAFECharacterProvider;
+import fedata.gba.general.GBAFEClass;
+import fedata.gba.general.GBAFEClassProvider;
+import fedata.gba.general.GBAFEItem;
+import fedata.gba.general.GBAFEItemProvider;
+import fedata.gba.general.GBAFEPromotionItem;
+import fedata.gba.general.GBAFEShop;
+import fedata.gba.general.GBAFEShopProvider;
+import fedata.gba.general.PaletteColor;
+import fedata.gba.general.PaletteInfo;
+import fedata.gba.general.WeaponRank;
+import fedata.gba.general.WeaponType;
 import random.gba.loader.ItemDataLoader.AdditionalData;
 import random.gba.randomizer.shuffling.GBAFEShufflingDataProvider;
 import random.gba.randomizer.shuffling.data.GBAFEPortraitData;
 import util.AddressRange;
 import util.WhyDoesJavaNotHaveThese;
 
-public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAFEItemProvider, GBAFEShufflingDataProvider, GBAFETextProvider, GBAFEStatboostProvider {
+public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAFEItemProvider, GBAFEShufflingDataProvider, GBAFETextProvider, GBAFEStatboostProvider, GBAFEShopProvider {
 	public static final String FriendlyName = "Fire Emblem: The Sacred Stones";
 	public static final String GameCode = "BE8E";
 
@@ -2197,6 +2213,111 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		}
 	}
 	
+	public enum Shops implements GBAFEShop {
+		
+		CHAPTER_2_ARMORY(0x9E8884L, 0x9ED7CCL),
+		CHAPTER_5_ARMORY(0x9E8BB0L, 0x9ED7D8L),
+		CHAPTER_5_VENDOR(0x9E8BBCL, 0x9ED7EEL),
+		CHAPTER_9A_ARMORY(0x9E9108L, 0x9ED80EL),
+		CHAPTER_9A_VENDOR(0x9E90CCL, 0x9ED7F8L),
+		CHAPTER_10B_ARMORY(0x9EA434L, 0x9ED8CAL),
+		CHAPTER_10B_VENDOR(0x9EA440L, 0x9ED8E2L),
+		CHAPTER_12A_VENDOR(0x9E948CL, 0x9ED826L),
+		CHAPTER_12B_VENDOR(0x9EA67CL, 0x9ED8FAL),
+		CHAPTER_14A_SECRET(0x9E9730L, 0x9ED83EL),
+		CHAPTER_14B_SECRET(0x9EA9ECL, 0x9ED912L),
+		CHAPTER_15A_VENDOR(0x9E992CL, 0x9ED860L),
+		CHAPTER_15B_VENDOR(0x9EAC1CL, 0x9ED934L),
+		CHAPTER_17A_ARMORY(0x9E9C58L, 0x9ED894L),
+		CHAPTER_17A_VENDOR(0x9E9C4CL, 0x9ED87AL),
+		CHAPTER_17B_ARMORY(0x9EAF6CL, 0x9ED968L),
+		CHAPTER_17B_VENDOR(0x9EAF60L, 0x9ED94EL),
+		CHAPTER_19A_SECRET(0x9E9EB8L, 0x9ED8B8L),
+		CHAPTER_19B_SECRET(0x9EB1CCL, 0x9ED98CL),
+		
+		// Map Shops
+		BETHROEN_ARMORY(0x20629CL, 0xA3F00EL),
+		BETHROEN_VENDOR(0x2062A0L, 0xA3F0D2L),
+		CAER_PELYN_VENDOR(0x206220L, 0xA3F0B4L),
+		GRADO_SECRET(0x206324L, 0xA3F1B8L),
+		IDE_ARMORY(0x2060FCL, 0xA3EFB8L),
+		JEHANNA_SECRET(0x206304L, 0xA3F18EL),
+		JEHANNA_VENDOR(0x206320L, 0xA3F10AL),
+		NARUBE_RIVER_ARMORY(0x20635CL, 0xA3F032L),
+		NARUBE_RIVER_VENDOR(0x206360L, 0xA3F12AL),
+		PORT_KIRIS_ARMORY(0x2061DCL, 0xA3EFEAL),
+		PORT_KIRIS_VENDOR(0x2061E0L, 0xA3F096L),
+		RAUSTEN_ARMORY(0x20639CL, 0xA3F050L),
+		RAUSTEN_SECRET(0x2063A4L, 0xA3F1E8L),
+		RAUSTEN_VENDOR(0x2063A0L, 0xA3F144L),
+		SERAFEW_ARMORY(0x20615CL, 0xA3EFCEL),
+		SERAFEW_VENDOR(0x206160L, 0xA3F082L),
+		TAIZEL_VENDOR(0x2062C0L, 0xA3F0EEL)
+		;
+		
+		long pointerOffset;
+		long originalShopAddress;
+		
+		private Shops(final long pointerOffset, final long originalShopList) {
+			this.pointerOffset = pointerOffset;
+			this.originalShopAddress = originalShopList;
+		}
+		
+		public static Set<Shops> allVendors() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_5_VENDOR, CHAPTER_9A_VENDOR, CHAPTER_10B_VENDOR, CHAPTER_12A_VENDOR, CHAPTER_12B_VENDOR, CHAPTER_15A_VENDOR, CHAPTER_15B_VENDOR, CHAPTER_17A_VENDOR, CHAPTER_17B_VENDOR,
+					BETHROEN_VENDOR, CAER_PELYN_VENDOR, JEHANNA_VENDOR, NARUBE_RIVER_VENDOR, PORT_KIRIS_VENDOR, RAUSTEN_VENDOR, SERAFEW_VENDOR, TAIZEL_VENDOR));
+		}
+		
+		public static Set<Shops> allArmories() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_2_ARMORY, CHAPTER_5_ARMORY, CHAPTER_9A_ARMORY, CHAPTER_10B_ARMORY, CHAPTER_17A_ARMORY, CHAPTER_17B_ARMORY, BETHROEN_ARMORY, IDE_ARMORY, NARUBE_RIVER_ARMORY, PORT_KIRIS_ARMORY,
+					RAUSTEN_ARMORY, SERAFEW_ARMORY));
+		}
+		
+		public static Set<Shops> allSecretShops() {
+			return new HashSet<Shops>(Arrays.asList(CHAPTER_14A_SECRET, CHAPTER_14B_SECRET, CHAPTER_19A_SECRET, CHAPTER_19B_SECRET, GRADO_SECRET, JEHANNA_SECRET, RAUSTEN_SECRET));
+		}
+		
+		public static Set<Shops> allMapShops() {
+			return new HashSet<Shops>(Arrays.asList(BETHROEN_ARMORY, BETHROEN_VENDOR, CAER_PELYN_VENDOR, GRADO_SECRET, IDE_ARMORY, JEHANNA_SECRET, JEHANNA_VENDOR, NARUBE_RIVER_ARMORY, NARUBE_RIVER_VENDOR, PORT_KIRIS_ARMORY, PORT_KIRIS_VENDOR,
+					RAUSTEN_ARMORY, RAUSTEN_VENDOR, RAUSTEN_SECRET, SERAFEW_ARMORY, SERAFEW_VENDOR, TAIZEL_VENDOR));
+		}
+		
+		public Set<GBAFEShop> groupedShops() {
+			switch (this) {
+			case BETHROEN_ARMORY:
+			case IDE_ARMORY:
+			case NARUBE_RIVER_ARMORY:
+			case PORT_KIRIS_ARMORY:
+			case RAUSTEN_ARMORY:
+			case SERAFEW_ARMORY:
+				return new HashSet<GBAFEShop>(Arrays.asList(BETHROEN_ARMORY, IDE_ARMORY, NARUBE_RIVER_ARMORY, PORT_KIRIS_ARMORY, RAUSTEN_ARMORY, SERAFEW_ARMORY));
+			case BETHROEN_VENDOR:
+			case CAER_PELYN_VENDOR:
+			case JEHANNA_VENDOR:
+			case NARUBE_RIVER_VENDOR:
+			case PORT_KIRIS_VENDOR:
+			case RAUSTEN_VENDOR:
+			case SERAFEW_VENDOR:
+			case TAIZEL_VENDOR:
+				return new HashSet<GBAFEShop>(Arrays.asList(BETHROEN_VENDOR, CAER_PELYN_VENDOR, JEHANNA_VENDOR, NARUBE_RIVER_VENDOR, PORT_KIRIS_VENDOR, RAUSTEN_VENDOR, SERAFEW_VENDOR, TAIZEL_VENDOR));
+			case JEHANNA_SECRET:
+			case GRADO_SECRET:
+			case RAUSTEN_SECRET:
+				return new HashSet<GBAFEShop>(Arrays.asList(JEHANNA_SECRET, GRADO_SECRET, RAUSTEN_SECRET));
+			default:
+				return null;
+			}
+		}
+		
+		public long getPointerOffset() {
+			return pointerOffset;
+		}
+		
+		public long getOriginalShopAddress() {
+			return originalShopAddress;
+		}
+	}
+	
 	public enum Palette {
 		ARCHER_NEIMI(0x01, Character.NEIMI.ID, CharacterClass.ARCHER_F.ID, 0xEF9000),
 		
@@ -3967,5 +4088,21 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	@Override
 	public int getNumberEntries() {
 		return 23;
+	}
+	
+	public Set<GBAFEShop> allShops() {
+		return new HashSet<GBAFEShop>(Arrays.asList(Shops.values()));
+	}
+	
+	public Set<GBAFEShop> allVendors() {
+		return new HashSet<GBAFEShop>(Shops.allVendors());
+	}
+	
+	public Set<GBAFEShop> allArmories() {
+		return new HashSet<GBAFEShop>(Shops.allArmories());
+	}
+	
+	public Set<GBAFEShop> allSecretShops() {
+		return new HashSet<GBAFEShop>(Shops.allSecretShops());
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Item.java
@@ -276,6 +276,17 @@ public class FE8Item implements GBAFEItemData {
 		wasModified = true;
 	}
 	
+	public int getCostPerUse() {
+		return WhyDoesJavaNotHaveThese.intValueFromByteSubarray(data, 26, 2, true);
+	}
+	
+	public void setCostPerUse(int costPerUse) {
+		byte[] costData = WhyDoesJavaNotHaveThese.byteArrayFromLongValue(costPerUse, true, 2);
+		data[26] = costData[0];
+		data[27] = costData[1];
+		wasModified = true;
+ 	}
+	
 	public void applyRandomEffect(WeightedDistributor<WeaponEffects> allowedEffects, ItemDataLoader itemData, TextLoader textData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
 		if (getType() == WeaponType.NOT_A_WEAPON) {
 			return;

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
@@ -32,6 +32,7 @@ public interface GBAFEItemProvider {
 	public Set<GBAFEItem> weaponsWithEffectiveness();
 	public Set<GBAFEItem> weaponsOfTypeUpToRank(WeaponType type, WeaponRank rank, Boolean rangedOnly, Boolean requiresMelee);
 	public Set<GBAFEItem> weaponsOfTypeAndEqualRank(WeaponType type, WeaponRank rank, Boolean rangedOnly, Boolean requiresMelee, Boolean allowLower);
+	public Set<GBAFEItem> weaponsOfRank(WeaponRank rank);
 	public Set<GBAFEItem> healingStaves(WeaponRank maxRank);
 	public Set<GBAFEItem> prfWeaponsForClassID(int classID);
 	public Set<GBAFEItem> allPotentialChestRewards();
@@ -52,6 +53,21 @@ public interface GBAFEItemProvider {
 	public Set<GBAFEItem> commonDrops();
 	public Set<GBAFEItem> uncommonDrops();
 	public Set<GBAFEItem> rareDrops();
+	
+	public Set<GBAFEItem> disallowedWeaponsInShops();
+	
+	// Not sure if I want to define shop randomization pools explicitly or via rules using defined sets of items.
+	// For now, I've settled on defining early/mid/late using weapon ranks instead of being more specific. If it turns out
+	// we need more control, then we can re-introduce these.
+	
+//	public Set<GBAFEItem> earlyShops();
+//	public Set<GBAFEItem> midShops();
+//	public Set<GBAFEItem> lateShops();
+//	
+//	public Set<GBAFEItem> armoryItems();
+	public Set<GBAFEItem> vendorItems(boolean rare); // Rare items are less likely for early game.
+	public Set<GBAFEItem> secretItems(); // More interesting weapons and promotional items.
+	public Set<GBAFEItem> rareSecretItems(); // Should include things like statboosters or things that would be a bit much for normal secret shops.
 	
 	public String statBoostStringForWeapon(GBAFEItem weapon);
 	public String effectivenessStringForWeapon(GBAFEItem weapon, Boolean shortString);

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEShop.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEShop.java
@@ -1,0 +1,11 @@
+package fedata.gba.general;
+
+import java.util.Set;
+
+public interface GBAFEShop {
+	
+	public long getPointerOffset();
+	public long getOriginalShopAddress();
+	public Set<GBAFEShop> groupedShops();
+
+}

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEShop.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEShop.java
@@ -4,8 +4,13 @@ import java.util.Set;
 
 public interface GBAFEShop {
 	
+	public enum GameStage {
+		EARLY, MID, LATE
+	}
+	
 	public long getPointerOffset();
 	public long getOriginalShopAddress();
 	public Set<GBAFEShop> groupedShops();
 
+	public GameStage getGameStage();
 }

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEShopProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEShopProvider.java
@@ -1,5 +1,6 @@
 package fedata.gba.general;
 
+import java.util.List;
 import java.util.Set;
 
 public interface GBAFEShopProvider {
@@ -8,4 +9,7 @@ public interface GBAFEShopProvider {
 	public Set<GBAFEShop> allVendors();
 	public Set<GBAFEShop> allArmories();
 	public Set<GBAFEShop> allSecretShops();
+	
+	public List<GBAFEShop> orderedShops();
+	public Boolean isMapShop(GBAFEShop shop);
 }

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEShopProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEShopProvider.java
@@ -1,0 +1,11 @@
+package fedata.gba.general;
+
+import java.util.Set;
+
+public interface GBAFEShopProvider {
+
+	public Set<GBAFEShop> allShops();
+	public Set<GBAFEShop> allVendors();
+	public Set<GBAFEShop> allArmories();
+	public Set<GBAFEShop> allSecretShops();
+}

--- a/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
@@ -1,5 +1,6 @@
 package random.gba.loader;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,6 +66,7 @@ public class ItemDataLoader {
 	private Map<Integer, List<GBAFEPromotionItem>> promotionItemsForClassIDs;
 	
 	public static final String RecordKeeperCategoryWeaponKey = "Weapons";
+	public static final String RecordKeeperCategoryItemKey = "Items";
 	
 	public ItemDataLoader(GBAFEItemProvider provider, FileHandler handler, FreeSpaceManager freeSpace) {
 		super();
@@ -358,6 +360,105 @@ public class ItemDataLoader {
 	
 	public GBAFEItemData[] getAllWeapons() {
 		return feItemsFromItemSet(provider.allWeapons());
+	}
+	
+	public GBAFEItemData[] getAllItems() {
+		return feItemsFromItemSet(new HashSet<GBAFEItem>(Arrays.asList(provider.allItems())));
+	}
+	
+	public List<GBAFEItemData> earlyGameArmory() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.SWORD, WeaponRank.E, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LANCE, WeaponRank.E, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.AXE, WeaponRank.E, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.BOW, WeaponRank.E, false, false, false))));
+		return items;
+	}
+	
+	public List<GBAFEItemData> midGameArmory() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.SWORD, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LANCE, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.AXE, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.BOW, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.SWORD, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LANCE, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.AXE, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.BOW, WeaponRank.C, false, false, false))));
+		return items;
+	}
+	
+	public List<GBAFEItemData> lateGameArmory() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.SWORD, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LANCE, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.AXE, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.BOW, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.SWORD, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LANCE, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.AXE, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.BOW, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.SWORD, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LANCE, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.AXE, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.BOW, WeaponRank.S, false, false, false))));
+		items.removeAll(Arrays.asList(feItemsFromItemSet(provider.disallowedWeaponsInShops())));
+		return items;
+	}
+	
+	public List<GBAFEItemData> earlyGameVendor() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.ANIMA, WeaponRank.E, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LIGHT, WeaponRank.E, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.DARK, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.STAFF, WeaponRank.E, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.vendorItems(false))));
+		return items;
+	}
+	
+	public List<GBAFEItemData> midGameVendor() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.ANIMA, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LIGHT, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.DARK, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.STAFF, WeaponRank.D, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.ANIMA, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LIGHT, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.DARK, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.STAFF, WeaponRank.C, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.vendorItems(true))));
+		return items;
+	}
+	
+	public List<GBAFEItemData> lateGameVendor() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.ANIMA, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LIGHT, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.DARK, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.STAFF, WeaponRank.B, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.ANIMA, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LIGHT, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.DARK, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.STAFF, WeaponRank.A, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.ANIMA, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.LIGHT, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.DARK, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.weaponsOfTypeAndEqualRank(WeaponType.STAFF, WeaponRank.S, false, false, false))));
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.vendorItems(true))));
+		items.removeAll(Arrays.asList(feItemsFromItemSet(provider.disallowedWeaponsInShops())));
+		return items;
+	}
+	
+	public List<GBAFEItemData> secretItems() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.secretItems())));
+		return items;
+	}
+	
+	public List<GBAFEItemData> rareSecretItems() {
+		List<GBAFEItemData> items = new ArrayList<GBAFEItemData>();
+		items.addAll(Arrays.asList(feItemsFromItemSet(provider.rareSecretItems())));
+		return items;
 	}
 	
 	public long[] possibleStatBoostAddresses() {
@@ -799,6 +900,28 @@ public class ItemDataLoader {
 		}
 	}
 	
+	public void recordItems(RecordKeeper rk, Boolean isInitial, TextLoader textData, FileHandler handler) {
+		for (GBAFEItemData item : getAllItems()) {
+			if (item != null && item.getType() == WeaponType.NOT_A_WEAPON) {
+				recordItem(rk, item, isInitial, textData, handler);
+			}
+		}
+	}
+	
+	private void recordItem(RecordKeeper rk, GBAFEItemData item, Boolean isInitial, TextLoader textData, FileHandler handler) {
+		int nameIndex = item.getNameIndex();
+		String name = textData.getStringAtIndex(nameIndex, true).trim();
+		int descriptionIndex = item.getDescriptionIndex();
+		String description = textData.getStringAtIndex(descriptionIndex, true).trim();
+		if (isInitial) {
+			rk.recordOriginalEntry(RecordKeeperCategoryItemKey, name, "Description", description);
+			rk.recordOriginalEntry(RecordKeeperCategoryItemKey, name, "Cost per Use", String.format("%d",  item.getCostPerUse()));
+		} else {
+			rk.recordUpdatedEntry(RecordKeeperCategoryItemKey, name, "Description", description);
+			rk.recordUpdatedEntry(RecordKeeperCategoryItemKey, name, "Cost per Use", String.format("%d",  item.getCostPerUse()));
+		}
+	}
+	
 	private void recordWeapon(RecordKeeper rk, GBAFEItemData item, Boolean isInitial, ClassDataLoader classData, TextLoader textData, FileHandler handler) {
 		int nameIndex = item.getNameIndex();
 		String name = textData.getStringAtIndex(nameIndex, true).trim();
@@ -812,6 +935,7 @@ public class ItemDataLoader {
 			rk.recordOriginalEntry(RecordKeeperCategoryWeaponKey, name, "Weight (WT)", String.format("%d", item.getWeight()));
 			rk.recordOriginalEntry(RecordKeeperCategoryWeaponKey, name, "Durability", String.format("%d", item.getDurability()));
 			rk.recordOriginalEntry(RecordKeeperCategoryWeaponKey, name, "Critical", String.format("%d",  item.getCritical()));
+			rk.recordOriginalEntry(RecordKeeperCategoryWeaponKey, name, "Cost per Use", String.format("%d", item.getCostPerUse()));
 			
 			long statPointerAddress = item.getStatBonusPointer();
 			if (statPointerAddress != 0) {
@@ -888,6 +1012,7 @@ public class ItemDataLoader {
 			rk.recordUpdatedEntry(RecordKeeperCategoryWeaponKey, name, "Weight (WT)", String.format("%d", item.getWeight()));
 			rk.recordUpdatedEntry(RecordKeeperCategoryWeaponKey, name, "Durability", String.format("%d", item.getDurability()));
 			rk.recordUpdatedEntry(RecordKeeperCategoryWeaponKey, name, "Critical", String.format("%d",  item.getCritical()));
+			rk.recordUpdatedEntry(RecordKeeperCategoryWeaponKey, name, "Cost per Use", String.format("%d", item.getCostPerUse()));
 			
 			long statPointerAddress = item.getStatBonusPointer();
 			if (statPointerAddress != 0) {

--- a/Universal FE Randomizer/src/random/gba/loader/ShopLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ShopLoader.java
@@ -1,0 +1,173 @@
+package random.gba.loader;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import fedata.gba.GBAFEItemData;
+import fedata.gba.general.GBAFEItem;
+import fedata.gba.general.GBAFEItemProvider;
+import fedata.gba.general.GBAFEShop;
+import fedata.gba.general.GBAFEShopProvider;
+import io.FileHandler;
+import util.DebugPrinter;
+import util.Diff;
+import util.DiffCompiler;
+import util.FreeSpaceManager;
+import util.WhyDoesJavaNotHaveThese;
+import util.recordkeeper.RecordKeeper;
+
+public class ShopLoader {
+
+	private GBAFEShopProvider provider;
+	private FreeSpaceManager freeSpace;
+	
+	private Map<GBAFEShop, List<GBAFEItemData>> itemMap;
+	private Map<GBAFEShop, List<GBAFEItemData>> updatedItemMap;
+	private Map<GBAFEShop, Long> listAddressMap;
+	
+	public static final String RecordKeeperCategoryShopKey = "Shops";
+	
+	public ShopLoader(GBAFEShopProvider provider, GBAFEItemProvider itemProvider, ItemDataLoader itemData, FileHandler handler, FreeSpaceManager freeSpace) {
+		super();
+		
+		this.freeSpace = freeSpace;
+		this.provider = provider;
+		
+		itemMap = new HashMap<GBAFEShop, List<GBAFEItemData>>();
+		listAddressMap = new HashMap<GBAFEShop, Long>();
+		
+		for (GBAFEShop shop : provider.allShops()) {
+			long pointerOffset = shop.getPointerOffset();
+			long originalShopList = shop.getOriginalShopAddress();
+			
+			long readShopAddress = WhyDoesJavaNotHaveThese.longValueFromByteArray(handler.readBytesAtOffset(pointerOffset, 4), true) - 0x8000000L;
+			if (readShopAddress != originalShopList) {
+				DebugPrinter.error(DebugPrinter.Key.GBA_SHOP_LOADER, "Address mismatch for shop: " + shop.toString());
+				continue;
+			}
+			DebugPrinter.log(DebugPrinter.Key.GBA_SHOP_LOADER, "Loading shop: " + shop.toString());
+			List<GBAFEItemData> itemsSold = new ArrayList<GBAFEItemData>();
+			handler.setNextReadOffset(readShopAddress);
+			byte[] readBuffer;
+			do {
+				readBuffer = handler.continueReadingBytes(2);
+				if (readBuffer[0] != 0) {
+					GBAFEItemData item = itemData.itemWithID(readBuffer[0] & 0xFF);
+					DebugPrinter.log(DebugPrinter.Key.GBA_SHOP_LOADER, "Found Item: " + itemData.itemWithID(item.getID()).displayString());
+					itemsSold.add(item);
+				}
+			} while (readBuffer[0] != 0);
+			DebugPrinter.log(DebugPrinter.Key.GBA_SHOP_LOADER, "Finished shop: " + shop.toString());
+			itemMap.put(shop, itemsSold);
+			listAddressMap.put(shop, readShopAddress);
+		}
+		
+		updatedItemMap = new HashMap<GBAFEShop, List<GBAFEItemData>>();
+	}
+	
+	public List<GBAFEShop> getAllShops() {
+		return provider.orderedShops();
+	}
+	
+	public List<GBAFEItemData> getItemsInShop(GBAFEShop shop) {
+		if (shopWasUpdated(shop)) {
+			return updatedItemMap.get(shop);	
+		} else {
+			return itemMap.get(shop);
+		}
+	}
+	
+	public boolean shopWasUpdated(GBAFEShop shop) {
+		return updatedItemMap.containsKey(shop);
+	}
+	
+	public void setItemsInShop(GBAFEShop shop, List<GBAFEItemData> items) {	
+		updatedItemMap.put(shop, items);
+	}
+	
+	public boolean isArmory(GBAFEShop shop) {
+		return provider.allArmories().contains(shop);
+	}
+	
+	public boolean isVendor(GBAFEShop shop) {
+		return provider.allVendors().contains(shop);
+	}
+	
+	public boolean isMapShop(GBAFEShop shop) {
+		return provider.isMapShop(shop);
+	}
+	
+	public boolean isSecret(GBAFEShop shop) {
+		return provider.allSecretShops().contains(shop);
+	}
+	
+	public Set<GBAFEShop> linkedShops(GBAFEShop shop) {
+		return shop.groupedShops();
+	}
+	
+	public void compileDiffs(DiffCompiler diffCompiler) {
+		for (GBAFEShop shop : provider.allShops()) {
+			if (shopWasUpdated(shop) == false) { continue; }
+			
+			long originalOffset = listAddressMap.get(shop);
+			
+			List<GBAFEItemData> newItems = updatedItemMap.get(shop);
+			int bytesNeeded = (newItems.size() + 1) * 2;
+			byte[] itemData = new byte[bytesNeeded];
+			int index = 0;
+			for (GBAFEItemData item : newItems) {
+				byte itemID = (byte)(0xFF & item.getID());
+				itemData[index++] = itemID;
+				itemData[index++] = 0;
+			}
+			itemData[index++] = 0;
+			itemData[index++] = 0;
+			
+			long newOffset = freeSpace.reserveSpace(bytesNeeded, shop.toString(), true);
+			
+			diffCompiler.addDiff(new Diff(newOffset, bytesNeeded, itemData, null));
+			diffCompiler.addDiff(new Diff(shop.getPointerOffset(), 4, WhyDoesJavaNotHaveThese.gbaAddressFromOffset(newOffset), WhyDoesJavaNotHaveThese.gbaAddressFromOffset(originalOffset)));
+			
+			listAddressMap.put(shop, newOffset);
+		}
+	}
+	
+	public void recordShopData(RecordKeeper rk, Boolean isInitial, ItemDataLoader itemData, TextLoader textData) {
+		for (GBAFEShop shop : provider.orderedShops()) {
+			recordShop(rk, shop, isInitial, itemData, textData, RecordKeeperCategoryShopKey);
+		}
+	}
+
+	private void recordShop(RecordKeeper rk, GBAFEShop shop, Boolean isInitial, ItemDataLoader itemData, TextLoader textData, String category) {
+		if (isInitial) {
+			rk.recordOriginalEntry(category, shop.toString(), "ID", shop.toString());
+			rk.recordOriginalEntry(category, shop.toString(), "Pointer Offset", String.format("0x%08X", shop.getPointerOffset()));
+			rk.recordOriginalEntry(category, shop.toString(), "Shop List Address", String.format("0x%08X", shop.getOriginalShopAddress()));
+			
+			List<GBAFEItemData> items = itemMap.get(shop);
+			for (int i = 0; i < items.size(); i++) {
+				GBAFEItemData item = items.get(i);
+				rk.recordOriginalEntry(category, shop.toString(), "Item #" + (i + 1), textData.getStringAtIndex(itemData.itemWithID(item.getID()).getNameIndex(), true));
+			}
+		} else {
+			rk.recordUpdatedEntry(category, shop.toString(), "ID", shop.toString());
+			rk.recordUpdatedEntry(category, shop.toString(), "Pointer Offset", String.format("0x%08X", shop.getPointerOffset()));
+			rk.recordUpdatedEntry(category, shop.toString(), "Shop List Address", String.format("0x%08X", listAddressMap.get(shop)));
+			
+			List<GBAFEItemData> items = updatedItemMap.get(shop);
+			if (items == null) {
+				items = itemMap.get(shop);
+			}
+			for (int i = 0; i < items.size(); i++) {
+				GBAFEItemData item = items.get(i);
+				rk.recordUpdatedEntry(category, shop.toString(), "Item #" + (i + 1), textData.getStringAtIndex(itemData.itemWithID(item.getID()).getNameIndex(), true));
+			}
+		}
+		
+	}
+}

--- a/Universal FE Randomizer/src/random/gba/loader/StatboostLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/StatboostLoader.java
@@ -56,6 +56,7 @@ public class StatboostLoader {
 	}
 	
 	public void recordInitial(RecordKeeper rk, ItemDataLoader itemData, StatboosterOptions options) {
+		if (options == null) { return; }
 		for (GBAFEStatboost boost : getStatboosters(options.includeMov, options.includeCon)) {
 			for (GBAFEItemData item : itemData.itemsByStatboostAddress(boost.getAddressOffset())) {
 				String name = item.displayString();
@@ -74,6 +75,7 @@ public class StatboostLoader {
 	}
 	
 	public void recordUpdated(RecordKeeper rk, ItemDataLoader itemData, StatboosterOptions options) {
+		if (options == null) { return; }
 		for (GBAFEStatboost boost : getStatboosters(options.includeMov, options.includeCon)) {
 			for (GBAFEItemData item : itemData.itemsByStatboostAddress(boost.getAddressOffset())) {
 				String name = item.displayString();

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -56,6 +56,7 @@ public class GBARandomizer extends Randomizer {
 	private ItemAssignmentOptions itemAssignmentOptions;
 	private CharacterShufflingOptions shufflingOptions;
 	private PrfOptions prfs;
+	private ShopOptions shopOptions;
 	
 	private CharacterDataLoader charData;
 	private ClassDataLoader classData;
@@ -65,6 +66,7 @@ public class GBARandomizer extends Randomizer {
 	private PaletteLoader paletteData;
 	private TextLoader textData;
 	private PortraitDataLoader portraitData;
+	private ShopLoader shopData;
 	
 	private boolean needsPaletteFix;
 	private Map<GBAFECharacterData, GBAFECharacterData> characterMap; // valid with random recruitment. Maps slots to reference character.
@@ -86,7 +88,7 @@ public class GBARandomizer extends Randomizer {
 			GrowthOptions growths, BaseOptions bases, ClassOptions classes, WeaponOptions weapons,
 			OtherCharacterOptions other, EnemyOptions enemies, GameMechanicOptions otherOptions,
 			RecruitmentOptions recruit, ItemAssignmentOptions itemAssign, CharacterShufflingOptions shufflingOptions, StatboosterOptions statboosterOptions, 
-			RewardOptions rewards, PrfOptions prfs, String seed) {
+			RewardOptions rewards, PrfOptions prfs, ShopOptions shopOptions, String seed) {
 		super();
 		this.sourcePath = sourcePath;
 		this.targetPath = targetPath;
@@ -107,6 +109,7 @@ public class GBARandomizer extends Randomizer {
 		this.shufflingOptions = shufflingOptions;
 		this.rewardOptions = rewards;
 		this.prfs = prfs;
+		this.shopOptions = shopOptions;
 		if (itemAssignmentOptions == null) { itemAssignmentOptions = new ItemAssignmentOptions(WeaponReplacementPolicy.ANY_USABLE, ShopAdjustment.NO_CHANGE, false, false); }
 		
 		this.gameType = gameType;
@@ -180,7 +183,9 @@ public class GBARandomizer extends Randomizer {
 		charData.recordCharacters(recordKeeper, true, classData, itemData, textData);
 		classData.recordClasses(recordKeeper, true, classData, textData);
 		itemData.recordWeapons(recordKeeper, true, classData, textData, handler);
+		itemData.recordItems(recordKeeper, true, textData, handler);
 		chapterData.recordChapters(recordKeeper, true, charData, classData, itemData, textData);
+		shopData.recordShopData(recordKeeper, true, itemData, textData);
 		
 		paletteData.recordReferencePalettes(recordKeeper, charData, classData, textData);
 		statboostData.recordInitial(recordKeeper, itemData, statboosterOptions);
@@ -197,6 +202,8 @@ public class GBARandomizer extends Randomizer {
 		try { randomizeBasesIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing bases.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
 		updateProgress(0.55);
 		try { randomizeWeaponsIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing weapons.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
+		updateProgress(0.58);
+		try { randomizeShopsIfNessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing shops.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n",  Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
 		updateProgress(0.60);
 		try { randomizeOtherCharacterTraitsIfNecessary(seed); } catch (Exception e) { notifyError("Encountered error while randomizing other character traits.\n\n" + e.getClass().getSimpleName() + "\n\nStack Trace:\n\n" + String.join("\n", Arrays.asList(e.getStackTrace()).stream().map(element -> (element.toString())).limit(5).collect(Collectors.toList()))); return; }
 		updateProgress(0.65);
@@ -215,6 +222,7 @@ public class GBARandomizer extends Randomizer {
 		chapterData.compileDiffs(diffCompiler);
 		classData.compileDiffs(diffCompiler, handler, freeSpace);
 		itemData.compileDiffs(diffCompiler, handler);
+		shopData.compileDiffs(diffCompiler);
 		paletteData.compileDiffs(diffCompiler);
 		textData.commitChanges(freeSpace, diffCompiler);
 		portraitData.compileDiffs(diffCompiler);
@@ -266,8 +274,10 @@ public class GBARandomizer extends Randomizer {
 		charData.recordCharacters(recordKeeper, false, classData, itemData, textData);
 		classData.recordClasses(recordKeeper, false, classData, textData);
 		itemData.recordWeapons(recordKeeper, false, classData, textData, targetFileHandler);
+		itemData.recordItems(recordKeeper, false, textData, targetFileHandler);
 		chapterData.recordChapters(recordKeeper, false, charData, classData, itemData, textData);
 		statboostData.recordUpdated(recordKeeper, itemData, statboosterOptions);
+		shopData.recordShopData(recordKeeper, false, itemData, textData);
 		
 		if (gameType == FEBase.GameType.FE8) {
 			paletteData.recordUpdatedFE8Palettes(recordKeeper, charData, classData, textData);
@@ -338,6 +348,9 @@ public class GBARandomizer extends Randomizer {
 		updateStatusString("Loading Item Data...");
 		updateProgress(0.25);
 		itemData = new ItemDataLoader(FE7Data.itemProvider, handler, freeSpace);
+		updateStatusString("Loading Shop Data...");
+		updateProgress(0.27);
+		shopData = new ShopLoader(FE7Data.shopProvider, FE7Data.itemProvider, itemData, handler, freeSpace);
 		updateStatusString("Loading Palette Data...");
 		updateProgress(0.30);
 		paletteData = new PaletteLoader(FEBase.GameType.FE7, handler, charData, classData);
@@ -376,6 +389,9 @@ public class GBARandomizer extends Randomizer {
 		updateStatusString("Loading Item Data...");
 		updateProgress(0.25);
 		itemData = new ItemDataLoader(FE6Data.itemProvider, handler, freeSpace);
+		updateStatusString("Loading Shop Data...");
+		updateProgress(0.27);
+		shopData = new ShopLoader(FE6Data.shopProvider, FE6Data.itemProvider, itemData, handler, freeSpace);
 		updateStatusString("Loading Palette Data...");
 		updateProgress(0.30);
 		paletteData = new PaletteLoader(FEBase.GameType.FE6, handler, charData, classData);
@@ -418,6 +434,9 @@ public class GBARandomizer extends Randomizer {
 		updateStatusString("Loading Item Data...");
 		updateProgress(0.25);
 		itemData = new ItemDataLoader(FE8Data.itemProvider, handler, freeSpace);
+		updateStatusString("Loading Shop Data...");
+		updateProgress(0.27);
+		shopData = new ShopLoader(FE8Data.shopProvider, FE8Data.itemProvider, itemData, handler, freeSpace);
 		updateStatusString("Loading Palette Data...");
 		updateProgress(0.30);
 		paletteData = new PaletteLoader(FEBase.GameType.FE8, handler, charData, classData);
@@ -532,6 +551,14 @@ public class GBARandomizer extends Randomizer {
 				Random rng = new Random(SeedGenerator.generateSeedValue(seed, WeaponsRandomizer.rngSalt + 4));
 				WeaponsRandomizer.randomizeEffects(weapons.effectsList, itemData, textData, weapons.noEffectIronWeapons, weapons.noEffectSteelWeapons, weapons.noEffectThrownWeapons, weapons.effectChance, rng);
 			}
+		}
+	}
+	
+	private void randomizeShopsIfNessary(String seed) {
+		if (shopOptions != null) {
+			updateStatusString("Randomizing Shops...");
+			Random rng = new Random(SeedGenerator.generateSeedValue(seed, ShopRandomizer.rngSalt));
+			ShopRandomizer.randomizeShops(shopData, itemData, false, false, shopOptions.shopSize.minValue, shopOptions.shopSize.maxValue, rng);
 		}
 	}
 	

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -2662,19 +2662,29 @@ public class GBARandomizer extends Randomizer {
 		
 
 		if(shufflingOptions != null) {
-			StringBuilder sb = new StringBuilder();
-			sb.append(String.format("Leveling Mode: %s", shufflingOptions.getLevelingMode() == ShuffleLevelingMode.AUTOLEVEL ? "autolevel characters": "leave characters unchanged")).append("<br>");
-			sb.append(String.format("Shuffle chance: %d%%", shufflingOptions.getChance())).append("<br>");
-			sb.append(shufflingOptions.shouldChangeDescription() ? "Description will be changed" : "Description will be left unchanged").append("<br>");
-			sb.append("Included configurations:<br>");
-			for (String s : shufflingOptions.getIncludedShuffles()) {
-				sb.append(s).append("<br>");
+			if (shufflingOptions.isShuffleEnabled()) {
+				StringBuilder sb = new StringBuilder();
+				sb.append(String.format("Leveling Mode: %s", shufflingOptions.getLevelingMode() == ShuffleLevelingMode.AUTOLEVEL ? "autolevel characters": "leave characters unchanged")).append("<br>");
+				sb.append(String.format("Shuffle chance: %d%%", shufflingOptions.getChance())).append("<br>");
+				sb.append(shufflingOptions.shouldChangeDescription() ? "Description will be changed" : "Description will be left unchanged").append("<br>");
+				sb.append("Included configurations:<br>");
+				for (String s : shufflingOptions.getIncludedShuffles()) {
+					sb.append(s).append("<br>");
+				}
+				rk.addHeaderItem("Character Shuffling", sb.toString());
+			} else {
+				rk.addHeaderItem("Character Shuffling", "NO");
 			}
-			rk.addHeaderItem("Character Shuffling", sb.toString());
 		}
 		
 		if (statboosterOptions != null) {
 			statboosterOptions.record(rk);
+		}
+		
+		if (shopOptions != null) {
+			rk.addHeaderItem("Randomize Shops", "YES (" + shopOptions.shopSize.minValue + " ~ " + shopOptions.shopSize.maxValue + " items)");
+		} else {
+			rk.addHeaderItem("Randomize Shops", "NO");
 		}
 		
 		return rk;

--- a/Universal FE Randomizer/src/random/gba/randomizer/ShopRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ShopRandomizer.java
@@ -1,0 +1,213 @@
+package random.gba.randomizer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import fedata.gba.GBAFEItemData;
+import fedata.gba.general.GBAFEShop;
+import fedata.gba.general.WeaponType;
+import random.gba.loader.ItemDataLoader;
+import random.gba.loader.ShopLoader;
+import random.general.PoolDistributor;
+import random.general.WeightedDistributor;
+
+public class ShopRandomizer {
+	
+	public static int rngSalt = 8480;
+	
+	private enum ItemQuality {
+		EARLY, MID, LATE, SECRET, SUPER_SECRET;
+	}
+
+	public static void randomizeShops(ShopLoader shopData, ItemDataLoader itemData, boolean includePromoWeapons, boolean includePoisonWeapons, int minimumItemsPerShop, int maximumItemsPerShop, Random rng) {
+		List<GBAFEShop> allShops = shopData.getAllShops();
+		for (GBAFEShop shop : allShops) {
+			if (shopData.shopWasUpdated(shop)) { continue; }
+			
+			List<GBAFEShop> linked = new ArrayList<GBAFEShop>(shop.groupedShops());
+			Set<GBAFEItemData> sharedItemList = new HashSet<GBAFEItemData>();
+			
+			for (GBAFEShop currentShop : linked) {
+				WeightedDistributor<ItemQuality> distributor = new WeightedDistributor<ItemQuality>();
+				
+				switch (currentShop.getGameStage()) {
+				case EARLY:
+					// 80% early, 15% mid, 4% late, 1% secret
+					distributor.addItem(ItemQuality.EARLY, 80);
+					distributor.addItem(ItemQuality.MID, 15);
+					distributor.addItem(ItemQuality.LATE, 4);
+					distributor.addItem(ItemQuality.SECRET, 1);
+					break;
+				case MID:
+					// 15% early, 60% mid, 20% late, 4% secret, 1% rare secret
+					distributor.addItem(ItemQuality.EARLY, 15);
+					distributor.addItem(ItemQuality.MID, 60);
+					distributor.addItem(ItemQuality.LATE, 20);
+					distributor.addItem(ItemQuality.SECRET, 4);
+					distributor.addItem(ItemQuality.SUPER_SECRET, 1);
+					break;
+				case LATE:
+					// 10% early, 30% mid, 50% late, 8% secret, 2% rare secret
+					distributor.addItem(ItemQuality.EARLY, 10);
+					distributor.addItem(ItemQuality.MID, 30);
+					distributor.addItem(ItemQuality.LATE, 50);
+					distributor.addItem(ItemQuality.SECRET, 8);
+					distributor.addItem(ItemQuality.SUPER_SECRET, 2);
+					break;
+				}
+				
+				PoolDistributor<GBAFEItemData> earlyPool = new PoolDistributor<GBAFEItemData>();
+				PoolDistributor<GBAFEItemData> midPool = new PoolDistributor<GBAFEItemData>();
+				PoolDistributor<GBAFEItemData> latePool = new PoolDistributor<GBAFEItemData>();
+				PoolDistributor<GBAFEItemData> secretPool = new PoolDistributor<GBAFEItemData>();
+				PoolDistributor<GBAFEItemData> superSecretPool = new PoolDistributor<GBAFEItemData>();
+				
+				if (shopData.isArmory(currentShop)) {
+					earlyPool.addAll(itemData.earlyGameArmory());
+					midPool.addAll(itemData.midGameArmory());
+					latePool.addAll(itemData.lateGameArmory());
+					List<GBAFEItemData> secretItems = itemData.secretItems();
+					secretItems.removeIf(item -> item.getType() == WeaponType.NOT_A_WEAPON || item.getType() == WeaponType.STAFF || item.getType() == WeaponType.ANIMA || item.getType() == WeaponType.DARK || item.getType() == WeaponType.LIGHT);
+					secretPool.addAll(secretItems);
+					List<GBAFEItemData> superSecretItems = itemData.rareSecretItems();
+					superSecretItems.removeIf(item -> item.getType() == WeaponType.NOT_A_WEAPON || item.getType() == WeaponType.STAFF || item.getType() == WeaponType.ANIMA || item.getType() == WeaponType.DARK || item.getType() == WeaponType.LIGHT);
+					superSecretPool.addAll(superSecretItems);
+				} else if (shopData.isVendor(currentShop)) {
+					earlyPool.addAll(itemData.earlyGameVendor());
+					midPool.addAll(itemData.midGameVendor());
+					latePool.addAll(itemData.lateGameVendor());
+					List<GBAFEItemData> secretItems = itemData.secretItems();
+					secretItems.removeIf(item -> item.getType() == WeaponType.SWORD || item.getType() == WeaponType.LANCE || item.getType() == WeaponType.AXE || item.getType() == WeaponType.BOW);
+					secretPool.addAll(secretItems);
+					List<GBAFEItemData> superSecretItems = itemData.rareSecretItems();
+					superSecretItems.removeIf(item -> item.getType() == WeaponType.SWORD || item.getType() == WeaponType.LANCE || item.getType() == WeaponType.AXE || item.getType() == WeaponType.BOW);
+					superSecretPool.addAll(superSecretItems);
+				} else { // Secret shops.
+					distributor = new WeightedDistributor<ItemQuality>();
+					switch (currentShop.getGameStage()) {
+					case EARLY:
+						// 90% secret, 10% rare secret
+						distributor.addItem(ItemQuality.SECRET, 90);
+						distributor.addItem(ItemQuality.SUPER_SECRET, 10);
+						break;
+					case MID:
+						// 75% secret, 25% rare secret
+						distributor.addItem(ItemQuality.SECRET, 75);
+						distributor.addItem(ItemQuality.SUPER_SECRET, 25);
+						break;
+					case LATE:
+						// 60% secret, 40% rare secret
+						distributor.addItem(ItemQuality.SECRET, 60);
+						distributor.addItem(ItemQuality.SUPER_SECRET, 40);
+						break;
+					}
+					
+					List<GBAFEItemData> secretItems = itemData.secretItems();
+					secretPool.addAll(secretItems);
+					List<GBAFEItemData> superSecretItems = itemData.rareSecretItems();
+					superSecretPool.addAll(superSecretItems);
+				}
+				
+				if (includePoisonWeapons == false) {
+					for (GBAFEItemData item : itemData.getAllWeapons()) {
+						if (itemData.isPoisonWeapon(item.getID())) {
+							earlyPool.removeItem(item, true);
+							midPool.removeItem(item, true);
+							latePool.removeItem(item, true);
+							secretPool.removeItem(item, true);
+							superSecretPool.removeItem(item, true);
+						}
+					}
+				}
+				
+				if (includePromoWeapons == false) {
+					for (GBAFEItemData item : itemData.getAllWeapons()) {
+						if (itemData.isPromoWeapon(item.getID())) {
+							earlyPool.removeItem(item, true);
+							midPool.removeItem(item, true);
+							latePool.removeItem(item, true);
+							secretPool.removeItem(item, true);
+							superSecretPool.removeItem(item, true);
+						}
+					}
+				}
+				
+				List<GBAFEItemData> newShopList = new ArrayList<GBAFEItemData>();
+				int range = maximumItemsPerShop - minimumItemsPerShop;
+				int numberOfItems = rng.nextInt(range) + minimumItemsPerShop;
+				while (newShopList.size() < numberOfItems && distributor.possibleResults().isEmpty() == false) {
+					ItemQuality quality = distributor.getRandomItem(rng);
+					GBAFEItemData addedItem = null;
+					switch (quality) {
+					case EARLY:
+						addedItem = addRandomElement(newShopList, sharedItemList, earlyPool, rng, false);
+						if (addedItem == null) {
+							distributor.removeItem(ItemQuality.EARLY);
+							continue;
+						}
+						break;
+					case MID:
+						addedItem = addRandomElement(newShopList, sharedItemList, midPool, rng, false);
+						if (addedItem == null) {
+							distributor.removeItem(ItemQuality.MID);
+							continue;
+						}
+						break;
+					case LATE:
+						addedItem = addRandomElement(newShopList, sharedItemList, latePool, rng, false); 
+						if (addedItem == null) {
+							distributor.removeItem(ItemQuality.LATE);
+							continue;
+						}
+						break;
+					case SECRET:
+						addedItem = addRandomElement(newShopList, sharedItemList, secretPool, rng, true); 
+						if (addedItem == null) {
+							distributor.removeItem(ItemQuality.SECRET);
+							continue;
+						}
+						break;
+					case SUPER_SECRET:
+						addedItem = addRandomElement(newShopList, sharedItemList, superSecretPool, rng, true); 
+						if (addedItem == null) {
+							distributor.removeItem(ItemQuality.SUPER_SECRET);
+							continue;
+						}
+						break;
+					}
+					
+					if (addedItem != null) {
+						sharedItemList.add(addedItem);
+					}
+				}
+				
+				shopData.setItemsInShop(currentShop, newShopList);
+			}
+		}
+	}
+	
+	private static GBAFEItemData addRandomElement(List<GBAFEItemData> destination, Set<GBAFEItemData> excludeSet, PoolDistributor<GBAFEItemData> pool, Random rng, boolean deprioritizeWeapons) {
+		if (destination.containsAll(pool.possibleResults())) {
+			return null;
+		}
+		if (excludeSet.containsAll(pool.possibleResults())) {
+			return null;
+		}
+		
+		GBAFEItemData item = pool.getRandomItem(rng, false);
+		boolean rerolledWeapon = false;
+		while (destination.contains(item) || excludeSet.contains(item)) {
+			item = pool.getRandomItem(rng, false);
+			if (item.getType() != WeaponType.NOT_A_WEAPON && deprioritizeWeapons && !rerolledWeapon) {
+				rerolledWeapon = true;
+				item = pool.getRandomItem(rng, false);
+			}
+		}
+		destination.add(item);
+		return item;
+	}
+}

--- a/Universal FE Randomizer/src/random/gba/randomizer/StatboosterRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/StatboosterRandomizer.java
@@ -20,7 +20,7 @@ public class StatboosterRandomizer {
 	public static int SALT = 4831789;
 	
 	public static void randomize(StatboosterOptions options, StatboostLoader loader, ItemDataLoader itemData, TextLoader texts, Random rng) {
-		if (!options.enabled) {
+		if (options == null || !options.enabled) {
 			return;
 		}
 

--- a/Universal FE Randomizer/src/random/general/WeightedDistributor.java
+++ b/Universal FE Randomizer/src/random/general/WeightedDistributor.java
@@ -32,6 +32,12 @@ public class WeightedDistributor<T> {
 		itemSet.add(item);
 	}
 	
+	public void addItems(List<T> items, int weight) {
+		for (T item : items) {
+			addItem(item, weight);
+		}
+	}
+	
 	public void removeItem(T itemToRemove) {
 		if (itemToRemove == null) { return; }
 		boolean didRemove = itemList.removeIf(item -> (item == itemToRemove));

--- a/Universal FE Randomizer/src/ui/LegacyViewContainer.java
+++ b/Universal FE Randomizer/src/ui/LegacyViewContainer.java
@@ -38,6 +38,7 @@ public class LegacyViewContainer extends YuneViewContainer {
     private CharacterShufflingView characterShufflingView;
     private PrfView prfView;
     private StatboosterView statboosterView;
+    private ShopView shopView;
 
     // FE4
     private FE4SkillsView skillsView;
@@ -204,6 +205,15 @@ public class LegacyViewContainer extends YuneViewContainer {
         recruitData.top = new FormAttachment(classView.group, 0, SWT.TOP);
         recruitData.left = new FormAttachment(classView.group, 5);
         recruitView.group.setLayoutData(recruitData);
+        
+        shopView = new ShopView(this);
+        shopView.group.setSize(200, 200);
+        
+        FormData shopData = new FormData();
+        shopData.top = new FormAttachment(recruitView.group, 5);
+        shopData.left = new FormAttachment(recruitView.group, 0, SWT.LEFT);
+        shopData.right = new FormAttachment(recruitView.group, 0, SWT.RIGHT);
+        shopView.group.setLayoutData(shopData);
 
         characterShufflingView = new CharacterShufflingView(this, type);
         characterShufflingView.group.setSize(200, 200);
@@ -321,6 +331,7 @@ public class LegacyViewContainer extends YuneViewContainer {
         enemyView.initialize(bundle.enemies);
         miscView.initialize(bundle.otherOptions);
         rewardView.initialize(bundle.rewards);
+        shopView.initialize(bundle.shopOptions);
 
         // GBA Specific
         prfView.initialize(bundle.prfs);
@@ -339,6 +350,7 @@ public class LegacyViewContainer extends YuneViewContainer {
         bundle.classes = classView.getOptions();
         bundle.enemies = enemyView.getOptions();
         bundle.weapons = weaponView.getOptions();
+        bundle.shopOptions = shopView.getOptions();
 
         // GBA specific
         bundle.prfs = prfView.getOptions();

--- a/Universal FE Randomizer/src/ui/RandomizeButtonListener.java
+++ b/Universal FE Randomizer/src/ui/RandomizeButtonListener.java
@@ -97,7 +97,7 @@ public class RandomizeButtonListener implements Listener {
             GBAOptionBundle bundle = (GBAOptionBundle) baseBundle;
             // Update the Bundle in the Option Recorder
             OptionRecorder.recordGBAFEOptions(bundle, type);
-            randomizer = new GBARandomizer(sourceFile, writePath, type, compiler, bundle.growths, bundle.bases, bundle.classes, bundle.weapons, bundle.other, bundle.enemies, bundle.otherOptions, bundle.recruitmentOptions, bundle.itemAssignmentOptions, bundle.characterShufflingOptions, bundle.statboosterOptions, bundle.rewards, bundle.prfs, bundle.seed);
+            randomizer = new GBARandomizer(sourceFile, writePath, type, compiler, bundle.growths, bundle.bases, bundle.classes, bundle.weapons, bundle.other, bundle.enemies, bundle.otherOptions, bundle.recruitmentOptions, bundle.itemAssignmentOptions, bundle.characterShufflingOptions, bundle.statboosterOptions, bundle.rewards, bundle.prfs, bundle.shopOptions, bundle.seed);
         } else if (type.isSFC()) {
             // Update the Bundle in the Option Recorder
             FE4OptionBundle bundle = (FE4OptionBundle) baseBundle;

--- a/Universal FE Randomizer/src/ui/model/ShopOptions.java
+++ b/Universal FE Randomizer/src/ui/model/ShopOptions.java
@@ -1,0 +1,11 @@
+package ui.model;
+
+public class ShopOptions {
+
+	public final MinMaxOption shopSize;
+	
+	public ShopOptions(MinMaxOption shopSize) {
+		super();
+		this.shopSize = shopSize;
+	}
+}

--- a/Universal FE Randomizer/src/ui/tabs/gba/GBAItemsTab.java
+++ b/Universal FE Randomizer/src/ui/tabs/gba/GBAItemsTab.java
@@ -8,6 +8,7 @@ import ui.common.YuneTabItem;
 import ui.views.ItemAssignmentView;
 import ui.views.PrfView;
 import ui.views.RewardRandomizationView;
+import ui.views.ShopView;
 import ui.views.WeaponsView;
 import ui.views.StatboosterView;
 import util.OptionRecorder;
@@ -30,6 +31,7 @@ public class GBAItemsTab extends YuneTabItem {
     private RewardRandomizationView rewards;
     private PrfView prfs;
     private StatboosterView statboosters;
+    private ShopView shops;
 
     public GBAItemsTab(CTabFolder parent, FEBase.GameType type) {
         super(parent, type);
@@ -38,16 +40,17 @@ public class GBAItemsTab extends YuneTabItem {
     @Override
     protected void compose() {
         weapons = addView(new WeaponsView(container, type, 2), GuiUtil.defaultGridData(2));
-        setViewData(weapons, 1, 3);
+        setViewData(weapons, 1, 4);
         itemAssignment = addView(new ItemAssignmentView(container, type));
 
         // these two views are located below the weapons view which has a colspan of two.
         // But since there is a margin of 5 pixels between the two, views, they would be a bit wider and so misaligned.
         // reduce each of these views by 5px to make sure they are properly aligned with the weapons view
         statboosters = addView(new StatboosterView(container));
-        setViewData(statboosters, 1, 3);
+        setViewData(statboosters, 1, 4);
         rewards = addView(new RewardRandomizationView(container, type));
         prfs = addView(new PrfView(container));
+        shops = addView(new ShopView(container));
     }
 
     @Override
@@ -72,6 +75,7 @@ public class GBAItemsTab extends YuneTabItem {
         this.rewards.initialize(bundle.rewards);
         this.prfs.initialize(bundle.prfs);
         this.statboosters.initialize(bundle.statboosterOptions);
+        this.shops.initialize(bundle.shopOptions);
     }
 
     @Override
@@ -81,5 +85,6 @@ public class GBAItemsTab extends YuneTabItem {
         bundle.rewards = rewards.getOptions();
         bundle.prfs = prfs.getOptions();
         bundle.statboosterOptions = statboosters.getOptions();
+        bundle.shopOptions = shops.getOptions();
     }
 }

--- a/Universal FE Randomizer/src/ui/views/CharacterShufflingView.java
+++ b/Universal FE Randomizer/src/ui/views/CharacterShufflingView.java
@@ -276,26 +276,27 @@ public class CharacterShufflingView extends YuneView<CharacterShufflingOptions> 
 			includeFE8Button.setEnabled(false);
 			selectFilesButton.setEnabled(false);
 		} else {
-			enableButton.setSelection(true);
+			boolean isEnabled = options.isShuffleEnabled();
+			enableButton.setSelection(isEnabled);
 			
-			modeContainer.setEnabled(true);
+			modeContainer.setEnabled(isEnabled);
 			
-			autoLevelingButton.setEnabled(true);
+			autoLevelingButton.setEnabled(isEnabled);
 			autoLevelingButton.setSelection(ShuffleLevelingMode.AUTOLEVEL.equals(options.getLevelingMode()));
 			
-			unchangedButton.setEnabled(true);
+			unchangedButton.setEnabled(isEnabled);
 			unchangedButton.setSelection(ShuffleLevelingMode.UNCHANGED.equals(options.getLevelingMode()));
 
-			shuffleChanceSpinner.setEnabled(true);
+			shuffleChanceSpinner.setEnabled(isEnabled);
 			shuffleChanceSpinner.setSelection(options.getChance());
 			
-			includeFE6Button.setEnabled(!GameType.FE6.equals(type));
+			includeFE6Button.setEnabled(!GameType.FE6.equals(type) && isEnabled);
 			includeFE6Button.setSelection(!GameType.FE6.equals(type) && options.getIncludedShuffles().contains("fe6chars.json"));
 			
-			includeFE7Button.setEnabled(!GameType.FE7.equals(type));
+			includeFE7Button.setEnabled(!GameType.FE7.equals(type) && isEnabled);
 			includeFE7Button.setSelection(!GameType.FE7.equals(type) && options.getIncludedShuffles().contains("fe7chars.json"));
 			
-			includeFE8Button.setEnabled(!GameType.FE8.equals(type));
+			includeFE8Button.setEnabled(!GameType.FE8.equals(type) && isEnabled);
 			includeFE8Button.setSelection(!GameType.FE8.equals(type) && options.getIncludedShuffles().contains("fe8chars.json"));
 		}
 	}

--- a/Universal FE Randomizer/src/ui/views/ShopView.java
+++ b/Universal FE Randomizer/src/ui/views/ShopView.java
@@ -1,0 +1,90 @@
+package ui.views;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import ui.general.MinMaxControl;
+import ui.model.GrowthOptions;
+import ui.model.MinMaxOption;
+import ui.model.ShopOptions;
+
+public class ShopView extends YuneView<ShopOptions> {
+	private Boolean isEnabled = false;
+	
+	private Button enableButton;
+	
+	private MinMaxControl shopSizeControl;
+	
+	public ShopView(Composite parent) {
+		super();
+		createGroup(parent);
+		compose();
+	}
+	
+	@Override
+	public String getGroupTitle() {
+		return "Shops";
+	}
+
+	@Override
+	public String getGroupTooltip() {
+		return "Randomizes the items sold in all shops.";
+	}
+
+	@Override
+	protected void compose() {
+		enableButton = new Button(group, SWT.CHECK);
+		enableButton.setText("Enable Shop Randomization");
+		enableButton.addListener(SWT.Selection, new Listener() {
+			@Override
+			public void handleEvent(Event event) {
+				setEnabled(enableButton.getSelection());
+			}
+		});
+		
+		shopSizeControl = new MinMaxControl(group, SWT.NONE, "Min Items:", "Max Items:");
+		shopSizeControl.getMinSpinner().setValues(4, 0, 20, 0, 1, 5);
+		shopSizeControl.getMaxSpinner().setValues(12, 0, 24, 0, 1, 5);
+		shopSizeControl.setEnabled(false);
+
+		FormData rangeData = new FormData();
+		rangeData.top = new FormAttachment(enableButton, 10);
+		rangeData.left = new FormAttachment(0, 5);
+		rangeData.right = new FormAttachment(100, -5);
+		shopSizeControl.setLayoutData(rangeData);
+	}
+	
+	private void setEnabled(boolean isEnabled) {
+		this.isEnabled = isEnabled;
+		shopSizeControl.setEnabled(isEnabled);
+	}
+
+	@Override
+	public void initialize(ShopOptions options) {
+		if (options != null) {
+			enableButton.setSelection(true);
+			shopSizeControl.setEnabled(true);
+			shopSizeControl.setMin(options.shopSize.minValue);
+			shopSizeControl.setMax(options.shopSize.maxValue);
+			isEnabled = true;
+		} else {
+			enableButton.setSelection(false);
+			shopSizeControl.setEnabled(false);
+			isEnabled = false;
+		}
+	}
+
+	@Override
+	public ShopOptions getOptions() {
+		if (isEnabled) {
+			return new ShopOptions(shopSizeControl.getMinMaxOption());
+		}
+		
+		return null;
+	}
+}

--- a/Universal FE Randomizer/src/util/DebugPrinter.java
+++ b/Universal FE Randomizer/src/util/DebugPrinter.java
@@ -14,7 +14,7 @@ public class DebugPrinter {
 		
 		PALETTE("Palette"), CHAPTER_LOADER("ChapterLoader"), DIFF("Diff"), HUFFMAN("Huffman"), TEXT_LOADING("Text"), RANDOM("Random"), FREESPACE("Free Space"), WEAPONS("Weapon Effect"), UPS("UPS"), CLASS_RANDOMIZER("Class Random"),
 		PALETTE_RECYCLER("Palette Recycling"), FE8_SUMMONER_MODULE("Summoner"), FE4_CHARACTER_LOADER("FE4 Character Loader"), FE4_ITEM_MAPPER("FE4 Item Mapper"), FE4_SKILL_RANDOM("FE4 Skill Randomizer"), 
-		GBA_TEXT_CODE_CHANGE("GBAFE Text Change"), GBA_RANDOM_RECRUITMENT("GBA Random Recruitment"), LZ77("LZ77"), 
+		GBA_TEXT_CODE_CHANGE("GBAFE Text Change"), GBA_RANDOM_RECRUITMENT("GBA Random Recruitment"), LZ77("LZ77"), GBA_SHOP_LOADER("Shop Loader"),
 		
 		GCN_HANDLER("GCN Handler"), FE9_CHARACTER_LOADER("FE9 Character Loader"), FE9_TEXT_LOADER("FE9 Text Loader"),
 		FE9_CLASS_LOADER("FE9 Class Loader"), FE9_ITEM_LOADER("FE9 Item Loader"), FE9_SKILL_LOADER("FE9 Skill Loader"),
@@ -65,6 +65,8 @@ public class DebugPrinter {
 	
 	private static Boolean shouldPrintLabel(Key label) {
 		switch (label) {
+		case GBA_SHOP_LOADER:
+			return true;
 //		case MAIN:
 		case PALETTE:
 			return true;

--- a/Universal FE Randomizer/src/util/OptionRecorder.java
+++ b/Universal FE Randomizer/src/util/OptionRecorder.java
@@ -13,7 +13,7 @@ import java.util.prefs.Preferences;
 
 public class OptionRecorder {
     private static final Integer FE4OptionBundleVersion = 7;
-    private static final Integer GBAOptionBundleVersion = 16;
+    private static final Integer GBAOptionBundleVersion = 17;
     private static final Integer FE9OptionBundleVersion = 14;
 
     public static class AllOptions {
@@ -38,6 +38,7 @@ public class OptionRecorder {
         public ItemAssignmentOptions itemAssignmentOptions;
         public CharacterShufflingOptions characterShufflingOptions;
         public StatboosterOptions statboosterOptions;
+        public ShopOptions shopOptions;
         public PrfOptions prfs;
     }
 
@@ -312,7 +313,7 @@ public class OptionRecorder {
     }
 
     public static void recordGBAFEOptions(GameType gameType, GrowthOptions growths, BaseOptions bases, ClassOptions classes, WeaponOptions weapons,
-                                          OtherCharacterOptions other, EnemyOptions enemies, GameMechanicOptions otherOptions, RewardOptions rewards, RecruitmentOptions recruitment, ItemAssignmentOptions itemAssignment, CharacterShufflingOptions shufflingOptions, StatboosterOptions statboosterOptions, String seed) {
+                                          OtherCharacterOptions other, EnemyOptions enemies, GameMechanicOptions otherOptions, RewardOptions rewards, RecruitmentOptions recruitment, ItemAssignmentOptions itemAssignment, CharacterShufflingOptions shufflingOptions, StatboosterOptions statboosterOptions, ShopOptions shopOptions, String seed) {
         GBAOptionBundle bundle = new GBAOptionBundle();
         bundle.growths = growths;
         bundle.bases = bases;
@@ -327,6 +328,8 @@ public class OptionRecorder {
         bundle.characterShufflingOptions = shufflingOptions;
         bundle.statboosterOptions = statboosterOptions;
         bundle.rewards = rewards;
+        bundle.shopOptions = shopOptions;
+        
         recordGBAFEOptions(bundle, gameType);
     }
 

--- a/Universal FE Randomizer/src/util/WhyDoesJavaNotHaveThese.java
+++ b/Universal FE Randomizer/src/util/WhyDoesJavaNotHaveThese.java
@@ -113,6 +113,16 @@ public class WhyDoesJavaNotHaveThese {
 		return new byte[] {(byte)(address & 0xFF), (byte)((address & 0xFF00) >> 8), (byte)((address & 0xFF0000) >> 16), (byte)((address & 0xFF000000) >> 24)};
 	}
 	
+	public static int intValueFromByteSubarray(byte[] data, int start, int length, boolean isLittleEndian) {
+		byte[] effectiveData = new byte[length];
+		for (int i = 0; i < length; i++) {
+			effectiveData[i] = data[start + i];
+		}
+		
+		long value = longValueFromByteArray(effectiveData, isLittleEndian);
+		return (int)value;
+	}
+	
 	public static byte[] byteArrayFromByteList(List<Byte> byteList) {
 		byte[] byteArray = new byte[byteList.size()];
 		for (int i = 0; i < byteList.size(); i++) {

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordBuilder.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordBuilder.java
@@ -32,7 +32,7 @@ public class RecordBuilder {
             if (currentColumn == 0)
                 output.append("<tr>\n");
 
-            output.append(String.format("<td><a href=\"#%s\">%s</a></td>\n", entry, entry));
+            output.append(String.format("<td><a href=\"#%s\">%s</a></td>\n", keyFromString(entry), entry));
             currentColumn += 1;
             if (currentColumn == columns) {
                 output.append("</tr>\n");

--- a/Universal FE Randomizer/src/util/recordkeeper/RecordCategoryMap.java
+++ b/Universal FE Randomizer/src/util/recordkeeper/RecordCategoryMap.java
@@ -6,10 +6,13 @@ import java.util.stream.Collectors;
 public class RecordCategoryMap {
 	private boolean sorted = false;
 	private Map<String, RecordEntry> entries = new HashMap<>();
+	private List<String> orderedKeys = new ArrayList<String>();
 
 	public void addEntry(String key, RecordEntry entry) {
 		if (!entries.containsKey(key))
 			entries.put(key, entry);
+		
+		orderedKeys.add(key);
 	}
 
 	public RecordEntry getEntry(String key) {
@@ -21,11 +24,13 @@ public class RecordCategoryMap {
 	}
 
 	public List<String> getKeyList() {
-		List<RecordEntry> entryList = new ArrayList<>(entries.values());
 		if (sorted) {
+			List<RecordEntry> entryList = new ArrayList<>(entries.values());
 			Collections.sort(entryList, entryList.get(0).getComparator());
+			return entryList.stream().map(e -> e.entryKey).collect(Collectors.toList());
+		} else {
+			return orderedKeys;
 		}
-		return entryList.stream().map(e -> e.entryKey).collect(Collectors.toList());
 	}
 
 	public void setSorted() {


### PR DESCRIPTION
This Pull Request adds the ability to randomize shops with simple options available. Shops are pre-determined to be either Early game, Mid game, or Late game, with corresponding item pools. For the time being, this is all hard-coded, but maybe we can expose these levers if we can find a good way to specify them without overcomplicating it.

For the time being, weapons are largely determined by rank for when they show up. The early game pool is entirely made up of E rank weapons (and Flux). The mid-game pool includes D and C rank weapons. The late-game pool includes B and A rank weapons.

While shops are denoted as Early/Mid/Late game, they do not strictly use their corresponding pool. Instead, each stage of shop has a different distribution of which pool to use. These can be found in `ShopRandomizer.java`.

* Early game: 80% early pool, 15% mid pool, 4% late pool, 1% secret pool (pool for secret shop items).
* Mid game: 15% early pool, 60% mid pool, 20% late pool, 4% secret pool, 1% super secret pool (pool for "rare" secret shop items)
* Late game: 10% early pool, 30% mid pool, 50% late pool, 8% secret pool, 2% super secret pool

The only control given to the user for now is the ability to define how many items are in each shop. In vanilla, shop sizes range from 2 all the way to 20+, so by default, it's set to 4 - 12 as a middle ground, but this is adjustable.