### PR TITLE
Smart growths and Smart bases

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
@@ -2,6 +2,7 @@ package fedata.gba;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 
 import fedata.gba.fe7.FE7Data;
 import fedata.gba.general.WeaponRank;
@@ -136,6 +137,10 @@ public abstract class GBAFEClassData extends AbstractGBAData implements FEPrinta
 	
 	public GBAFEStatDto getGrowths() {
 		return new GBAFEStatDto(getHPGrowth(), getSTRGrowth(), getSKLGrowth(), getSPDGrowth(), getDEFGrowth(), getRESGrowth(), getLCKGrowth());
+	}
+	
+	public List<GBAFEStatDto.Stat> getGrowthStatOrder() {
+		return getGrowths().orderedStats();
 	}
 	
 	public int getBaseHP() {

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEClassData.java
@@ -139,8 +139,14 @@ public abstract class GBAFEClassData extends AbstractGBAData implements FEPrinta
 		return new GBAFEStatDto(getHPGrowth(), getSTRGrowth(), getSKLGrowth(), getSPDGrowth(), getDEFGrowth(), getRESGrowth(), getLCKGrowth());
 	}
 	
-	public List<GBAFEStatDto.Stat> getGrowthStatOrder() {
-		return getGrowths().orderedStats();
+	// Defense growths are generally lower than offense growths, so this helps to adjust that slightly.
+	public List<GBAFEStatDto.Stat> getGrowthStatOrder(boolean adjustDefenses) {
+		GBAFEStatDto growths = getGrowths();
+		if (adjustDefenses) {
+			growths.def += 5;
+			growths.res += 5;
+		}
+		return growths.orderedStats();
 	}
 	
 	public int getBaseHP() {

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEStatDto.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEStatDto.java
@@ -1,6 +1,8 @@
 package fedata.gba;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import util.WhyDoesJavaNotHaveThese;
@@ -23,6 +25,9 @@ public class GBAFEStatDto {
 	public int res;
 	public int lck;
 	
+	public enum Stat {
+		HP, POW, SKL, SPD, DEF, RES, LCK
+	}
 	
 	/**
 	 * Empty default constructor 
@@ -65,6 +70,47 @@ public class GBAFEStatDto {
 		def = args[4];
 		res = args[5];
 		lck = args[6];
+	}
+	
+	/**
+	 * Returns a stat list that is ordered from the highest value to the lowest value.
+	 */
+	public List<Stat> orderedStats() {
+		List<Stat> list = new ArrayList<Stat>();
+		GBAFEStatDto workingDTO = new GBAFEStatDto(hp, str, skl, spd, def, res, lck);
+		for (int i = 0; i < 7; i++) {
+			Stat highest = workingDTO.highestStat();
+			if (highest == null) { break; }
+			list.add(highest);
+			workingDTO.invalidateStat(highest);
+		}
+		
+		return list;
+	}
+	
+	private void invalidateStat(Stat stat) {
+		switch (stat) {
+		case HP: hp = -1; break;
+		case POW: str = -1; break;
+		case SKL: skl = -1; break;
+		case SPD: spd = -1; break;
+		case LCK: lck = -1; break;
+		case DEF: def = -1; break;
+		case RES: res = -1; break;
+		}
+	}
+	
+	private Stat highestStat() {
+		List<Integer> list = asList();
+		int highest = Collections.max(list);
+		if (highest == hp) { return Stat.HP; }
+		else if (highest == str) { return Stat.POW; }
+		else if (highest == skl) { return Stat.SKL; }
+		else if (highest == spd) { return Stat.SPD; }
+		else if (highest == lck) { return Stat.LCK; }
+		else if (highest == def) { return Stat.DEF; }
+		else if (highest == res) { return Stat.RES; }
+		else { return null; }
 	}
 	
 	/**

--- a/Universal FE Randomizer/src/fedata/gba/GBAFEStatDto.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEStatDto.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import util.WhyDoesJavaNotHaveThese;
 
@@ -136,6 +137,63 @@ public class GBAFEStatDto {
 	}
 	
 	/**
+	 * Returns a new GBAFEStatDto with its stats multiplied. Does not modify the original.
+	 */
+	public GBAFEStatDto multipliedBy(int multiplier) {
+		return new GBAFEStatDto(
+				hp * multiplier,
+				str * multiplier,
+				skl * multiplier,
+				spd * multiplier,
+				def * multiplier,
+				res * multiplier,
+				lck * multiplier
+				);
+	}
+	
+	/**
+	 * Divides all the stats with a divisor. By default the result is floored, but can be overridden to ceiling instead.
+	 */
+	public GBAFEStatDto dividedBy(int divisor, boolean ceil) {
+		if (ceil) {
+			return new GBAFEStatDto(
+					(int)Math.ceil((double)hp / (double)divisor),
+					(int)Math.ceil((double)str / (double)divisor),
+					(int)Math.ceil((double)skl / (double)divisor),
+					(int)Math.ceil((double)spd / (double)divisor),
+					(int)Math.ceil((double)def / (double)divisor),
+					(int)Math.ceil((double)res / (double)divisor),
+					(int)Math.ceil((double)lck / (double)divisor)
+					);
+		} else {
+			return new GBAFEStatDto(
+					hp / divisor,
+					str / divisor,
+					skl / divisor,
+					spd / divisor,
+					def / divisor,
+					res / divisor,
+					lck / divisor
+					);
+		}
+	}
+	
+	/**
+	 * Returns the remainder of each stat when divided by the divisor.
+	 */
+	public GBAFEStatDto remainderFor(int divisor) {
+		return new GBAFEStatDto(
+				hp % divisor,
+				str % divisor,
+				skl % divisor,
+				spd % divisor,
+				def % divisor,
+				res % divisor,
+				lck % divisor
+				);
+	}
+	
+	/**
 	 * Adds the stats of the given DAO to the current instance
 	 */
 	public GBAFEStatDto add(GBAFEStatDto other) {
@@ -148,6 +206,21 @@ public class GBAFEStatDto {
 		this.lck += other.lck;
 		return this;
 	} 
+	
+	/**
+	 * Adds stats from a second set and returns the rsults. Does not modify the original.
+	 */
+	public GBAFEStatDto addedWith(GBAFEStatDto other) {
+		return new GBAFEStatDto(
+				this.hp + other.hp,
+				this.str + other.str,
+				this.skl + other.skl,
+				this.spd + other.spd,
+				this.def + other.def,
+				this.res + other.res,
+				this.lck + other.lck
+				);
+	}
 	
 	/**
 	 * Substracts the stats from the given DAO from the current instance
@@ -209,6 +282,32 @@ public class GBAFEStatDto {
 		if (o1.res < o2.res) { dao.res += o1.res - o2.res; }
 		if (o1.lck < o2.lck) { dao.lck += o1.lck - o2.lck; }
 		return dao;
+	}
+	
+	/**
+	 * Determines the expected value of a set of base stats when leveled up a certain amount of levels
+	 * at a given set of growths, where the final value is the cumulative growth over the levels
+	 * with the remainder past 100 represented as a chance for an additional +1 after that.
+	 * 
+	 * 
+	 * For example, if the growth passed in is 25%:
+	 * If leveling up by 1, then the cumulative growth is 25%, so the result is +0 with a 25% chance of +1.
+	 * If leveling up by 3, then the cumulative growth is 75%, so the result is +0 with a 75% chance of +1.
+	 * If leveling up by 5, then the cumulative growth is 125%, so the result is +1 with a 25% chance of +2.
+	 * If leveling up by 10, then the cumulative growth is 250%, so the result is +2 with a 50% chance of +3.
+	 */
+	public static GBAFEStatDto expectedValueLevel(GBAFEStatDto bases, GBAFEStatDto growths, int numberOfLevels, Random rng) {
+		GBAFEStatDto cumulativeGrowths = growths.multipliedBy(numberOfLevels);
+		GBAFEStatDto workingStats = bases.addedWith(cumulativeGrowths.dividedBy(100, false));
+		GBAFEStatDto remainderGrowths = growths.remainderFor(100);
+		if (rng.nextInt(100) < remainderGrowths.hp) { workingStats.hp += 1; }
+		if (rng.nextInt(100) < remainderGrowths.str) { workingStats.str += 1; }
+		if (rng.nextInt(100) < remainderGrowths.skl) { workingStats.skl += 1; }
+		if (rng.nextInt(100) < remainderGrowths.spd) { workingStats.spd += 1; }
+		if (rng.nextInt(100) < remainderGrowths.def) { workingStats.def += 1; }
+		if (rng.nextInt(100) < remainderGrowths.res) { workingStats.res += 1; }
+		if (rng.nextInt(100) < remainderGrowths.lck) { workingStats.lck += 1; }
+		return workingStats;
 	}
 	
 	@Override

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -74,6 +74,12 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public static final int PaletteEntryCount = 130;
 	public static final int PaletteEntrySize = 16;
 	
+	// Delphi Shield logic is a hard coded check against the effectiveness pointer of a weapon.
+	// This address it checks against is 0x86615DB, which can be found at the following offset
+	// and should be replaced if we create our own effectiveness pointers.
+	public static final long FlierEffectivenessPointer = 0x86615DBL;
+	public static final int DelphiShieldEffectivenessCheckPointer = 0x16A84;
+	
 	// These are spaces confirmed free inside the natural ROM size (0xFFFFFF).
 	// It's somewhat limited, so let's not use these unless we absolutely have to (like for palettes).
 	// These are only valid when patched. The JP ROM does *not* have these.

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -1881,7 +1881,7 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {8, 5, 6}, new int[] {11, 12, 13, 14}, new int[] {});
 					break;
 				case CAVALIER:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 9, 10}, new int[] {3, 5});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 9, 10}, new int[] {});
 					break;
 				case CLERIC:
 				case PRIEST:

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -125,6 +125,12 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public static final int LuciusEquipment1IDOffset = 0x7D0C2;
 	public static final int LuciusEquipment2IDOffset = 0x7D0D8;
 	
+	// Delphi Shield logic is a hard coded check against the effectiveness pointer of a weapon.
+	// This address it checks against is 0x8C97ED2, which can be found at the following offset
+	// and should be replaced if we create our own effectiveness pointers.
+	public static final long FlierEffectivenessPointer = 0x8C97ED2L;
+	public static final int DelphiShieldEffectivenessCheckPointer = 0x168A0;
+	
 	// These are spaces confirmed free inside the natural ROM size (0xFFFFFF).
 	// It's somewhat limited, so let's not use these unless we absolutely have to (like for palettes).
 	public static final List<AddressRange> InternalFreeRange = createFreeRangeList();

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -1939,6 +1939,8 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		
 		public CharacterClass[] blacklistedClasses() {
 			switch(this) {
+			case CHAPTER_2:
+				return new CharacterClass[] {CharacterClass.BRIGAND}; // Give Ross/Garcia a chance so that they don't get mobbed by fliers.
 			case CHAPTER_5X:
 				return new CharacterClass[] {CharacterClass.WYVERN_RIDER, CharacterClass.WYVERN_RIDER_F}; // The cutscene after the chapter has wyvern riders flying on screen. Keep those the same.
 			case CHAPTER_6:
@@ -2521,7 +2523,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7, 8}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
 					break;
 				case EIRIKA_MASTER_LORD:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7, 8}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
 					break;
 				case EPHRAIM_LORD:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7, 8}, new int[] {12, 13, 14}, new int[] {9, 10}, new int[] {});

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2626,7 +2626,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					break;
 				case CAVALIER:
 				case CAVALIER_F:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 3, 9, 5, 10, 11}, new int[] {});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 9, 10}, new int[] {});
 					break;
 				case PALADIN:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {}, new int[] {8, 9, 10, 11}, new int[] {}, new int[] {});

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -101,6 +101,12 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	public static final int WorldMapEventItemSize = 4;
 	public static final int WorldMapEventCount = 58;
 	
+	// Fili Shield logic is a hard coded check against the effectiveness pointer of a weapon.
+	// This address it checks against is 0x88ADF2A, which can be found at the following offset
+	// and should be replaced if we create our own effectiveness pointers.
+	public static final long FlierEffectivenessPointer = 0x88ADF2AL;
+	public static final int FiliShieldEffectivenessCheckPointer = 0x16C74;
+	
 	// These are spaces confirmed free inside the natural ROM size (0xFFFFFF).
 	// It's somewhat limited, so let's not use these unless we absolutely have to (like for palettes).
 	public static final List<AddressRange> InternalFreeRange = createFreeRangeList();

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -2524,10 +2524,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {9, 10, 11}, new int[] {12, 13, 14});
 					break;
 				case EPHRAIM_LORD:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7, 8}, new int[] {}, new int[] {9, 10}, new int[] {12, 13, 14});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7, 8}, new int[] {12, 13, 14}, new int[] {9, 10}, new int[] {});
 					break;
 				case EPHRAIM_MASTER_LORD:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {}, new int[] {9, 10}, new int[] {});
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {12, 13, 14}, new int[] {9, 10}, new int[] {});
 					break;
 				case TRAINEE:
 				case TRAINEE_2:
@@ -2602,13 +2602,15 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 				case SWORDMASTER:
 				case SWORDMASTER_F:
 				case ARCHER:
-				case ARCHER_F:
 				case SNIPER:
 				case SNIPER_F:
 				case MONK:
 				case PRIEST:
 				case CLERIC:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {11, 12, 13, 14}, new int[] {});
+					break;
+				case ARCHER_F:
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {11, 12, 13, 14}, new int[] {8, 9});
 					break;
 				case FIGHTER:
 				case BRIGAND:
@@ -2627,7 +2629,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 3, 9, 5, 10, 11}, new int[] {});
 					break;
 				case PALADIN:
-					this.info = new PaletteInfo(classID, charID, offset, new int[] {}, new int[] {8, 9, 10, 11}, new int[] {6, 7}, new int[] {5, 3, 4}); // Secondary is shield (which is blended with white). Tertiary is mane + shield crest.
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {}, new int[] {8, 9, 10, 11}, new int[] {}, new int[] {});
 					break;
 				case PALADIN_F:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {8, 9, 10}, new int[] {5, 3, 4}); // Hair also affects shield. Secondary is mane + shield crest.
@@ -2663,8 +2665,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {7, 6}, new int[] {9, 10, 14}, new int[] {});
 					break;
 				case MAGE:
-				case MAGE_F:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {6, 7}, new int[] {12, 13, 14}, new int[] {8, 9, 10});
+					break;
+				case MAGE_F:
+					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {12, 13, 14}, new int[] {8, 9, 10});
 					break;
 				case SAGE:
 					this.info = new PaletteInfo(classID, charID, offset, new int[] {5, 6, 7}, new int[] {11, 12, 13, 14}, new int[] {8, 9, 10});

--- a/Universal FE Randomizer/src/fedata/gba/general/PaletteColor.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/PaletteColor.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import util.DebugPrinter;
 import util.WhyDoesJavaNotHaveThese;
 
 public class PaletteColor implements Comparable<PaletteColor> {
@@ -131,10 +132,16 @@ public class PaletteColor implements Comparable<PaletteColor> {
 		
 		// Remove dupes first, if any.
 		List<PaletteColor> colorsArray = new ArrayList<PaletteColor>();
-		Set<String> uniqueColors = new HashSet<String>();
 		for (PaletteColor color : colors) {
-			if (uniqueColors.contains(color.toHexString())) { continue; }
-			uniqueColors.add(color.toHexString());
+			// Consider any color where the difference between the individual R G B values between two colors is less than
+			// or equal to 24 (one tick of 8 on each channel) to be "identical".
+			if (colorsArray.stream().anyMatch(current -> 
+			(Math.abs(color.getRedValue() - current.getRedValue()) + 
+					Math.abs(color.getGreenValue() - current.getGreenValue()) + 
+					Math.abs(color.getBlueValue() - current.getBlueValue()) <= 24))) {
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "Dropping color for being too similar to an existing color: " + color.toHexString());
+				continue;
+			}
 			colorsArray.add(color);
 		}
 					

--- a/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
@@ -16,6 +16,9 @@ import fedata.gba.GBAFECharacterData;
 import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
+import fedata.gba.fe6.FE6Data;
+import fedata.gba.fe7.FE7Data;
+import fedata.gba.fe8.FE8Data;
 import fedata.gba.general.GBAFEClass;
 import fedata.gba.general.GBAFEItem;
 import fedata.gba.general.GBAFEItemProvider;
@@ -23,6 +26,7 @@ import fedata.gba.general.WeaponRanks;
 import fedata.gba.general.GBAFEPromotionItem;
 import fedata.gba.general.WeaponRank;
 import fedata.gba.general.WeaponType;
+import fedata.general.FEBase.GameType;
 import io.FileHandler;
 import util.AddressRange;
 import util.ByteArrayBuilder;
@@ -167,7 +171,7 @@ public class ItemDataLoader {
 		}
 	}
 	
-	public void prepareForRandomization() {
+	public void prepareForRandomization(GameType type, DiffCompiler diffCompiler) {
 		// Translate existing effectiveness pointers to our new ones.
 		for (GBAFEItemData itemData : itemMap.values()) {
 			long ptr = itemData.getEffectivenessPointer();
@@ -179,6 +183,30 @@ public class ItemDataLoader {
 				newPtr += 0x8000000L;
 				itemData.setEffectivenessPointer(newPtr);
 			}
+		}
+		
+		// Delphi/Fili Shield uses a hard coded pointer check. Since we create
+		// a new effectiveness pointer for fliers, we need to overwrite that check
+		// too.
+		int delphiPointer = 0;
+		long oldAddress = 0;
+		long flierEffectivenessAddress = offsetsForAdditionalData.get(AdditionalData.FLIERS_EFFECT);
+		if (type == GameType.FE6) {
+			oldAddress = FE6Data.FlierEffectivenessPointer;
+			delphiPointer = FE6Data.DelphiShieldEffectivenessCheckPointer;
+		} else if (type == GameType.FE7) {
+			oldAddress = FE7Data.FlierEffectivenessPointer;
+			delphiPointer = FE7Data.DelphiShieldEffectivenessCheckPointer;
+		} else if (type == GameType.FE8) {
+			oldAddress = FE8Data.FlierEffectivenessPointer;
+			delphiPointer = FE8Data.FiliShieldEffectivenessCheckPointer;
+		}
+		
+		if (delphiPointer != 0) {
+			diffCompiler.addDiff(new Diff(delphiPointer, 
+					4, 
+					WhyDoesJavaNotHaveThese.byteArrayFromLongValue(flierEffectivenessAddress + 0x8000000L, true, 4), 
+					WhyDoesJavaNotHaveThese.byteArrayFromLongValue(oldAddress, true, 4)));
 		}
 	}
 	

--- a/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
@@ -179,6 +179,11 @@ public class PaletteLoader {
 					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Initializing Character 0x" + Integer.toHexString(charID) + " (" + fe8char.toString() + ")" + " with palette at offset 0x" + Long.toHexString(paletteInfo.getOffset()) + " (Class: " + Integer.toHexString(classID) + " (" + fe8class.toString() + "))");
 					DebugPrinter.log(DebugPrinter.Key.PALETTE, "Palette size: " + Integer.toString(palette.getOriginalCompressedLength()) + " bytes");
 				}
+				// Special case: Pegasus Knights that have a Wyvern Knight promotion will have conflicting primary colors.
+				// If a character a Wyvern palette and a non-wyvern palette, drop the wyvern palette and let the other palette dictate primary color.
+				// This primarily affects Vanessa and Tana, which both have Wyvern Knight (F) so we can just remove that one kind of palette here.
+				referenceMap.remove(FE8Data.CharacterClass.WYVERN_KNIGHT_F.ID);
+				
 			}
 			for (FE8Data.Character character : FE8Data.Character.safeCreatureCampaignCharacters) {
 				int charID = FE8Data.Character.canonicalIDForCharacterID(character.ID);

--- a/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
@@ -580,11 +580,13 @@ public class PaletteLoader {
 					Long targetOffset = mapper.getPaletteOffset(unpromotedPaletteID);
 					if (targetOffset == null) { 
 						targetOffset = freeSpace.reserveInternalSpace(compressedBase.length, "Palette 0x" + Integer.toHexString(unpromotedPaletteID), true);
+						DebugPrinter.log(DebugPrinter.Key.PALETTE_RECYCLER, "Setting new target offset for palette ID 0x" + Integer.toHexString(unpromotedPaletteID) + " to 0x" + Long.toHexString(targetOffset));
 						appendedPaletteIDsV2.put(unpromotedPaletteID, change.basePalette);
 					}
 					
 					change.basePalette.overrideOffset(targetOffset);
 					change.basePalette.setIdentifier(unpromotedPaletteID);
+					charData.characterWithID(change.character.getID()).setUnpromotedPaletteIndex(unpromotedPaletteID);
 				}
 				
 				int promotedPaletteID = change.character.getPromotedPaletteIndex();
@@ -596,13 +598,16 @@ public class PaletteLoader {
 					Long targetOffset = mapper.getPaletteOffset(promotedPaletteID);
 					if (targetOffset == null) {
 						targetOffset = freeSpace.reserveInternalSpace(compressedPromotion.length, "Palette 0x" + Integer.toHexString(promotedPaletteID), true);
+						DebugPrinter.log(DebugPrinter.Key.PALETTE_RECYCLER, "Setting new target offset for palette ID 0x" + Integer.toHexString(promotedPaletteID) + " to 0x" + Long.toHexString(targetOffset));
 						appendedPaletteIDsV2.put(promotedPaletteID, change.promotedPalette);
 					}
 					
 					change.promotedPalette.overrideOffset(targetOffset);
 					change.promotedPalette.setIdentifier(promotedPaletteID);
+					charData.characterWithID(change.character.getID()).setPromotedPaletteIndex(promotedPaletteID);
 				}
 			}
+			charData.commit();
 		}
 	}
 	
@@ -647,7 +652,8 @@ public class PaletteLoader {
 				PaletteV2 appendedPalette = appendedPaletteIDsV2.get(appendedPaletteID);
 				long offsetToWriteTo = baseOffset + (appendedPaletteID * entrySize);
 				byte[] bytesToWrite = WhyDoesJavaNotHaveThese.bytesFromAddress(appendedPalette.getDestinationOffset());
-				compiler.addDiff(new Diff(offsetToWriteTo, bytesToWrite.length, bytesToWrite, new byte[] {0, 0, 0, 0}));
+				compiler.addDiff(new Diff(offsetToWriteTo, bytesToWrite.length, bytesToWrite, null));
+				DebugPrinter.log(DebugPrinter.Key.PALETTE, "[Palette 0x" + Integer.toHexString(appendedPaletteID) + "] Writing bytes " + WhyDoesJavaNotHaveThese.displayStringForBytes(bytesToWrite) + " to offset 0x" + Long.toHexString(offsetToWriteTo));
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/PaletteLoader.java
@@ -183,6 +183,11 @@ public class PaletteLoader {
 				// If a character a Wyvern palette and a non-wyvern palette, drop the wyvern palette and let the other palette dictate primary color.
 				// This primarily affects Vanessa and Tana, which both have Wyvern Knight (F) so we can just remove that one kind of palette here.
 				referenceMap.remove(FE8Data.CharacterClass.WYVERN_KNIGHT_F.ID);
+				// Similarly, Amelia's Recruit class has a blue outfit by default when her primary color
+				// should be red. Remove Recruit as well.
+				referenceMap.remove(FE8Data.CharacterClass.RECRUIT.ID);
+				referenceMap.remove(FE8Data.CharacterClass.RECRUIT_2.ID);
+				referenceMap.remove(FE8Data.CharacterClass.SUPER_RECRUIT.ID);
 				
 			}
 			for (FE8Data.Character character : FE8Data.Character.safeCreatureCampaignCharacters) {

--- a/Universal FE Randomizer/src/random/gba/loader/PaletteMapper.java
+++ b/Universal FE Randomizer/src/random/gba/loader/PaletteMapper.java
@@ -79,8 +79,21 @@ public class PaletteMapper {
 				}
 			}
 			
+			// Since this is the last chance for palettes to be assigned, we will use any palette IDs that have been recycled and
+			// remap them to the end of the ROM.
 			if (paletteID == 0) {
-				System.err.println("No palettes available to fulfill palette.");
+				// Grab any palette ID that's not used. We will unregister the old address and write the new address (at the end of the ROM).
+				recycled = requestRecycledPaletteID(0);
+				if (recycled != null) {
+					paletteID = recycled;
+					DebugPrinter.log(DebugPrinter.Key.PALETTE_RECYCLER, "Final recycling palette 0x" + Integer.toHexString(paletteID) + " for character 0x" + Integer.toHexString(queuedItem.character.getID()) + " (" + queuedItem.character.displayString() + ") of type: " + queuedItem.requiredType.name() + " actual size: " + queuedItem.sizeNeeded);
+					// Remove the old offset, since we won't need it anymore.
+					registeredPaletteOffsets.remove(paletteID);
+					// Set the new length to what we need.
+					registeredPaletteLengths.put(paletteID, queuedItem.sizeNeeded);
+				} else {
+					System.err.println("No palettes available to fulfill palette for character:" + queuedItem.character.displayString());
+				}
 			}
 			
 			GBAFECharacterData[] linked = charData.linkedCharactersForCharacter(queuedItem.character);

--- a/Universal FE Randomizer/src/random/gba/loader/StatboostLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/StatboostLoader.java
@@ -56,6 +56,7 @@ public class StatboostLoader {
 	}
 	
 	public void recordInitial(RecordKeeper rk, ItemDataLoader itemData, StatboosterOptions options) {
+		if (options == null) { return; }
 		for (GBAFEStatboost boost : getStatboosters(options.includeMov, options.includeCon)) {
 			for (GBAFEItemData item : itemData.itemsByStatboostAddress(boost.getAddressOffset())) {
 				String name = item.displayString();
@@ -74,6 +75,7 @@ public class StatboostLoader {
 	}
 	
 	public void recordUpdated(RecordKeeper rk, ItemDataLoader itemData, StatboosterOptions options) {
+		if (options == null) { return; }
 		for (GBAFEStatboost boost : getStatboosters(options.includeMov, options.includeCon)) {
 			for (GBAFEItemData item : itemData.itemsByStatboostAddress(boost.getAddressOffset())) {
 				String name = item.displayString();

--- a/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
@@ -40,9 +40,9 @@ public class BasesRandomizer {
 			GBAFEStatDto characterBaseline = GBAFEStatDto.expectedValueLevel(classBaseline, character.getGrowths(), startingLevel - 1, rng);
 			
 			// Now we add a modifier based on how a character rolls.
-			// HP can range from the lower of -1 * the character's level or -3 up to the higher of the character's level or +3/
-			// So a level 1 character can go from -3 to +3 and a level 10 character can go from -10 to +10.
-			NormalDistributor hpDistributor = new NormalDistributor(Math.min(-1 * startingLevel,  -3), Math.max(startingLevel, 3), 1);
+			// Class Base HP is pretty bad all around, so we'll skew this upward with a range between 0 and characters level or +5, whichever is greater.
+			// So a level 1 character will get a bonus of 0 ~ 5 and a level 10 character will get a bonus of 0 ~ 10
+			NormalDistributor hpDistributor = new NormalDistributor(0, Math.max(startingLevel, 5), 1);
 			// Most normal stats can range from -4 to +4
 			NormalDistributor statDistributor = new NormalDistributor(-4, 4, 1);
 			// LCK is an absolute random.

--- a/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
@@ -43,8 +43,12 @@ public class BasesRandomizer {
 			// Class Base HP is pretty bad all around, so we'll skew this upward with a range between 0 and characters level or +5, whichever is greater.
 			// So a level 1 character will get a bonus of 0 ~ 5 and a level 10 character will get a bonus of 0 ~ 10
 			NormalDistributor hpDistributor = new NormalDistributor(0, Math.max(startingLevel, 5), 1);
-			// Most normal stats can range from -4 to +4
-			NormalDistributor statDistributor = new NormalDistributor(-4, 4, 1);
+			// Most normal stats can range from +0 to +6
+			NormalDistributor statDistributor = new NormalDistributor(-2, 4, 1);
+			if (isPromoted) {
+				// Promoted class bases are so bad, we are going to shift the stat distributor for most stats upward to compensate.
+				statDistributor = new NormalDistributor(2, 8, 1);
+			}
 			// LCK is an absolute random.
 			// If the unit is unpromoted, this ranges from 0 to the higher of their level or 10.
 			// i.e. A level 1 unit will have LCK between 0 and 10.

--- a/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
@@ -43,7 +43,7 @@ public class BasesRandomizer {
 			// Class Base HP is pretty bad all around, so we'll skew this upward with a range between 0 and characters level or +5, whichever is greater.
 			// So a level 1 character will get a bonus of 0 ~ 5 and a level 10 character will get a bonus of 0 ~ 10
 			NormalDistributor hpDistributor = new NormalDistributor(0, Math.max(startingLevel, 5), 1);
-			// Most normal stats can range from +0 to +6
+			// Most normal stats can range from -2 to +4
 			NormalDistributor statDistributor = new NormalDistributor(-2, 4, 1);
 			if (isPromoted) {
 				// Promoted class bases are so bad, we are going to shift the stat distributor for most stats upward to compensate.

--- a/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/BasesRandomizer.java
@@ -32,7 +32,7 @@ public class BasesRandomizer {
 			Boolean isPromoted = classData.isPromotedClass(character.getClassID());
 			if (isPromoted) {
 				// Promoted class bases are kind of bad, so add a few levels here.
-				startingLevel += 5;
+				startingLevel += 10;
 			}
 			GBAFEStatDto classBaseline = new GBAFEStatDto(characterClass.getBases());
 			// Use a mix of the class's bases and the character's growths (character growths are randomized before this step, so they may not be in line

--- a/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/ClassRandomizer.java
@@ -434,23 +434,25 @@ public class ClassRandomizer {
 		} else {
 			GBASlotAdjustmentService.transferWeaponRanks(character, sourceClass, targetClass, rng);
 		}
-		switch (classOptions.basesTransfer) {
-		case ADJUST_TO_MATCH:
-			applyBaseCorrectionForCharacter(character, sourceClass, targetClass);
-			break;
-		case NO_CHANGE:
-			// We need to make sure nobody underflows, so keep an eye out for negative personal bases.
-			if (character.getBaseHP() + targetClass.getBaseHP() < 0) { character.setBaseHP(-1 * targetClass.getBaseHP() + 1); } // Should always have at least 1 HP.
-			if (character.getBaseSTR() + targetClass.getBaseSTR() < 0) { character.setBaseSTR(-1 * targetClass.getBaseSTR()); }
-			if (character.getBaseSKL() + targetClass.getBaseSKL() < 0) { character.setBaseSKL(-1 * targetClass.getBaseSKL()); }
-			if (character.getBaseSPD() + targetClass.getBaseSPD() < 0) { character.setBaseSPD(-1 * targetClass.getBaseSPD()); }
-			if (character.getBaseDEF() + targetClass.getBaseDEF() < 0) { character.setBaseDEF(-1 * targetClass.getBaseDEF()); }
-			if (character.getBaseRES() + targetClass.getBaseRES() < 0) { character.setBaseRES(-1 * targetClass.getBaseRES()); }
-			if (character.getBaseLCK() + targetClass.getBaseLCK() < 0) { character.setBaseLCK(-1 * targetClass.getBaseLCK()); }
-			break;
-		case ADJUST_TO_CLASS:
-			adjustBasesToMatchClass(character, sourceClass, targetClass);
-			break;
+		if (charData.isBossCharacterID(character.getID()) == false) {
+			switch (classOptions.basesTransfer) {
+			case ADJUST_TO_MATCH:
+				applyBaseCorrectionForCharacter(character, sourceClass, targetClass);
+				break;
+			case NO_CHANGE:
+				// We need to make sure nobody underflows, so keep an eye out for negative personal bases.
+				if (character.getBaseHP() + targetClass.getBaseHP() < 0) { character.setBaseHP(-1 * targetClass.getBaseHP() + 1); } // Should always have at least 1 HP.
+				if (character.getBaseSTR() + targetClass.getBaseSTR() < 0) { character.setBaseSTR(-1 * targetClass.getBaseSTR()); }
+				if (character.getBaseSKL() + targetClass.getBaseSKL() < 0) { character.setBaseSKL(-1 * targetClass.getBaseSKL()); }
+				if (character.getBaseSPD() + targetClass.getBaseSPD() < 0) { character.setBaseSPD(-1 * targetClass.getBaseSPD()); }
+				if (character.getBaseDEF() + targetClass.getBaseDEF() < 0) { character.setBaseDEF(-1 * targetClass.getBaseDEF()); }
+				if (character.getBaseRES() + targetClass.getBaseRES() < 0) { character.setBaseRES(-1 * targetClass.getBaseRES()); }
+				if (character.getBaseLCK() + targetClass.getBaseLCK() < 0) { character.setBaseLCK(-1 * targetClass.getBaseLCK()); }
+				break;
+			case ADJUST_TO_CLASS:
+				adjustBasesToMatchClass(character, sourceClass, targetClass);
+				break;
+			}
 		}
 		
 		switch (classOptions.growthOptions) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -691,6 +691,7 @@ public class GBARandomizer extends Randomizer {
 		// Fix the palettes based on final classes.
 		if (needsPaletteFix) {
 			PaletteHelper.synchronizePalettes(gameType, recruitOptions != null ? recruitOptions.includeExtras : false, charData, classData, paletteData, characterMap, freeSpace);
+			charData.commit();
 		}
 		
 		// Fix promotions so that forcing a promoted unit to promote again doesn't demote them.
@@ -2329,6 +2330,9 @@ public class GBARandomizer extends Randomizer {
 				break;
 			case DELTA:
 				rk.addHeaderItem("Randomize Bases", "Delta (+/- " + bases.deltaOption.variance + ")");
+				break;
+			case SMART:
+				rk.addHeaderItem("Randomize Bases", "Smart");
 				break;
 			}
 		} else {

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -462,6 +462,10 @@ public class GBARandomizer extends Randomizer {
 				updateStatusString("Randomizing growths...");
 				GrowthsRandomizer.fullyRandomizeGrowthsWithRange(growths.fullOption.minValue, growths.fullOption.maxValue, growths.adjustHP, charData, rng);
 				break;
+			case SMART:
+				updateStatusString("Smart Randomizing growths...");
+				GrowthsRandomizer.smartRandomizeGrowths(charData, classData, rng);
+				break;
 			}
 		}
 	}
@@ -2303,6 +2307,9 @@ public class GBARandomizer extends Randomizer {
 				break;
 			case FULL:
 				rk.addHeaderItem("Randomize Growths", "Full (" + growths.fullOption.minValue + "% ~ " + growths.fullOption.maxValue + "%)");	
+				break;
+			case SMART:
+				rk.addHeaderItem("Randomize Growths", "Smart");
 				break;
 			}
 			

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -482,6 +482,10 @@ public class GBARandomizer extends Randomizer {
 				updateStatusString("Applying random deltas to growths...");
 				BasesRandomizer.randomizeBasesByRandomDelta(bases.deltaOption.variance, charData, classData, rng);
 				break;
+			case SMART:
+				updateStatusString("Smart Randomizing bases...");
+				BasesRandomizer.smartRandomizeBases(charData, classData, chapterData, rng);
+				break;
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -680,7 +680,7 @@ public class GBARandomizer extends Randomizer {
 		// Some characters have discrepancies between character data and chapter data. We'll try to address that before we get to any modifications.
 		charData.applyLevelCorrectionsIfNecessary();
 		
-		itemData.prepareForRandomization();
+		itemData.prepareForRandomization(gameType, diffCompiler);
 	}
 	
 	private void makeFinalAdjustments(String seed) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/GrowthsRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GrowthsRandomizer.java
@@ -37,10 +37,6 @@ public class GrowthsRandomizer {
 		NormalDistributor defDistributor = new NormalDistributor(5, 50, 5);
 		NormalDistributor resDistributor = new NormalDistributor(5, 50, 5);
 		
-		List<Bucket> topBuckets = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE);
-		List<Bucket> bottomBuckets = Arrays.asList(Bucket.ABYSMAL, Bucket.BAD, Bucket.AVERAGE, Bucket.GOOD);
-		List<Bucket> allBuckets = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE, Bucket.BAD, Bucket.ABYSMAL);
-		
 		for (GBAFECharacterData character : allPlayableCharacters) {
 			if (character.wasModified()) {
 				continue;
@@ -55,13 +51,13 @@ public class GrowthsRandomizer {
 			// The lowest two stats for the class cannot be excellent. (index 5 or 6)
 			statOrder.remove(Stat.HP); // HP excluded
 			
-			int newHPGrowth = hpDistributor.getRandomValue(rng, allBuckets);
-			int newSTRGrowth = powDistributor.getRandomValue(rng, statOrder.indexOf(Stat.POW) < 2 ? topBuckets : (statOrder.indexOf(Stat.POW) >= 5 ? bottomBuckets : allBuckets));
-			int newSKLGrowth = sklDistributor.getRandomValue(rng, statOrder.indexOf(Stat.SKL) < 2 ? topBuckets : (statOrder.indexOf(Stat.SKL) >= 5 ? bottomBuckets : allBuckets));
-			int newSPDGrowth = spdDistributor.getRandomValue(rng, statOrder.indexOf(Stat.SPD) < 2 ? topBuckets : (statOrder.indexOf(Stat.SPD) >= 5 ? bottomBuckets : allBuckets));
-			int newLCKGrowth = lckDistributor.getRandomValue(rng, statOrder.indexOf(Stat.LCK) < 2 ? topBuckets : (statOrder.indexOf(Stat.LCK) >= 5 ? bottomBuckets : allBuckets));
-			int newDEFGrowth = defDistributor.getRandomValue(rng, statOrder.indexOf(Stat.DEF) < 2 ? topBuckets : (statOrder.indexOf(Stat.DEF) >= 5 ? bottomBuckets : allBuckets));
-			int newRESGrowth = resDistributor.getRandomValue(rng, statOrder.indexOf(Stat.RES) < 2 ? topBuckets : (statOrder.indexOf(Stat.RES) >= 5 ? bottomBuckets : allBuckets));
+			int newHPGrowth = hpDistributor.getRandomValue(rng, NormalDistributor.allBuckets);
+			int newSTRGrowth = powDistributor.getRandomValue(rng, statOrder.indexOf(Stat.POW) < 2 ? NormalDistributor.topBuckets : (statOrder.indexOf(Stat.POW) >= 5 ? NormalDistributor.bottomBuckets : NormalDistributor.allBuckets));
+			int newSKLGrowth = sklDistributor.getRandomValue(rng, statOrder.indexOf(Stat.SKL) < 2 ? NormalDistributor.topBuckets : (statOrder.indexOf(Stat.SKL) >= 5 ? NormalDistributor.bottomBuckets : NormalDistributor.allBuckets));
+			int newSPDGrowth = spdDistributor.getRandomValue(rng, statOrder.indexOf(Stat.SPD) < 2 ? NormalDistributor.topBuckets : (statOrder.indexOf(Stat.SPD) >= 5 ? NormalDistributor.bottomBuckets : NormalDistributor.allBuckets));
+			int newLCKGrowth = lckDistributor.getRandomValue(rng, statOrder.indexOf(Stat.LCK) < 2 ? NormalDistributor.topBuckets : (statOrder.indexOf(Stat.LCK) >= 5 ? NormalDistributor.bottomBuckets : NormalDistributor.allBuckets));
+			int newDEFGrowth = defDistributor.getRandomValue(rng, statOrder.indexOf(Stat.DEF) < 2 ? NormalDistributor.topBuckets : (statOrder.indexOf(Stat.DEF) >= 5 ? NormalDistributor.bottomBuckets : NormalDistributor.allBuckets));
+			int newRESGrowth = resDistributor.getRandomValue(rng, statOrder.indexOf(Stat.RES) < 2 ? NormalDistributor.topBuckets : (statOrder.indexOf(Stat.RES) >= 5 ? NormalDistributor.bottomBuckets : NormalDistributor.allBuckets));
 			
 			GBAFEStatDto newGrowths = new GBAFEStatDto(newHPGrowth, newSTRGrowth, newSKLGrowth, newSPDGrowth, newDEFGrowth, newRESGrowth, newLCKGrowth);
 			character.setGrowths(newGrowths);

--- a/Universal FE Randomizer/src/random/gba/randomizer/StatboosterRandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/StatboosterRandomizer.java
@@ -20,7 +20,7 @@ public class StatboosterRandomizer {
 	public static int SALT = 4831789;
 	
 	public static void randomize(StatboosterOptions options, StatboostLoader loader, ItemDataLoader itemData, TextLoader texts, Random rng) {
-		if (!options.enabled) {
+		if (options == null || !options.enabled) {
 			return;
 		}
 

--- a/Universal FE Randomizer/src/random/general/NormalDistributor.java
+++ b/Universal FE Randomizer/src/random/general/NormalDistributor.java
@@ -1,0 +1,116 @@
+package random.general;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+// Extreme quotation marks around the "Normal" part, since we're
+// not going to be exact, but this is just a way to generate a random
+// number that we can qualify as good or bad, extreme or average.
+public class NormalDistributor {
+	
+	public enum Bucket {
+		ABYSMAL, // Bottom 5% (1 / 20)
+		BAD, // 5% - 35% (6 / 20)
+		AVERAGE, // 35% - 65% (6 / 20) (+ whatever remainder didn't sort evenly into the other buckets)
+		GOOD, // 65 - 95% (6 / 20)
+		EXCELLENT // Top 5% (1 / 20)
+	}
+	
+	List<Integer> abysmalValues = new ArrayList<Integer>();
+	List<Integer> badValues = new ArrayList<Integer>();
+	List<Integer> averageValues = new ArrayList<Integer>();
+	List<Integer> goodValues = new ArrayList<Integer>();
+	List<Integer> excellentValues = new ArrayList<Integer>();
+
+	// Bounds are inclusive.
+	public NormalDistributor(int lowerBound, int upperBound, int steps) {
+		List<Integer> allValues = new ArrayList<Integer>();
+		for (int i = lowerBound; i <= upperBound; i += steps) {
+			allValues.add(i);
+		}
+		
+		int size = allValues.size();
+		if (size == 0) {
+			assert false; // This is not allowed.
+		}
+		if (size < 5) {
+			// we'll have to stretch the definition on one end.
+			// start assigning from excellent and extend downwards.
+			excellentValues.add(lastItem(allValues));
+			dropLastButDontEmpty(allValues);
+			goodValues.add(lastItem(allValues));
+			dropLastButDontEmpty(allValues);
+			averageValues.add(lastItem(allValues));
+			dropLastButDontEmpty(allValues);
+			badValues.add(lastItem(allValues));
+			dropLastButDontEmpty(allValues);
+			abysmalValues.add(lastItem(allValues));
+		}
+		else {
+			float itemsPer5 = (float)size / 20f;
+			int itemsPerBucket = (int)Math.floor(itemsPer5 * 6);
+			int usedFrontIndex = 0;
+			int usedBackIndex = allValues.size();
+			int extremeCount = itemsPer5 < 1 ? 1 : (int)Math.floor(itemsPer5);
+			abysmalValues.addAll(allValues.subList(usedFrontIndex, extremeCount));
+			excellentValues.addAll(allValues.subList(usedBackIndex - extremeCount, usedBackIndex));
+			usedFrontIndex += extremeCount;
+			usedBackIndex -= extremeCount;
+			badValues.addAll(allValues.subList(usedFrontIndex, usedFrontIndex + itemsPerBucket));
+			goodValues.addAll(allValues.subList(usedBackIndex - itemsPerBucket, usedBackIndex));
+			usedFrontIndex += itemsPerBucket;
+			usedBackIndex -= itemsPerBucket;
+			// Everything else goes into the average bucket.
+			averageValues.addAll(allValues.subList(usedFrontIndex, usedBackIndex));
+		}
+	}
+	
+	public int getRandomValue(Random rng, List<Bucket> allowedBuckets) {
+		if (allowedBuckets.isEmpty()) { return 0; }
+		
+		while (true) {
+			int randomNum = rng.nextInt(20); // 0 ~ 19
+			if (randomNum == 0 && allowedBuckets.contains(Bucket.ABYSMAL)) {
+				return getRandomValue(Bucket.ABYSMAL, rng);
+			} else if (randomNum <= 6 && allowedBuckets.contains(Bucket.BAD)) {
+				return getRandomValue(Bucket.BAD, rng);
+			} else if (randomNum <= 12 && allowedBuckets.contains(Bucket.AVERAGE)) {
+				return getRandomValue(Bucket.AVERAGE, rng);
+			} else if (randomNum <= 18 && allowedBuckets.contains(Bucket.GOOD)) {
+				return getRandomValue(Bucket.GOOD, rng);
+			} else if (allowedBuckets.contains(Bucket.EXCELLENT)) {
+				return getRandomValue(Bucket.EXCELLENT, rng);
+			}
+		}
+	}
+	
+	public int getRandomValue(Bucket bucket, Random rng) {
+		switch (bucket) {
+		case ABYSMAL: return abysmalValues.get(rng.nextInt(abysmalValues.size()));
+		case BAD: return badValues.get(rng.nextInt(badValues.size()));
+		case AVERAGE: return averageValues.get(rng.nextInt(averageValues.size()));
+		case GOOD: return goodValues.get(rng.nextInt(goodValues.size()));
+		default: return excellentValues.get(rng.nextInt(excellentValues.size()));
+		}
+	}
+	
+	public Bucket getBucketForValue(int value) {
+		if (abysmalValues.contains(value)) { return Bucket.ABYSMAL; }
+		else if (badValues.contains(value)) { return Bucket.BAD; }
+		else if (averageValues.contains(value)) { return Bucket.AVERAGE; }
+		else if (goodValues.contains(value)) { return Bucket.GOOD; }
+		else if (excellentValues.contains(value)) { return Bucket.EXCELLENT; }
+		else { return null; }
+	}
+	
+	private Integer lastItem(List<Integer> list) {
+		return list.get(list.size() - 1);
+	}
+	
+	private void dropLastButDontEmpty(List<Integer> list) {
+		if (list.size() > 1) {
+			list.remove(list.size() - 1);
+		}
+	}
+}

--- a/Universal FE Randomizer/src/random/general/NormalDistributor.java
+++ b/Universal FE Randomizer/src/random/general/NormalDistributor.java
@@ -1,13 +1,21 @@
 package random.general;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+
+import random.general.NormalDistributor.Bucket;
 
 // Extreme quotation marks around the "Normal" part, since we're
 // not going to be exact, but this is just a way to generate a random
 // number that we can qualify as good or bad, extreme or average.
 public class NormalDistributor {
+	
+	public static List<Bucket> topBuckets = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE);
+	public static List<Bucket> bottomBuckets = Arrays.asList(Bucket.ABYSMAL, Bucket.BAD, Bucket.AVERAGE, Bucket.GOOD);
+	public static List<Bucket> allBuckets = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE, Bucket.BAD, Bucket.ABYSMAL);
+	public static List<Bucket> notAbysmal = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE, Bucket.BAD);
 	
 	public enum Bucket {
 		ABYSMAL, // Bottom 5% (1 / 20)

--- a/Universal FE Randomizer/src/random/general/NormalDistributor.java
+++ b/Universal FE Randomizer/src/random/general/NormalDistributor.java
@@ -13,15 +13,15 @@ import random.general.NormalDistributor.Bucket;
 public class NormalDistributor {
 	
 	public static List<Bucket> topBuckets = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE);
-	public static List<Bucket> bottomBuckets = Arrays.asList(Bucket.ABYSMAL, Bucket.BAD, Bucket.AVERAGE, Bucket.GOOD);
+	public static List<Bucket> bottomBuckets = Arrays.asList(Bucket.ABYSMAL, Bucket.BAD, Bucket.AVERAGE);
 	public static List<Bucket> allBuckets = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE, Bucket.BAD, Bucket.ABYSMAL);
 	public static List<Bucket> notAbysmal = Arrays.asList(Bucket.EXCELLENT, Bucket.GOOD, Bucket.AVERAGE, Bucket.BAD);
 	
 	public enum Bucket {
 		ABYSMAL, // Bottom 5% (1 / 20)
-		BAD, // 5% - 35% (6 / 20)
-		AVERAGE, // 35% - 65% (6 / 20) (+ whatever remainder didn't sort evenly into the other buckets)
-		GOOD, // 65 - 95% (6 / 20)
+		BAD, // 5% - 30% (5 / 20)
+		AVERAGE, // 30% - 70% (8 / 20) (+ whatever remainder didn't sort evenly into the other buckets)
+		GOOD, // 70 - 95% (5 / 20)
 		EXCELLENT // Top 5% (1 / 20)
 	}
 	
@@ -57,18 +57,18 @@ public class NormalDistributor {
 		}
 		else {
 			float itemsPer5 = (float)size / 20f;
-			int itemsPerBucket = (int)Math.floor(itemsPer5 * 6);
+			int itemsPerGoodBadBucket = (int)Math.floor(itemsPer5 * 5);
 			int usedFrontIndex = 0;
 			int usedBackIndex = allValues.size();
-			int extremeCount = itemsPer5 < 1 ? 1 : (int)Math.floor(itemsPer5);
-			abysmalValues.addAll(allValues.subList(usedFrontIndex, extremeCount));
-			excellentValues.addAll(allValues.subList(usedBackIndex - extremeCount, usedBackIndex));
-			usedFrontIndex += extremeCount;
-			usedBackIndex -= extremeCount;
-			badValues.addAll(allValues.subList(usedFrontIndex, usedFrontIndex + itemsPerBucket));
-			goodValues.addAll(allValues.subList(usedBackIndex - itemsPerBucket, usedBackIndex));
-			usedFrontIndex += itemsPerBucket;
-			usedBackIndex -= itemsPerBucket;
+			int itemsPerExtremeBucket = itemsPer5 < 1 ? 1 : (int)Math.floor(itemsPer5 * 1);
+			abysmalValues.addAll(allValues.subList(usedFrontIndex, itemsPerExtremeBucket));
+			excellentValues.addAll(allValues.subList(usedBackIndex - itemsPerExtremeBucket, usedBackIndex));
+			usedFrontIndex += itemsPerExtremeBucket;
+			usedBackIndex -= itemsPerExtremeBucket;
+			badValues.addAll(allValues.subList(usedFrontIndex, usedFrontIndex + itemsPerGoodBadBucket));
+			goodValues.addAll(allValues.subList(usedBackIndex - itemsPerGoodBadBucket, usedBackIndex));
+			usedFrontIndex += itemsPerGoodBadBucket;
+			usedBackIndex -= itemsPerGoodBadBucket;
 			// Everything else goes into the average bucket.
 			averageValues.addAll(allValues.subList(usedFrontIndex, usedBackIndex));
 		}
@@ -81,14 +81,16 @@ public class NormalDistributor {
 			int randomNum = rng.nextInt(20); // 0 ~ 19
 			if (randomNum == 0 && allowedBuckets.contains(Bucket.ABYSMAL)) {
 				return getRandomValue(Bucket.ABYSMAL, rng);
-			} else if (randomNum <= 6 && allowedBuckets.contains(Bucket.BAD)) {
+			} else if (randomNum <= 5 && allowedBuckets.contains(Bucket.BAD)) {
 				return getRandomValue(Bucket.BAD, rng);
-			} else if (randomNum <= 12 && allowedBuckets.contains(Bucket.AVERAGE)) {
+			} else if (randomNum <= 13 && allowedBuckets.contains(Bucket.AVERAGE)) {
 				return getRandomValue(Bucket.AVERAGE, rng);
 			} else if (randomNum <= 18 && allowedBuckets.contains(Bucket.GOOD)) {
 				return getRandomValue(Bucket.GOOD, rng);
 			} else if (allowedBuckets.contains(Bucket.EXCELLENT)) {
 				return getRandomValue(Bucket.EXCELLENT, rng);
+			} else {
+				// They rolled excellent, but were banned from it. Just re-roll.
 			}
 		}
 	}

--- a/Universal FE Randomizer/src/ui/general/OpenFileFlow.java
+++ b/Universal FE Randomizer/src/ui/general/OpenFileFlow.java
@@ -10,19 +10,34 @@ public class OpenFileFlow implements Listener {
 	
 	Shell parent;
 	FileFlowDelegate delegate;
+	
+	String[] filterNames;
+	String[] filterExtensions;
 
 	public OpenFileFlow(Shell parent, FileFlowDelegate delegate) {
 		super();
 		this.parent = parent;
 		this.delegate = delegate;
+		
+		filterExtensions = new String[] {"*.gba;*.smc;*.sfc;*.iso", "*"};
+		filterNames = new String[] {"*.gba, *.smc, *.sfc, *.iso", "All Files (*.*)"};
+	}
+	
+	public OpenFileFlow(Shell parent, FileFlowDelegate delegate, String[] extensions, String[] names) {
+		super();
+		this.parent = parent;
+		this.delegate = delegate;
+		
+		filterNames = names;
+		filterExtensions = extensions;
 	}
 
 	@Override
 	public void handleEvent(Event event) {
 		// TODO Auto-generated method stub
 		FileDialog openDialog = new FileDialog(parent, SWT.OPEN);
-		openDialog.setFilterExtensions(new String[] {"*.gba;*.smc;*.sfc;*.iso", "*"});
-		openDialog.setFilterNames(new String[] {"*.gba, *.smc, *.sfc, *.iso", "All Files (*.*)"});
+		openDialog.setFilterExtensions(filterExtensions);
+		openDialog.setFilterNames(filterNames);
 		delegate.onSelectedFile(openDialog.open());
 	}
 

--- a/Universal FE Randomizer/src/ui/model/BaseOptions.java
+++ b/Universal FE Randomizer/src/ui/model/BaseOptions.java
@@ -3,7 +3,7 @@ package ui.model;
 public class BaseOptions {
 	
 	public enum Mode {
-		REDISTRIBUTE, DELTA
+		REDISTRIBUTE, DELTA, SMART
 	}
 	
 	public final Mode mode;

--- a/Universal FE Randomizer/src/ui/model/GrowthOptions.java
+++ b/Universal FE Randomizer/src/ui/model/GrowthOptions.java
@@ -3,7 +3,7 @@ package ui.model;
 public class GrowthOptions {
 	
 	public enum Mode {
-		REDISTRIBUTE, DELTA, FULL
+		REDISTRIBUTE, DELTA, FULL, SMART
 	}
 	
 	public final Mode mode;

--- a/Universal FE Randomizer/src/ui/views/BasesView.java
+++ b/Universal FE Randomizer/src/ui/views/BasesView.java
@@ -32,6 +32,8 @@ public class BasesView extends YuneView<BaseOptions> {
 	private Button byDeltaOption;
 	private Spinner deltaSpinner;
 	
+	private Button smartOption;
+	
 	private Button adjustSTRMAG;
 
 	public BasesView(Composite parent, GameType type) {
@@ -164,11 +166,32 @@ public class BasesView extends YuneView<BaseOptions> {
 			optionData.top = new FormAttachment(deltaParamContainer, 10);
 			adjustSTRMAG.setLayoutData(optionData);
 		}
+		
+		/////////////////////////////////////////////////////////////
+		
+		smartOption = new Button(group, SWT.RADIO);
+		smartOption.setText("Smart Randomize");
+		smartOption.setToolTipText("Attempts to set bases in a way that avoids extreme stats most of the time.");
+		smartOption.setEnabled(false);
+		smartOption.setSelection(false);
+		smartOption.addListener(SWT.Selection, new Listener() {
+			@Override
+			public void handleEvent(Event arg0) {
+				setMode(BaseOptions.Mode.SMART);
+			}
+		});
+		
+		optionData = new FormData();
+		optionData.left = new FormAttachment(deltaParamContainer, 0, SWT.LEFT);
+		optionData.top = new FormAttachment(deltaParamContainer, 0);
+		smartOption.setLayoutData(optionData);
+		
 	}
 	
 	private void setEnableBases(Boolean enabled) {
 		redistributeOption.setEnabled(enabled);
 		byDeltaOption.setEnabled(enabled);
+		smartOption.setEnabled(enabled);
 		varianceSpinner.setEnabled(enabled && currentMode == BaseOptions.Mode.REDISTRIBUTE);
 		deltaSpinner.setEnabled(enabled && currentMode == BaseOptions.Mode.DELTA);
 		if (adjustSTRMAG != null) { adjustSTRMAG.setEnabled(enabled); }
@@ -188,6 +211,10 @@ public class BasesView extends YuneView<BaseOptions> {
 				varianceSpinner.setEnabled(false);
 				deltaSpinner.setEnabled(true);
 				break;
+			case SMART:
+				varianceSpinner.setEnabled(false);
+				deltaSpinner.setEnabled(false);
+				break;
 			}
 		}
 	}
@@ -205,6 +232,8 @@ public class BasesView extends YuneView<BaseOptions> {
 			break;
 		case DELTA:
 			deltaOption = new VarOption(deltaSpinner.getSelection());
+			break;
+		default:
 			break;
 		}
 		
@@ -227,12 +256,19 @@ public class BasesView extends YuneView<BaseOptions> {
 			case REDISTRIBUTE:
 				redistributeOption.setSelection(true);
 				byDeltaOption.setSelection(false);
+				smartOption.setSelection(false);
 				varianceSpinner.setSelection(options.redistributionOption.variance);
 				break;
 			case DELTA:
 				redistributeOption.setSelection(false);
 				byDeltaOption.setSelection(true);
+				smartOption.setSelection(false);
 				deltaSpinner.setSelection(options.deltaOption.variance);
+				break;
+			case SMART:
+				redistributeOption.setSelection(false);
+				byDeltaOption.setSelection(false);
+				smartOption.setSelection(true);
 				break;
 			}
 			

--- a/Universal FE Randomizer/src/ui/views/CharacterShufflingView.java
+++ b/Universal FE Randomizer/src/ui/views/CharacterShufflingView.java
@@ -245,6 +245,7 @@ public class CharacterShufflingView extends YuneView<CharacterShufflingOptions> 
 	@Override
 	public CharacterShufflingOptions getOptions() {
 		boolean isEnabled = enableButton.getSelection();
+		if (!isEnabled) { return null; }
 		ShuffleLevelingMode levelingMode = autoLevelingButton.getSelection() ? ShuffleLevelingMode.AUTOLEVEL : ShuffleLevelingMode.UNCHANGED;
 		int chance = shuffleChanceSpinner.getSelection();
 		List<String> shuffles = new ArrayList<>(includedShuffles);

--- a/Universal FE Randomizer/src/ui/views/GrowthsView.java
+++ b/Universal FE Randomizer/src/ui/views/GrowthsView.java
@@ -210,7 +210,7 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 		
 		optionData = new FormData();
 		optionData.left = new FormAttachment(fullRandomOption, 0, SWT.LEFT);
-		optionData.top = new FormAttachment(fullRandomOption, 0);
+		optionData.top = new FormAttachment(fullRandomOption, 10);
 		smartOption.setLayoutData(optionData);
 
 		adjustHPGrowths = new Button(group, SWT.CHECK);

--- a/Universal FE Randomizer/src/ui/views/GrowthsView.java
+++ b/Universal FE Randomizer/src/ui/views/GrowthsView.java
@@ -33,6 +33,8 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 
 	private Button fullRandomOption;
 	private MinMaxControl growthRangeControl;
+	
+	private Button smartOption;
 
 	private Button adjustHPGrowths;
 	private Button adjustSTRMAGSplit;
@@ -194,6 +196,22 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 		optionData.left = new FormAttachment(deltaParamContainer, 0, SWT.LEFT);
 		optionData.top = new FormAttachment(deltaParamContainer, 0);
 		fullRandomOption.setLayoutData(optionData);
+		
+		smartOption = new Button(modeContainer, SWT.RADIO);
+		smartOption.setText("Smart Randomize");
+		smartOption.setToolTipText("Attempts to generate growth rates that are randomized, but relatively normal looking.");
+		smartOption.setEnabled(false);
+		smartOption.addListener(SWT.Selection, new Listener() {
+			@Override
+			public void handleEvent(Event event) {
+				setMode(GrowthOptions.Mode.SMART);
+			}
+		});
+		
+		optionData = new FormData();
+		optionData.left = new FormAttachment(fullRandomOption, 0, SWT.LEFT);
+		optionData.top = new FormAttachment(fullRandomOption, 0);
+		smartOption.setLayoutData(optionData);
 
 		adjustHPGrowths = new Button(group, SWT.CHECK);
 		adjustHPGrowths.setText("Adjust HP Growths");
@@ -241,6 +259,11 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 					deltaSpinner.setEnabled(false);
 					growthRangeControl.setEnabled(true);
 					break;
+				case SMART:
+					varianceSpinner.setEnabled(false);
+					deltaSpinner.setEnabled(false);
+					growthRangeControl.setEnabled(false);
+					break;
 			}
 		}
 	}
@@ -263,6 +286,8 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 			case FULL:
 				fullOption = growthRangeControl.getMinMaxOption();
 				break;
+			case SMART:
+				break;
 		}
 
 		boolean adjustSTRMAG = adjustSTRMAGSplit != null ? adjustSTRMAGSplit.getSelection() : false;
@@ -274,6 +299,7 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 		redistributeOption.setEnabled(enabled);
 		byDeltaOption.setEnabled(enabled);
 		fullRandomOption.setEnabled(enabled);
+		smartOption.setEnabled(enabled);
 		varianceSpinner.setEnabled(enabled && currentMode == GrowthOptions.Mode.REDISTRIBUTE);
 		deltaSpinner.setEnabled(enabled && currentMode == GrowthOptions.Mode.DELTA);
 		growthRangeControl.setEnabled(enabled);
@@ -300,6 +326,7 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 				redistributeOption.setSelection(true);
 				byDeltaOption.setSelection(false);
 				fullRandomOption.setSelection(false);
+				smartOption.setSelection(false);
 				varianceSpinner.setSelection(options.redistributionOption.variance);
 				if (options.redistributionOption.minValue < growthRangeControl.getMinSpinner().getMaximum()) {
 					growthRangeControl.setMin(options.redistributionOption.minValue);
@@ -313,6 +340,7 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 				redistributeOption.setSelection(false);
 				byDeltaOption.setSelection(true);
 				fullRandomOption.setSelection(false);
+				smartOption.setSelection(false);
 				deltaSpinner.setSelection(options.deltaOption.variance);
 				if (options.deltaOption.minValue < growthRangeControl.getMinSpinner().getMaximum()) {
 					growthRangeControl.setMin(options.deltaOption.minValue);
@@ -326,6 +354,7 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 				redistributeOption.setSelection(false);
 				byDeltaOption.setSelection(false);
 				fullRandomOption.setSelection(true);
+				smartOption.setSelection(false);
 				if (options.fullOption.minValue < growthRangeControl.getMinSpinner().getMaximum()) {
 					growthRangeControl.setMin(options.fullOption.minValue);
 					growthRangeControl.setMax(options.fullOption.maxValue);
@@ -333,6 +362,12 @@ public class GrowthsView extends YuneView<GrowthOptions> {
 					growthRangeControl.setMax(options.fullOption.maxValue);
 					growthRangeControl.setMin(options.fullOption.minValue);
 				}
+				break;
+			case SMART:
+				redistributeOption.setSelection(false);
+				byDeltaOption.setSelection(false);
+				fullRandomOption.setSelection(false);
+				smartOption.setSelection(true);
 				break;
 		}
 


### PR DESCRIPTION
This pull request introduces a simplified option to get random growths and bases and attempts to approach it from a more holistic view, where characters are assigned more contextual growths based on their class. We do this by assigning a meaning to what it means to have an "Excellent", "Good", "Average", "Bad, "Abysmal" growth and bases in each area, in a rough normal distribution. Since the goal is to have one option you can just click and not think about too hard, this is what that actually breaks down as for each area.

## Growths

Stat\Tier|Abysmal (Bottom 5%)|Bad (Next 25%)|Average (Middle 40%)|Good (Next 25%)|Excellent (Top 5%)
-|-|-|-|-|-
HP|45%|50% ~ 60%|65% ~ 80%|85% ~ 95%|100%
STR/SKL/SPD/LCK|20%|25% ~ 35%|40% ~ 60%|65% ~ 75%|80%
DEF/RES|5%|10% ~ 15%|20% ~ 35%|40% ~ 45%|50%

For example, a Swordmaster should be fairly speedy, but somewhat fragile. Their class growths look like this:

HP|STR|SKL|SPD|LCK|DEF|RES
-|-|-|-|-|-|-
65%|25%|30%|30%|25%|15(+5)%|12(+5)%

HP is special, and has the full range of buckets to choose from. Beyond that, The two strongest stats in that list are Skill and Speed. For all Swordmasters, their SKL and SPD growths will always be a random number in the Average ~ Excellent buckets (if they roll lower than Average, it is promoted up to Average). Meanwhile, their lowest growths are in DEF and RES, so those stats will always be in the bottom Abysmal ~ Average buckets (if they roll higher than average, then they reroll). The remaining stats (STR and LCK in this example) roll from all buckets, again, with a roughly normal distribution.

We apply a +5 to defensive stats since they're naturally lower for all classes. This still keeps DEF and RES among the lowest on the swordmaster, but, for example, on the Knight, it looks more reasonable:


HP|STR|SKL|SPD|LCK|DEF|RES
-|-|-|-|-|-|-
80%|40%|30%|15%|25%|28(+5)%|20(+5)%

This makes STR and DEF the two highest, instead of what would have been STR and SKL (and will eliminate the possibility of rolling abysmal DEF on a knight).

## Bases

Bases work slightly differently. The same concept of buckets apply here, but we start off using the class bases and apply the character's growths (which were randomized before this step to be based loosely on their class (which would have been randomized before that)) to arrive at a character baseline starting stats. For every stat after that, they then get an additional random offset based on the same bucket idea as above with the same rough normal distribution. If they roll abysmal, then they get minimal offsets. If they roll excellent, they get significant positive offsets.

* For HP, this again is special since class base HP is pretty low, and ranges between 0 and the character's join level (+10 if promoted) (or 5, whichever is higher).
* For LCK, this is also special since class bases are 0, and is an absolute random between a range dictated by their level and whether they're promoted (still on a normal distribution curve).
  * If the unit is unpromoted, this ranges between 0 and the character's join level (or 10, whichever is higher).
  * If the unit is promoted, this ranges between 2 and the character's promoted join level + 15 (or 20, whichever is higher).
* For all other stats, the range depends on whether they're promoted.
  * If the unit is unpromoted, this ranges from -2 and 4.
    * If the combination of all rolled offsets is worse than -5, then a reroll is performed (mostly to avoid completely unusable characters.
  * If the unit is promoted, this ranges between 2 and 8.
  * Additionally, the class's best stat can never roll an Abysmal roll.

Or to break the offsets down more clearly, assume a Level 5 Promoted Unit:

Stat\Tier|Abysmal (Bottom 5%)|Bad (Next 25%)|Average (Middle 40%)|Good (Next 25%)|Excellent (Top 5%)
-|-|-|-|-|-
HP|+0|+1 ~ +3|+4 ~ +11|+12~+14|+15
LCK|2|3~6|7~15|16~19|20
STR/SKL/SPD/DEF/RES|+2|+3|+4 ~ +6|+7|+8