### PR TITLE
Fix Matthew not having enough keys for lyn mode (Issue #366)

### DIFF
--- a/Universal FE Randomizer/src/fedata/gba/GBAFEItemData.java
+++ b/Universal FE Randomizer/src/fedata/gba/GBAFEItemData.java
@@ -22,7 +22,7 @@ public interface GBAFEItemData extends FEModifiableData, FEPrintableData {
 	public int getID();
 	
 	public WeaponType getType();
-	
+	void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng);
 	public boolean hasAbility1();
 	public int getAbility1();
 	public String getAbility1Description(String delimiter);

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Data.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import fedata.gba.GBAFECharacterData;
-import fedata.gba.GBAFECharacterData.Affinity;
 import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
@@ -1361,9 +1360,9 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		}
 		
 		public static List<Item> formerThiefKit() {
-			return new ArrayList<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY, DOOR_KEY));
+			return new ArrayList<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY));
 		}
-		
+
 		public static Set<Item> itemsToRemoveFromFormerThief() {
 			return new HashSet<Item>(Arrays.asList(LOCKPICK));
 		}
@@ -3315,7 +3314,7 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 
 	public Set<GBAFEItem> formerThiefInventory() {
-		return new HashSet<GBAFEItem>(Item.formerThiefKit());
+		return new HashSet<>(Item.formerThiefKit());
 	}
 
 	public Set<GBAFEItem> thiefItemsToRemove() {
@@ -3721,4 +3720,9 @@ public class FE6Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 	
 	public Boolean isMapShop(GBAFEShop shop) { return false; }
+
+	@Override
+	public GBAFEItem getDoorKey() {
+		return FE6Data.Item.DOOR_KEY;
+	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe6/FE6Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe6/FE6Item.java
@@ -398,7 +398,7 @@ public class FE6Item implements GBAFEItemData {
 		}
 	}
 	
-	private void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
+	public void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
 		switch (effect) {
 		case STAT_BOOSTS:
 			long[] boosts = itemData.possibleStatBoostAddresses();

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Data.java
@@ -17,7 +17,6 @@ import fedata.gba.GBAFECharacterData;
 import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
-import fedata.gba.GBAFECharacterData.Affinity;
 import fedata.gba.general.*;
 import fedata.gba.general.GBAFEChapterMetadataChapter;
 import fedata.gba.general.GBAFECharacter;
@@ -1617,7 +1616,7 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		}
 		
 		public static List<Item> formerThiefKit() {
-			return new ArrayList<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY, DOOR_KEY));
+			return new ArrayList<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY));
 		}
 		
 		public static Set<Item> itemsToRemoveFromFormerThief() {
@@ -3911,7 +3910,7 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 	
 	public Set<GBAFEItem> formerThiefInventory() {
-		return new HashSet<GBAFEItem>(Item.formerThiefKit());
+		return new HashSet<>(Item.formerThiefKit());
 	}
 
 	public Set<GBAFEItem> thiefItemsToRemove() {
@@ -4240,6 +4239,11 @@ public class FE7Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 
 	public GBAFESpellAnimationCollection spellAnimationCollectionAtAddress(byte[] data, long offset) {
 		return new FE7SpellAnimationCollection(data, offset);
+	}
+
+	@Override
+	public GBAFEItem getDoorKey() {
+		return Item.DOOR_KEY;
 	}
 
 	@Override

--- a/Universal FE Randomizer/src/fedata/gba/fe7/FE7Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe7/FE7Item.java
@@ -411,7 +411,7 @@ public class FE7Item implements GBAFEItemData {
 		}
 	}
 	
-	private void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
+	public void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
 		switch (effect) {
 		case STAT_BOOSTS:
 			long[] boosts = itemData.possibleStatBoostAddresses();

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Data.java
@@ -18,13 +18,6 @@ import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
 import fedata.gba.general.*;
-import fedata.gba.GBAFECharacterData.Affinity;
-import fedata.gba.fe7.FE7Data.CharacterAndClassAbility1Mask;
-import fedata.gba.fe7.FE7Data.CharacterAndClassAbility2Mask;
-import fedata.gba.fe7.FE7Data.CharacterAndClassAbility3Mask;
-import fedata.gba.fe7.FE7Data.CharacterAndClassAbility4Mask;
-import fedata.gba.fe7.FE7Data.Item;
-import fedata.gba.fe7.FE7Data.Shops;
 import fedata.gba.general.CharacterNudge;
 import fedata.gba.general.GBAFEChapterMetadataChapter;
 import fedata.gba.general.GBAFECharacter;
@@ -1602,7 +1595,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 		}
 		
 		public static List<Item> formerThiefKit() {
-			return new ArrayList<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY, DOOR_KEY));
+			return new ArrayList<Item>(Arrays.asList(CHEST_KEY_5, DOOR_KEY));
 		}
 		
 		public static Set<Item> itemsToRemoveFromFormerThief() {
@@ -4155,7 +4148,7 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	}
 	
 	public Set<GBAFEItem> formerThiefInventory() {
-		return new HashSet<GBAFEItem>(Item.formerThiefKit());
+		return new HashSet<>(Item.formerThiefKit());
 	}
 
 	public Set<GBAFEItem> thiefItemsToRemove() {
@@ -4676,5 +4669,10 @@ public class FE8Data implements GBAFECharacterProvider, GBAFEClassProvider, GBAF
 	
 	public Boolean isMapShop(GBAFEShop shop) {
 		return Shops.allMapShops().contains(shop);
+	}
+
+	@Override
+	public GBAFEItem getDoorKey() {
+		return FE8Data.Item.DOOR_KEY;
 	}
 }

--- a/Universal FE Randomizer/src/fedata/gba/fe8/FE8Item.java
+++ b/Universal FE Randomizer/src/fedata/gba/fe8/FE8Item.java
@@ -402,7 +402,7 @@ public class FE8Item implements GBAFEItemData {
 		}
 	}
 	
-	private void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
+	public void applyEffect(WeaponEffects effect, ItemDataLoader itemData, GBAFESpellAnimationCollection spellAnimations, Random rng) {
 		switch (effect) {
 		case STAT_BOOSTS:
 			long[] boosts = itemData.possibleStatBoostAddresses();

--- a/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
+++ b/Universal FE Randomizer/src/fedata/gba/general/GBAFEItemProvider.java
@@ -1,12 +1,9 @@
 package fedata.gba.general;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import fedata.gba.GBAFECharacterData;
-import fedata.gba.GBAFEClassData;
 import fedata.gba.GBAFEItemData;
 import fedata.gba.GBAFESpellAnimationCollection;
 import random.gba.loader.ItemDataLoader.AdditionalData;
@@ -100,5 +97,6 @@ public interface GBAFEItemProvider {
 	public int numberOfAnimations();
 	public int bytesPerAnimation();
 	public GBAFESpellAnimationCollection spellAnimationCollectionAtAddress(byte[] data, long offset);
+	GBAFEItem getDoorKey();
 
 }

--- a/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
+++ b/Universal FE Randomizer/src/random/gba/loader/ItemDataLoader.java
@@ -1,17 +1,6 @@
 package random.gba.loader;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collector;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import fedata.gba.GBAFECharacterData;
@@ -1003,6 +992,10 @@ public class ItemDataLoader {
 			}
 		}
 		return ret;
+	}
+
+	public GBAFEItemData getDoorKey() {
+		return itemWithID(provider.getDoorKey().getID());
 	}
 	
 	private GBAFEItemData[] feItemsFromItemSet(Set<GBAFEItem> itemSet) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -2449,7 +2449,6 @@ public class GBARandomizer extends Randomizer {
 
 		GBAFEItemData doorKey = itemData.getDoorKey();
 		doorKey.applyEffect(WeaponEffects.UNBREAKABLE, itemData, null, rng);
-		doorKey.setCostPerUse(0);
 	}
 	
 	private void syncWorldMapSpriteToCharacter(GBAFEWorldMapSpriteData sprite, int characterID) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/GBARandomizer.java
@@ -6,10 +6,7 @@ import fedata.gba.fe6.FE6SpellAnimationCollection;
 import fedata.gba.fe7.FE7Data;
 import fedata.gba.fe7.FE7SpellAnimationCollection;
 import fedata.gba.fe8.*;
-import fedata.gba.general.GBAFEChapterMetadataChapter;
-import fedata.gba.general.GBAFEChapterMetadataData;
-import fedata.gba.general.WeaponRank;
-import fedata.gba.general.WeaponType;
+import fedata.gba.general.*;
 import fedata.general.FEBase;
 import fedata.general.FEBase.GameType;
 import io.DiffApplicator;
@@ -2449,6 +2446,10 @@ public class GBARandomizer extends Randomizer {
 			}
 			break;
 		}
+
+		GBAFEItemData doorKey = itemData.getDoorKey();
+		doorKey.applyEffect(WeaponEffects.UNBREAKABLE, itemData, null, rng);
+		doorKey.setCostPerUse(0);
 	}
 	
 	private void syncWorldMapSpriteToCharacter(GBAFEWorldMapSpriteData sprite, int characterID) {

--- a/Universal FE Randomizer/src/random/gba/randomizer/shuffling/CharacterShuffler.java
+++ b/Universal FE Randomizer/src/random/gba/randomizer/shuffling/CharacterShuffler.java
@@ -1,31 +1,10 @@
 package random.gba.randomizer.shuffling;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.function.BinaryOperator;
-import java.util.stream.Collectors;
-
-import javax.print.attribute.HashAttributeSet;
-
-import com.sun.jndi.ldap.pool.Pool;
-import fedata.gba.GBAFEChapterData;
-import fedata.gba.GBAFEChapterUnitData;
-import fedata.gba.GBAFECharacterData;
-import fedata.gba.GBAFEClassData;
-import fedata.gba.GBAFEStatDto;
-import fedata.gba.GBAFECharacterData.Affinity;
-import fedata.gba.fe6.FE6Data;
+import fedata.gba.*;
 import fedata.gba.general.PaletteColor;
 import fedata.general.FEBase.GameType;
 import io.FileHandler;
-import random.gba.loader.ChapterLoader;
-import random.gba.loader.CharacterDataLoader;
-import random.gba.loader.ClassDataLoader;
-import random.gba.loader.ItemDataLoader;
-import random.gba.loader.PortraitDataLoader;
-import random.gba.loader.TextLoader;
-import random.gba.randomizer.RecruitmentRandomizer;
+import random.gba.loader.*;
 import random.gba.randomizer.service.ClassAdjustmentDto;
 import random.gba.randomizer.service.GBASlotAdjustmentService;
 import random.gba.randomizer.service.GBATextReplacementService;
@@ -36,13 +15,12 @@ import random.general.PoolDistributor;
 import ui.model.CharacterShufflingOptions;
 import ui.model.CharacterShufflingOptions.ShuffleLevelingMode;
 import ui.model.ItemAssignmentOptions;
-import util.DebugPrinter;
-import util.FileReadHelper;
-import util.FreeSpaceManager;
-import util.GBAImageCodec;
-import util.LZ77;
-import util.PaletteUtil;
-import util.WhyDoesJavaNotHaveThese;
+import util.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * Randomizer that shuffles in characters from different games into the rom


### PR DESCRIPTION
The formerThiefInventory giving was bugged, as it tried to give 2 door keys, but returned the items as a HashSet, so one of them got filterered out as a duplicate.

However, since Lyn Chapter 6 has 3 doors, and it's not possible to give him 3 chest keys (1 weapon + 1 Chest Key + 2 Door Keys = 4 Item), I opted to just make door keys unbreakable (and sell for 0) after talking about it with PurdraDan. That also helps with not having to verify the fact that there are enough door keys in general if there just happen to not be thieves in a seed.